### PR TITLE
Fix engine with processor tables

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/CustomDataSourceReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/CustomDataSourceReferenceTests.cs
@@ -299,7 +299,9 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
 
             var metadata = type.GetCustomAttribute<CustomDataSourceAttribute>();
             var dataSources = type.GetCustomAttributes<DataSourceAttribute>();
-            var tables = ((ICustomDataSource)Activator.CreateInstance(type)).DataTables;
+            var instance = ((ICustomDataSource)Activator.CreateInstance(type));
+            var tables = instance.DataTables.Union(instance.MetadataTables);
+
             Assert.IsNotNull(metadata);
             Assert.IsNotNull(dataSources);
             Assert.IsNotNull(tables);
@@ -388,7 +390,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         {
             public IEnumerable<TableDescriptor> DataTables => new TableDescriptor[0];
 
-            public IEnumerable<TableDescriptor> MetadataTables { get; }
+            public IEnumerable<TableDescriptor> MetadataTables => new TableDescriptor[0];
 
             public IEnumerable<Option> CommandLineOptions => Enumerable.Empty<Option>();
 
@@ -449,9 +451,16 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
                 Any.TableDescriptor(),
             };
 
+            private static readonly TableDescriptor[] metadataTableDescriptors = new[]
+            {
+                Any.TableDescriptor(),
+                Any.TableDescriptor(),
+            };
+
             public SampleCds()
             {
                 this.DataTables = tableDescriptors;
+                this.MetadataTables = metadataTableDescriptors;
             }
 
             public IEnumerable<TableDescriptor> DataTables { get; }
@@ -519,9 +528,16 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
                 Any.TableDescriptor(),
             };
 
+            private static readonly TableDescriptor[] metadataTableDescriptors = new[]
+            {
+                Any.TableDescriptor(),
+                Any.TableDescriptor(),
+            };
+
             public MultiDataSourceCds()
             {
                 this.DataTables = tableDescriptors;
+                this.MetadataTables = metadataTableDescriptors;
             }
 
             public IEnumerable<TableDescriptor> DataTables { get; }

--- a/src/Microsoft.Performance.SDK.Runtime/CustomDataSourceReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/CustomDataSourceReference.cs
@@ -92,7 +92,10 @@ namespace Microsoft.Performance.SDK.Runtime
         /// </exception>
         public abstract IReadOnlyCollection<DataSourceAttribute> DataSources { get; }
 
-        /// <inheritdoc cref="ICustomDataSource.DataTables"/>
+        /// <summary>
+        ///     Gets the collection of tables exposed by this data source.
+        ///     These are both metadata and data tables for exposing the processed data.
+        /// </summary>
         /// <exception cref="ObjectDisposedException">
         ///     This instance is disposed.
         /// </exception>
