### PR TITLE
Update ErrorInfo formatting.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
@@ -534,20 +534,6 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
             {
                 this.GetObjectData(info, context);
             }
-
-            public override string ToString()
-            {
-                return new StringBuilder()
-                    .AppendLine("DirectoryPaths:")
-                    .Append(string.Join(Environment.NewLine + "    ", this.DirectoryPaths)).AppendLine()
-                    .AppendFormat("IncludeSubDirectories: {0}", this.IncludeSubDirectories).AppendLine()
-                    .AppendLine("SearchPatterns:")
-                    .Append(string.Join(Environment.NewLine + "    ", this.SearchPatterns)).AppendLine()
-                    .AppendLine("ExclusionFileNames:")
-                    .Append(string.Join(Environment.NewLine + "    ", this.ExclusionFileNames)).AppendLine()
-                    .AppendFormat("ExclusionsAreCaseSensitive: {0}", this.ExclusionsAreCaseSensitive)
-                    .ToString();
-            }
         }
     }
 }

--- a/src/Microsoft.Performance.SDK/ErrorInfoFormatter.cs
+++ b/src/Microsoft.Performance.SDK/ErrorInfoFormatter.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace Microsoft.Performance.SDK
@@ -86,8 +88,22 @@ namespace Microsoft.Performance.SDK
                         continue;
                     }
 
-                    sb.AppendLine()
-                      .AppendFormat(formatProvider, "{0}{1}: {2}", indent, property.Name, property.GetValue(info));
+                    var propValue = property.GetValue(info);
+                    if (propValue is IEnumerable e)
+                    {
+                        sb.AppendLine()
+                          .AppendFormat(formatProvider, "{0}{1}: ", indent, property.Name);
+                        foreach (var o in e)
+                        {
+                            sb.AppendLine()
+                              .AppendFormat("{0}{1}", indent + "    ", o);
+                        }
+                    }
+                    else
+                    {
+                        sb.AppendLine()
+                          .AppendFormat(formatProvider, "{0}{1}: {2}", indent, property.Name, propValue?.ToString() ?? string.Empty);
+                    }
                 }
 
                 if (info.Details != null && info.Details.Length > 0)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.109.1",
+  "version": "0.109.0",
   "publicReleaseRefSpec": [
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$",
     "^refs/heads/servicing/v?\\d+(?:\\.\\d+)?$"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "publicReleaseRefSpec": [
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$",
     "^refs/heads/servicing/v?\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Fixes #64 and #65

Update ErrorInfo printing logic.

Some error properties, such as lists, were not printing properly. Rather than
printing all of their items, they were simply printing the type name, which is
not useful.

Some other internal errors had overridden ToString unnecessarily, which led to
a loss of information.

This change rectifies these issues so that printing is consistent and useful.