### PR TITLE
Use Unix-style separator in deployment items.

### DIFF
--- a/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -987,10 +987,10 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
         [TestMethod]
         [FunctionalTest]
-        [DeploymentItem(@"TestData\source123_test_data.s123d")]
-        [DeploymentItem(@"TestData\source4_test_data.s4d")]
-        [DeploymentItem(@"TestData\source5_test_data.s5d")]
-        [DeploymentItem(@"TestData\ProcessTestSuite.json")]
+        [DeploymentItem(@"TestData/source123_test_data.s123d")]
+        [DeploymentItem(@"TestData/source4_test_data.s4d")]
+        [DeploymentItem(@"TestData/source5_test_data.s5d")]
+        [DeploymentItem(@"TestData/ProcessTestSuite.json")]
         [DynamicData(nameof(ProcessTestData), DynamicDataSourceType.Method)]
         public void Process_WhenComplete_DataWasProcessed(
             EngineProcessTestCaseDto testCase)
@@ -1095,10 +1095,10 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
         [TestMethod]
         [FunctionalTest]
-        [DeploymentItem(@"TestData\source123_test_data.s123d")]
-        [DeploymentItem(@"TestData\source4_test_data.s4d")]
-        [DeploymentItem(@"TestData\source5_test_data.s5d")]
-        [DeploymentItem(@"TestData\ProcessTestSuite.json")]
+        [DeploymentItem(@"TestData/source123_test_data.s123d")]
+        [DeploymentItem(@"TestData/source4_test_data.s4d")]
+        [DeploymentItem(@"TestData/source5_test_data.s5d")]
+        [DeploymentItem(@"TestData/ProcessTestSuite.json")]
         [DynamicData(nameof(ProcessTestData), DynamicDataSourceType.Method)]
         public void Process_Isolated_WhenComplete_DataWasProcessed(
             EngineProcessTestCaseDto testCase)


### PR DESCRIPTION
The engine tests are using deployment items that have paths with directories. Using the Window's separator ('\\') does not work on Linux or other Unix-based operating systems.

We are changing the paths to use '/'.