### PR TITLE
Add security disclaimer to IsolationAssemblyLoader

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Discovery/IsolationAssemblyLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Discovery/IsolationAssemblyLoader.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Discovery
 {
     /// <summary>
     ///     Used to load assemblies into isolated contexts.
+    ///     <para/>
+    ///     Assemblies loaded through this class do not have any security
+    ///     boundary guarantees. For more information, refer to <see cref="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=netcore-3.1"/>
     /// </summary>
     public sealed class IsolationAssemblyLoader
         : IAssemblyLoader


### PR DESCRIPTION
The class name `IsolationAssemblyLoader` may imply some level of security. We should explicitly state that this is not the case since we are using the isolation given by `AssemblyLoadContext`s, which do not provide any security guarantees.