### PR TITLE
Revert to static shared assembly list. Add nuget.versioning to list.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/IsolatedAssemblyLoadingTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/IsolatedAssemblyLoadingTests.cs
@@ -58,40 +58,6 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
         }
 
         [TestMethod]
-        [UnitTest]
-        public void AlwaysSharedAssembliesContainSDKAssemblies()
-        {
-            var sharedAssemblies = IsolationAssemblyLoader.GetAlwaysSharedAssemblies();
-            var assemblyNames = sharedAssemblies.Values.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            Assert.IsTrue(assemblyNames.Contains("Microsoft.Performance.SDK.Runtime.NetCoreApp"));
-            Assert.IsTrue(assemblyNames.Contains("Microsoft.Performance.SDK.Runtime"));
-            Assert.IsTrue(assemblyNames.Contains("Microsoft.Performance.SDK"));
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void AlwaysSharedAssembliesContainReferencedAssemblies()
-        {
-            // Nuget.Versioning is currently referenced, so using it as a test case.
-
-            var sharedAssemblies = IsolationAssemblyLoader.GetAlwaysSharedAssemblies();
-            var assemblyNames = sharedAssemblies.Values.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            Assert.IsTrue(assemblyNames.Contains("NuGet.Versioning"));
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void AlwaysSharedAssembliesExcludesRuntime()
-        {
-            var sharedAssemblies = IsolationAssemblyLoader.GetAlwaysSharedAssemblies();
-            var assemblyNames = sharedAssemblies.Values.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            Assert.IsFalse(assemblyNames.Contains("System.Runtime"));
-        }
-
-        [TestMethod]
         [IntegrationTest]
         public void SharedAssembliesLoadFromDefaultContext()
         {

--- a/src/Microsoft.Performance.SDK.Runtime/Microsoft.Performance.SDK.Runtime.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime/Microsoft.Performance.SDK.Runtime.csproj
@@ -36,10 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Performance.SDK\Microsoft.Performance.SDK.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The dynamically generated list didn't work when the SDK was consumed by self-contained applications (the application includes the .NET runtime and libraries). So I reverted to a static list and added the Nuget.Versioning assembly.

Since I time thinking about this today I realize that this is probably the better approach. We don't want all assemblies referenced by the SDK to be shared, but only those with types that are publicly exposed.