### PR TITLE
Expose all extensions from the loader for now.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Plugins/PluginsLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Plugins/PluginsLoader.cs
@@ -107,6 +107,21 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins
         }
 
         /// <summary>
+        ///     Gets all of the loaded extensions.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        ///     This instance is disposed.
+        /// </exception>
+        public ExtensionRoot Extensions
+        {
+            get
+            {
+                this.ThrowIfDisposed();
+                return this.extensionRoot;
+            }
+        }
+
+        /// <summary>
         ///     All of the custom data sources that have been loaded by plugins.
         /// </summary>
         /// <exception cref="ObjectDisposedException">


### PR DESCRIPTION
We should expose all extensions consistently from the runtime to avoid accidentally using different instances of repositories.