### PR TITLE
Add license information to NuGet packages.

### DIFF
--- a/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
+++ b/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
@@ -9,11 +9,22 @@
     <Product>Performance ToolKit</Product>
     <Description>Contains .NET Core specific components of the Performance Toolkit Runtime.</Description>
     <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Performance.SDK.Runtime\Microsoft.Performance.SDK.Runtime.csproj" />
     <ProjectReference Include="..\Microsoft.Performance.SDK\Microsoft.Performance.SDK.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Performance.SDK.Runtime/Microsoft.Performance.SDK.Runtime.csproj
+++ b/Microsoft.Performance.SDK.Runtime/Microsoft.Performance.SDK.Runtime.csproj
@@ -9,6 +9,10 @@
     <Product>Performance ToolKit</Product>
     <Description>Contains the Performance Toolkit Runtime.</Description>
     <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,6 +29,10 @@
     <Compile Remove="Properties\**" />
     <EmbeddedResource Remove="Properties\**" />
     <None Remove="Properties\**" />
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Performance.SDK/Microsoft.Performance.SDK.csproj
+++ b/Microsoft.Performance.SDK/Microsoft.Performance.SDK.csproj
@@ -9,6 +9,10 @@
     <Product>Performance ToolKit</Product>
     <Description>Contains the Software Development Kit (SDK) for the Performance ToolKit.</Description>
     <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,6 +30,10 @@
     <Compile Remove="Properties\**" />
     <EmbeddedResource Remove="Properties\**" />
     <None Remove="Properties\**" />
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Performance.Testing.SDK/Microsoft.Performance.Testing.SDK.csproj
+++ b/Microsoft.Performance.Testing.SDK/Microsoft.Performance.Testing.SDK.csproj
@@ -2,11 +2,29 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>Microsoft.Performance.Testing.SDK</AssemblyName>
+    <RootNamespace>Microsoft.Performance.Testing.SDK</RootNamespace>
+    <Authors>Microsoft Corporation</Authors>
+    <Company>Microsoft Corporation</Company>
+    <Product>Performance ToolKit</Product>
+    <Description>Contains SDK specific test utilities.</Description>
+    <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Performance.SDK.Runtime\Microsoft.Performance.SDK.Runtime.csproj" />
     <ProjectReference Include="..\Microsoft.Performance.SDK\Microsoft.Performance.SDK.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Performance.Testing/Microsoft.Performance.Testing.csproj
+++ b/Microsoft.Performance.Testing/Microsoft.Performance.Testing.csproj
@@ -2,10 +2,28 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>Microsoft.Performance.Testing</AssemblyName>
+    <RootNamespace>Microsoft.Performance.Testing</RootNamespace>
+    <Authors>Microsoft Corporation</Authors>
+    <Company>Microsoft Corporation</Company>
+    <Product>Performance ToolKit</Product>
+    <Description>Contains test utilities.</Description>
+    <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.csproj
+++ b/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.csproj
@@ -9,6 +9,10 @@
     <Product>Performance ToolKit</Product>
     <Description>Contains the programmatic engine for the Performance ToolKit.</Description>
     <Copyright>Copyright © 2020 Microsoft Corporation</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-performance-toolkit-sdk</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,6 +30,10 @@
     <Compile Remove="Properties\**" />
     <EmbeddedResource Remove="Properties\**" />
     <None Remove="Properties\**" />
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ensures that all of our NuGet packages contain the License file.