@@ -346,7 +349,7 @@ namespace Microsoft.Performance.SDK.Runtime
                 get
                 {
                     this.ThrowIfDisposed();
-                    return this.Instance.DataTables.ToList().AsReadOnly();
+                    return this.Instance.DataTables.Union(this.Instance.MetadataTables).ToList().AsReadOnly();
                 }
             }
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
@@ -17,6 +18,18 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
         : CustomDataSourceBase
     {
         public const string Extension = ".s123d";
+
+        public Source123DataSource()
+            : base(GetTable)
+        {
+        }
+
+        private static IDictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>> GetTable()
+        {
+            var tables = new Dictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>>(1);
+            tables.Add(Source123Table.TableDescriptor, null);
+            return tables;
+        }
 
         protected override ICustomDataProcessor CreateProcessorCore(
             IEnumerable<IDataSource> dataSources, 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Processor.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Processor.cs
@@ -22,5 +22,18 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
             : base(sourceParser, options, applicationEnvironment, processorEnvironment, allTablesMapping, metadataTables)
         {
         }
+
+        protected override void BuildTableCore(TableDescriptor tableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval> createTable, ITableBuilder tableBuilder)
+        {           
+            if (tableDescriptor.Equals(Source123Table.TableDescriptor) && createTable == null)
+            {
+                var table = new Source123Table();
+                table.Build(tableBuilder);
+            }
+            else
+            {
+                base.BuildTableCore(tableDescriptor, createTable, tableBuilder);
+            }            
+        }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Table.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Table.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
+{
+    public class Source123Table
+    {
+        public static TableDescriptor TableDescriptor => new TableDescriptor(
+            Guid.Parse("{85CA4F92-4ECD-4EC4-B4B3-A98B373F29CA}"),
+            "Processor Test Table",
+            "Used by the Engine Tests to test a table via processor",
+            "Engine");
+
+        public static readonly ColumnConfiguration ColumnOne =
+                new ColumnConfiguration(new ColumnMetadata(Guid.NewGuid(), "One"));
+
+        public static readonly ColumnConfiguration ColumnTwo =
+            new ColumnConfiguration(new ColumnMetadata(Guid.NewGuid(), "Two"));
+
+        public static readonly ColumnConfiguration ColumnThree =
+            new ColumnConfiguration(new ColumnMetadata(Guid.NewGuid(), "Three"));
+
+        public void Build(ITableBuilder tableBuilder)
+        {
+            tableBuilder.SetRowCount(1)
+                .AddColumn(ColumnOne, Projection.Constant(1))
+                .AddColumn(ColumnTwo, Projection.Constant(2))
+                .AddColumn(ColumnThree, Projection.Constant(3));
+        }
+    }
+}

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Table.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Table.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Performance.SDK.Processing;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.SDK.Processing;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -1043,6 +1043,40 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [TestMethod]
         [FunctionalTest]
         [DeploymentItem(@"TestData/source123_test_data.s123d")]
+        [DeploymentItem(@"TestData/BuildTableTestSuite.json")]
+        [DynamicData(nameof(BuildTableTestData), DynamicDataSourceType.Method)]
+        public void BuildTable_ProcessorSingleRowTable(
+            EngineBuildTableTestCaseDto testCase)
+        {
+            var sut = Engine.Create();
+
+            sut.EnableTable(Source123Table.TableDescriptor);
+
+            foreach (var file in testCase.FilePaths)
+            {
+                sut.AddFile(file);
+            }
+
+            var result = sut.Process();
+
+            var builtTable = result.BuildTable(Source123Table.TableDescriptor);
+
+            Assert.AreEqual(1, builtTable.RowCount);
+            Assert.AreEqual(3, builtTable.Columns.Count());
+            Assert.AreEqual(0, builtTable.BuiltInTableConfigurations.Count());
+            Assert.AreEqual(0, builtTable.TableCommands.Count());
+            Assert.IsNull(builtTable.DefaultConfiguration);
+            Assert.IsNull(builtTable.TableRowDetailsGenerator);
+
+            for (int i = 0; i < builtTable.Columns.Count; i++)
+            {
+                Assert.AreEqual(i + 1, builtTable.Columns.ElementAt(i).Project(0));
+            }
+        }
+
+        [TestMethod]
+        [FunctionalTest]
+        [DeploymentItem(@"TestData/source123_test_data.s123d")]
         [DeploymentItem(@"TestData/source4_test_data.s4d")]
         [DeploymentItem(@"TestData/source5_test_data.s5d")]
         [DeploymentItem(@"TestData/BuildTableTestSuite.json")]

--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -846,22 +846,7 @@ namespace Microsoft.Performance.Toolkit.Engine
                 instance.customDataSourceReferences.AddRange(catalog.PlugIns);
                 instance.sourceDataCookers.AddRange(repoTuple.Item2.SourceDataCookers);
                 instance.compositeDataCookers.AddRange(repoTuple.Item2.CompositeDataCookers);
-                instance.extensionRoot = new ExtensionRoot(catalog, repo);
-
-                var allTables = new HashSet<TableDescriptor>();
-                foreach (var tableId in repoTuple.Item2.TablesById)
-                {
-                    allTables.Add(tableId.Value.TableDescriptor);
-                    instance.tableGuidToDescriptor[tableId.Key] = tableId.Value.TableDescriptor;
-                }
-
-                foreach (var descriptor in catalog.PlugIns.SelectMany(x => x.AvailableTables))
-                {
-                    allTables.Add(descriptor);
-                    instance.tableGuidToDescriptor[descriptor.Guid] = descriptor;
-                }
-
-                instance.allTables.AddRange(allTables);
+                instance.extensionRoot = new ExtensionRoot(catalog, repo);                
 
                 instance.dataProcessors.AddRange(repoTuple.Item2.DataProcessors);
 
@@ -896,6 +881,21 @@ namespace Microsoft.Performance.Toolkit.Engine
                         Console.Error.WriteLine(e);
                     }
                 }
+
+                var allTables = new HashSet<TableDescriptor>();
+                foreach (var tableId in repoTuple.Item2.TablesById)
+                {
+                    allTables.Add(tableId.Value.TableDescriptor);
+                    instance.tableGuidToDescriptor[tableId.Key] = tableId.Value.TableDescriptor;
+                }
+
+                foreach (var descriptor in catalog.PlugIns.SelectMany(x => x.AvailableTables))
+                {
+                    allTables.Add(descriptor);
+                    instance.tableGuidToDescriptor[descriptor.Guid] = descriptor;
+                }
+
+                instance.allTables.AddRange(allTables);
 
                 instance.IsProcessed = false;
 


### PR DESCRIPTION
- Moved table parsing to after SetApplicationEnviroment
-- Processors tables are initialized after setting the application environment
- Exposed metadata tables to AvailableTables
- Added test for processor based table