### PR TITLE
Do metadata inspection per folder.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Discovery/SandboxPreloadValidatorTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Discovery/SandboxPreloadValidatorTests.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
-using Microsoft.Performance.SDK.Runtime.Discovery;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Performance.SDK.Runtime.NetCoreApp.Discovery;
 using Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins;
 using Microsoft.Performance.Testing;
@@ -15,13 +20,37 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.Discovery
     [TestClass]
     public class SandboxPreloadValidatorTests
     {
+        private DirectoryInfo TestScratchDir { get; set; }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.TestScratchDir = new DirectoryInfo(nameof(SandboxPreloadValidatorTests));
+
+            this.Cleanup();
+
+            this.TestScratchDir.Create();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            try
+            {
+                this.TestScratchDir.Delete(true);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+        }
+
         [TestMethod]
         [UnitTest]
         public void AssemblyNotFound_ReturnsFalseWithError()
         {
             var path = "not_there.dll";
 
-            var sut = new SandboxPreloadValidator(
+            using var sut = new SandboxPreloadValidator(
                 new[] { this.GetType().Assembly.Location, },
                 new FakeVersionChecker());
 
@@ -38,7 +67,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.Discovery
         {
             var path = this.GetType().Assembly.Location;
 
-            var sut = new SandboxPreloadValidator(
+            using var sut = new SandboxPreloadValidator(
                 new[] { this.GetType().Assembly.Location, },
                 new FakeVersionChecker());
 
@@ -58,7 +87,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.Discovery
                 SdkSetter = new SemanticVersion(999, 999, 999),
             };
 
-            var sut = new SandboxPreloadValidator(
+            using var sut = new SandboxPreloadValidator(
                 new[] { this.GetType().Assembly.Location, },
                 checker);
 
@@ -76,7 +105,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.Discovery
             var path = this.GetType().Assembly.Location;
             var checker = new FakeVersionChecker();
 
-            var sut = new SandboxPreloadValidator(
+            using var sut = new SandboxPreloadValidator(
                 new[] { this.GetType().Assembly.Location, },
                 checker);
 
@@ -93,6 +122,98 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.Discovery
             Assert.IsTrue(pluginsLoaded);
             Assert.IsNotNull(errors);
             Assert.AreEqual(0, errors.Count);
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void AssemblyCanBeVerifiedMultipleTimes()
+        {
+            var path = this.GetType().Assembly.Location;
+
+            using var sut = new SandboxPreloadValidator(
+                new[] { this.GetType().Assembly.Location, },
+                new FakeVersionChecker());
+
+            Assert.IsTrue(sut.IsAssemblyAcceptable(path, out var error));
+            Assert.AreEqual(ErrorInfo.None, error);
+
+            Assert.IsTrue(sut.IsAssemblyAcceptable(path, out error));
+            Assert.AreEqual(ErrorInfo.None, error);
+
+            Assert.IsTrue(sut.IsAssemblyAcceptable(path, out error));
+            Assert.AreEqual(ErrorInfo.None, error);
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void SameAssemblyWithDifferentMvidValidates()
+        {
+            var a = this.TestScratchDir.CreateSubdirectory("a");
+            var b = this.TestScratchDir.CreateSubdirectory("b");
+
+            var friendlyName = nameof(SameAssemblyWithDifferentMvidValidates);
+            var version = new Version(1, 2, 3, 4);
+
+            var assembly1Path = Path.Combine(a.FullName, friendlyName + ".dll");
+            var assembly2Path = Path.Combine(b.FullName, friendlyName + ".dll");
+
+            CreateAssembly(version, assembly1Path);
+            CreateAssembly(version, assembly2Path);
+
+            using var sut = new SandboxPreloadValidator(
+                new[]
+                {
+                    assembly1Path,
+                    assembly2Path,
+                },
+                new FakeVersionChecker());
+
+            Assert.IsTrue(sut.IsAssemblyAcceptable(assembly1Path, out var error));
+            Assert.AreEqual(ErrorInfo.None, error);
+
+            Assert.IsTrue(sut.IsAssemblyAcceptable(assembly2Path, out error));
+            Assert.AreEqual(ErrorInfo.None, error);
+        }
+
+        private static void CreateAssembly(
+            Version assemblyVersion,
+            string outPath)
+        {
+            //
+            // we would use Reflection.Emit to create these, but AssemblyBuilder.Save is
+            // not present in .NET Core.
+            // https://github.com/dotnet/runtime/issues/15704
+            //
+
+            var code = $@"
+using System.Reflection;
+
+[assembly: AssemblyVersion(""{assemblyVersion}"")]
+namespace Test
+{{
+    public static class TestClass
+    {{
+    }}
+}}";
+            var tree = SyntaxFactory.ParseSyntaxTree(code);
+            
+            var systemRefLocation = typeof(object).GetTypeInfo().Assembly.Location;
+            var systemReference = MetadataReference.CreateFromFile(systemRefLocation);
+            
+            var compilation = CSharpCompilation.Create(Path.GetFileNameWithoutExtension(outPath))
+                .WithOptions(
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .AddReferences(systemReference)
+                .AddSyntaxTrees(tree);
+
+            var compilationResult = compilation.Emit(outPath);
+
+            Assert.IsTrue(compilationResult.Success, 
+                string.Join(
+                    Environment.NewLine,
+                    compilationResult.Diagnostics));
+
+            Assert.IsTrue(File.Exists(outPath));
         }
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
Similar to how to load each folder into a separate Assembly Load Context, this change updates the metadata validation to also load per folder.