### PR TITLE
Update version.json

### DIFF
--- a/version.json
+++ b/version.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "0.108.0",
   "publicReleaseRefSpec": [
-    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+    "^refs/heads/release/v?\\d+(?:\\.\\d+)?$",
+    "^refs/heads/servicing/v?\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
We will have public releases out of release/* and servicing/* branches.
This change will tell NerdBank GitVersioning (Nbgv) that branches matching
those patterns will be considered to be public releases by the tool.