### PR TITLE
Update DataCookerPath and DataOutputPath API to not expose internal string rep of paths

### DIFF
--- a/documentation/Migration/Update-0.109.md
+++ b/documentation/Migration/Update-0.109.md
@@ -151,3 +151,42 @@ The following are changes that are not required, but may be useful to you.
 The method `SetApplicationEnvironmentCore` is now virtual, so you no longer have
 to override it if you do not want to. An `ApplicationEnvironment` property is
 now available on the base class that you may reference in your `CustomDataSource.`
+
+## DataCookerPath
+
+The following have been marked as obsolete and will be removed by SDK v1.0.0 release candidate 1:
+- `DataCookerPath.Format`
+- `DataCookerPath.EmptySourceParserId`
+- `DataCookerPath.CookerPath`
+- `DataCookerPath.Parse`
+- `DataCookerPath.GetSourceParserId`
+- `DataCookerPath.GetDataCookerId`
+- `DataCookerPath.IsWellFormed`
+To prevent future build breaks, remove references to these methods and properties.
+
+Both the constructors for `DataCookerPath` that accept string arguments and `DataCookerPath.Create` 
+have been marked obsolete and will be removed by SDK v1.0.0 release candidate 1. 
+To prevent future build breaks, replace calls to this class' constructor with either
+- `DataCookerPath.ForComposite`
+- `DataCookerPath.ForSource`
+depending on the type of data cooker the path is for.
+
+## DataOutputPath
+
+The following have been marked as obsolete and will be removed by SDK v1.0.0 release candidate 1:
+- `DataOutputPath.Format`
+- `DataOutputPath.Path`
+- `DataOutputPath.Combine`
+- `DataOutputPath.GetSourceId`
+- `DataOutputPath.GetDataCookerId`
+- `DataOutputPath.GetDataCookerPath`
+- `DataOutputPath.TryGetConstituents`
+- `DataOutputPath.IsWellFormed`
+To prevent future build breaks, remove references to these methods and properties.
+
+Both the constructors for `DataOutputPath` that accept string arguments and `DataOutputPath.Create` 
+have been marked obsolete and will be removed by SDK v1.0.0 release candidate 1. 
+To prevent future build breaks, replace calls to this class' constructor with either
+- `DataOutputPath.ForComposite`
+- `DataOutputPath.ForSource`
+depending on the type of data cooker the data output path is for.

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CustomDataProcessorExtensibilitySupportTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CustomDataProcessorExtensibilitySupportTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
                     "This table has required data extensions",
                     "Other",
                     true,
-                    requiredDataCookers: new List<DataCookerPath> { new DataCookerPath(SourceParserId, "CookerId1") })
+                    requiredDataCookers: new List<DataCookerPath> { DataCookerPath.ForSource(SourceParserId, "CookerId1") })
                 { Type = typeof(TestTable1) };
 
             public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
@@ -46,7 +46,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
                     "This table has required data extensions",
                     "Other",
                     true,
-                    requiredDataCookers: new List<DataCookerPath> { new DataCookerPath(SourceParserId, "CookerId1") })
+                    requiredDataCookers: new List<DataCookerPath> { DataCookerPath.ForSource(SourceParserId, "CookerId1") })
                 { Type = typeof(TestTable2) };
 
             public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
@@ -108,7 +108,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId);
 
-            var sourceCooker = new TestSourceDataCooker() { Path = new DataCookerPath(TestTable1.SourceParserId, "CookerId1") };
+            var sourceCooker = new TestSourceDataCooker() { Path = DataCookerPath.ForSource(TestTable1.SourceParserId, "CookerId1") };
             var sourceCookerReference = new TestSourceDataCookerReference(false)
                 { availability = DataExtensionAvailability.Available, Path = sourceCooker.Path };
 
@@ -134,7 +134,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId);
 
-            var sourceCooker = new TestSourceDataCooker() { Path = new DataCookerPath(TestTable2.SourceParserId, "CookerId1") };
+            var sourceCooker = new TestSourceDataCooker() { Path = DataCookerPath.ForSource(TestTable2.SourceParserId, "CookerId1") };
             var sourceCookerReference = new TestSourceDataCookerReference(false)
                 { availability = DataExtensionAvailability.Available, Path = sourceCooker.Path };
 
@@ -159,7 +159,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId);
 
-            var sourceCooker = new TestSourceDataCooker() { Path = new DataCookerPath(TestTable1.SourceParserId, "CookerId1") };
+            var sourceCooker = new TestSourceDataCooker() { Path = DataCookerPath.ForSource(TestTable1.SourceParserId, "CookerId1") };
             var sourceCookerReference = new TestSourceDataCookerReference(false)
                 { availability = DataExtensionAvailability.Available, Path = sourceCooker.Path };
 
@@ -179,7 +179,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId);
 
-            var sourceCooker = new TestSourceDataCooker() { Path = new DataCookerPath(TestTable1.SourceParserId, "CookerId1") };
+            var sourceCooker = new TestSourceDataCooker() { Path = DataCookerPath.ForSource(TestTable1.SourceParserId, "CookerId1") };
             var sourceCookerReference = new TestSourceDataCookerReference(false)
                 { availability = DataExtensionAvailability.Available, Path = sourceCooker.Path };
 
@@ -198,7 +198,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId);
 
-            var sourceCooker = new TestSourceDataCooker() { Path = new DataCookerPath(TestTable1.SourceParserId, "CookerId1") };
+            var sourceCooker = new TestSourceDataCooker() { Path = DataCookerPath.ForSource(TestTable1.SourceParserId, "CookerId1") };
             var sourceCookerReference = new TestSourceDataCookerReference(false)
                 { availability = DataExtensionAvailability.Available, Path = sourceCooker.Path };
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookerSchedulingNodeTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookerSchedulingNodeTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             this.cookerWithNoDependencies = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerWithNoDependencies"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerWithNoDependencies"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = this.emptyDependencyTypes,
@@ -122,13 +122,13 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             this.cookerWithOneDependency = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerWithOneDependency"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerWithOneDependency"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = this.emptyDependencyTypes,
                 RequiredDataCookers = new[]
                 {
-                    new DataCookerPath(SourceParserId, this.cookerWithNoDependencies.Path.DataCookerId),
+                    DataCookerPath.ForSource(SourceParserId, this.cookerWithNoDependencies.Path.DataCookerId),
                 }
             };
         }
@@ -201,17 +201,17 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         public void ScheduleDataCookers_CircularDependenciesThrows()
         {
             string cookerWithCircularDependency1Id = "CookerWithCircularDependency1";
-            var cookerWithCircularDependency1Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency1Id);
+            var cookerWithCircularDependency1Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency1Id);
 
             string cookerWithCircularDependency2Id = "CookerWithCircularDependency2";
-            var cookerWithCircularDependency2Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency2Id);
+            var cookerWithCircularDependency2Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency2Id);
 
             string cookerWithCircularDependency3Id = "CookerWithCircularDependency3";
-            var cookerWithCircularDependency3Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency3Id);
+            var cookerWithCircularDependency3Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency3Id);
 
             IDataCookerDescriptor cookerWithCircularDependency1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency1Id),
+                Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency1Id),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = this.emptyDependencyTypes,
@@ -220,7 +220,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             IDataCookerDescriptor cookerWithCircularDependency2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency2Id),
+                Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency2Id),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = this.emptyDependencyTypes,
@@ -229,7 +229,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             IDataCookerDescriptor cookerWithCircularDependency3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, cookerWithCircularDependency3Id),
+                Path = DataCookerPath.ForSource(SourceParserId, cookerWithCircularDependency3Id),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = this.emptyDependencyTypes,
@@ -257,7 +257,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             IDataCookerDescriptor cookerWithSameIterationDependencyType = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, cookerWithSameIterationDependencyTypeId),
+                Path = DataCookerPath.ForSource(SourceParserId, cookerWithSameIterationDependencyTypeId),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -294,7 +294,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             IDataCookerDescriptor cookerWithAsConsumedDependencyType = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, cookerWithAsConsumedDependencyTypeId),
+                Path = DataCookerPath.ForSource(SourceParserId, cookerWithAsConsumedDependencyTypeId),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -332,7 +332,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cookerWithAsConsumedDependencyType = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerWithNullDependencyTypes"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerWithNullDependencyTypes"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -364,7 +364,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -377,7 +377,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker3"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker3"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -422,7 +422,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = null,
@@ -431,7 +431,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -463,7 +463,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -476,7 +476,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker3"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker3"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -492,7 +492,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker4 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker4"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker4"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -552,7 +552,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -569,7 +569,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -592,7 +592,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -601,7 +601,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -633,7 +633,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -642,7 +642,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -679,7 +679,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -688,7 +688,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -697,7 +697,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -738,7 +738,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -747,7 +747,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -756,7 +756,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -765,7 +765,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -812,7 +812,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -821,7 +821,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -830,7 +830,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -864,7 +864,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -873,7 +873,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -882,7 +882,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -917,7 +917,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -926,7 +926,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -935,7 +935,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker3"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker3"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -944,7 +944,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -983,7 +983,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -992,7 +992,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1001,7 +1001,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker3"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker3"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1010,7 +1010,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1049,7 +1049,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1058,7 +1058,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1067,7 +1067,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1111,7 +1111,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1120,7 +1120,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1129,7 +1129,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1138,7 +1138,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1185,7 +1185,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1194,7 +1194,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var asRequiredCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1203,7 +1203,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1212,7 +1212,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,
@@ -1260,7 +1260,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1269,7 +1269,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -1296,7 +1296,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var asRequiredCooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "AsRequiredCooker"),
+                Path = DataCookerPath.ForSource(SourceParserId, "AsRequiredCooker"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsRequired,
                 DependencyTypes = null,
@@ -1305,7 +1305,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = null,

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             cooker0.ProcessDependencies(testRepo);
@@ -121,12 +121,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             var cooker1 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker1"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker1"),
             };
 
             var testRepo = new TestDataExtensionRepository();
@@ -153,12 +153,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             var cooker1 = new TestSourceDataCookerReference(false)
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker1"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker1"),
                 availability = DataExtensionAvailability.Error,
             };
 
@@ -185,17 +185,17 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             var cooker1 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker1"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker1"),
             };
 
             var cooker2 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker2"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker2"),
             };
 
             // the repository has all source cookers
@@ -232,7 +232,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             // the repository has all source cookers
@@ -240,7 +240,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             testRepo.sourceCookersByPath.Add(cooker0.Path, cooker0);
 
             // setup the requirements for the cookers
-            cooker0.requiredDataCookers.Add(new DataCookerPath("TestSourceParser", "Cooker1"));
+            cooker0.requiredDataCookers.Add(DataCookerPath.ForSource("TestSourceParser", "Cooker1"));
 
             cooker0.ProcessDependencies(testRepo);
 
@@ -263,17 +263,17 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             var cooker1 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker1"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker1"),
             };
 
             var cooker2 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker2"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker2"),
             };
 
             // the repository has all source cookers
@@ -304,12 +304,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser0", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser0", "Cooker0"),
             };
 
             var cooker1 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser1", "Cooker1"),
+                Path = DataCookerPath.ForSource("TestSourceParser1", "Cooker1"),
             };
 
             var testRepo = new TestDataExtensionRepository();
@@ -333,12 +333,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestCompositeDataCookerReference
             {
-                Path = new DataCookerPath("TestSourceParser", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSourceParser", "Cooker0"),
             };
 
             var cooker1 = new TestCompositeDataCookerReference
             {
-                Path = new DataCookerPath(DataCookerPath.EmptySourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker1"),
             };
 
             var testRepo = new TestDataExtensionRepository();
@@ -366,14 +366,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestCompositeDataCookerReference
             {
-                Path = new DataCookerPath(DataCookerPath.EmptySourceParserId, "Cooker0"),
+                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker0"),
             };
 
             var testRepo = new TestDataExtensionRepository();
             testRepo.compositeCookersByPath.Add(cooker0.Path, cooker0);
 
             // this doesn't exist
-            cooker0.requiredDataCookers.Add(new DataCookerPath("Cooker1"));
+            cooker0.requiredDataCookers.Add(DataCookerPath.ForComposite("Cooker1"));
 
             cooker0.ProcessDependencies(testRepo);
 
@@ -399,12 +399,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker0 = new TestSourceDataCookerReference
             {
-                Path = new DataCookerPath("TestSource0", "Cooker0"),
+                Path = DataCookerPath.ForSource("TestSource0", "Cooker0"),
             };
 
             var cooker1 = new TestCompositeDataCookerReference
             {
-                Path = new DataCookerPath(DataCookerPath.EmptySourceParserId, "Cooker0"),
+                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker0"),
             };
 
             var testRepo = new TestDataExtensionRepository();

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new TestCompositeDataCookerReference
             {
-                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForComposite("Cooker1"),
             };
 
             var testRepo = new TestDataExtensionRepository();
@@ -366,7 +366,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var cooker0 = new TestCompositeDataCookerReference
             {
-                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker0"),
+                Path = DataCookerPath.ForComposite("Cooker0"),
             };
 
             var testRepo = new TestDataExtensionRepository();
@@ -404,7 +404,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var cooker1 = new TestCompositeDataCookerReference
             {
-                Path = DataCookerPath.ForSource(DataCookerPath.EmptySourceParserId, "Cooker0"),
+                Path = DataCookerPath.ForComposite("Cooker0"),
             };
 
             var testRepo = new TestDataExtensionRepository();

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRetrievalFactoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRetrievalFactoryTests.cs
@@ -38,13 +38,13 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var sourceDataCookerReference1 = new TestSourceDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Available,
-                Path = new DataCookerPath("Source1", "SourceCooker1"),
+                Path = DataCookerPath.ForSource("Source1", "SourceCooker1"),
             };
 
             var dataCookerReference = new TestCompositeDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Available,
-                Path = new DataCookerPath("CompositeCooker1"),
+                Path = DataCookerPath.ForComposite("CompositeCooker1"),
             };
             dataCookerReference.requiredDataCookers.Add(sourceDataCookerReference1.Path);
 
@@ -73,7 +73,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var cookedDataRetrieval = new TestCookedDataRetrieval();
             var dataExtensionRepository = new TestDataExtensionRepository();
 
-            var cookerPath = new DataCookerPath("CompositeCooker1");
+            var cookerPath = DataCookerPath.ForComposite("CompositeCooker1");
 
             var dataExtensionRetrievalFactory =
                 new DataExtensionRetrievalFactory(cookedDataRetrieval, dataExtensionRepository);
@@ -92,7 +92,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataCookerReference = new TestCompositeDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Error,
-                Path = new DataCookerPath("CompositeCooker1"),
+                Path = DataCookerPath.ForComposite("CompositeCooker1"),
             };
 
             dataExtensionRepository.compositeCookersByPath.Add(dataCookerReference.Path, dataCookerReference);
@@ -114,13 +114,13 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var sourceDataCookerReference1 = new TestSourceDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Available,
-                Path = new DataCookerPath("Source1", "SourceCooker1"),
+                Path = DataCookerPath.ForSource("Source1", "SourceCooker1"),
             };
 
             var dataCookerReference = new TestCompositeDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Available,
-                Path = new DataCookerPath("CompositeCooker1"),
+                Path = DataCookerPath.ForComposite("CompositeCooker1"),
             };
             dataCookerReference.requiredDataCookers.Add(sourceDataCookerReference1.Path);
 
@@ -176,7 +176,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataCookerReference = new TestCompositeDataCookerReference(false)
             {
                 availability = DataExtensionAvailability.Error,
-                Path = new DataCookerPath("CompositeCooker1"),
+                Path = DataCookerPath.ForComposite("CompositeCooker1"),
             };
 
             var tableReference = new TestTableExtensionReference(false)

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagExtensionsTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagExtensionsTests.cs
@@ -49,14 +49,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // 2: n5 n4
             // 3: n6
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var n1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n1"), };
-            var n2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n2"), };
-            var n3 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n3"), };
-            var n4 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n4"), };
-            var n5 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n5"), };
-            var n6 = new TestCompositeDataCookerReference { Path = new DataCookerPath("n6"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var n1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n1"), };
+            var n2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n2"), };
+            var n3 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n3"), };
+            var n4 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n4"), };
+            var n5 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n5"), };
+            var n6 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("n6"), };
 
             r0.requiredDataCookers.Add(n1.Path);
             r0.requiredDataCookers.Add(n2.Path);

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagTests.cs
@@ -96,13 +96,13 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  d1   d2    d1
             //
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r1d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1"), };
+            var r0d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r1d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
             var r2d1 = r1d1;
 
             r0.requiredDataCookers.Add(r0d1.Path);
@@ -199,14 +199,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  |
             //  d3
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d1d3 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1d3"), };
-            var r1d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d1d3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1d3"), };
+            var r1d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
             var r2d1 = r1d1;
 
             r0.requiredDataCookers.Add(r0d1.Path);
@@ -312,14 +312,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //            |/
             //           d2
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r1d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1d1"), };
-            var r1d1d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1d2"), };
+            var r0d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r1d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
+            var r1d1d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1d2"), };
             var r2d2 = r1d1d2;
 
             r0.requiredDataCookers.Add(r0d1.Path);
@@ -423,11 +423,11 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // d3 -+--/      d3
             //
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d3 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d3"), };
-            var r0d4 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d4"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d3"), };
+            var r0d4 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d4"), };
 
             r0.requiredDataCookers.Add(r0d1.Path);
             r0.requiredDataCookers.Add(r0d2.Path);
@@ -516,10 +516,10 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  d2 d3 ->
             //
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d3 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d3"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d3 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d3"), };
 
             r0.requiredDataCookers.Add(r0d1.Path);
             r0d1.requiredDataCookers.Add(r0d2.Path);
@@ -559,10 +559,10 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  d2 d3 ->
             //
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d3 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d3"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d3 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d3"), };
 
             r0.requiredDataCookers.Add(r0d1.Path);
             r0d1.requiredDataCookers.Add(r0d2.Path);
@@ -627,11 +627,11 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
                 Any.ProcessorEnvironment(), 
                 ProcessorOptions.Default);
 
-            var sc1 = new TestSourceDataCookerReference { Path = new DataCookerPath(p.SourceParserId, "sc1"), };
-            var sc2 = new TestSourceDataCookerReference { Path = new DataCookerPath(p.SourceParserId, "sc2"), };
-            var sc3 = new TestSourceDataCookerReference { Path = new DataCookerPath(p.SourceParserId, "sc3"), };
-            var sc4 = new TestSourceDataCookerReference { Path = new DataCookerPath("not-there", "sc4"), };
-            var cc1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("cc1"), };
+            var sc1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForSource(p.SourceParserId, "sc1"), };
+            var sc2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForSource(p.SourceParserId, "sc2"), };
+            var sc3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForSource(p.SourceParserId, "sc3"), };
+            var sc4 = new TestSourceDataCookerReference { Path = DataCookerPath.ForSource("not-there", "sc4"), };
+            var cc1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("cc1"), };
 
             cc1.requiredDataCookers.Add(sc1.Path);
             cc1.requiredDataCookers.Add(sc2.Path);
@@ -719,14 +719,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  |
             //  d3
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d1d3 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1d3"), };
-            var r1d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d1d3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1d3"), };
+            var r1d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
             var r2d1 = r1d1;
 
             r0.requiredDataCookers.Add(r0d1.Path);
@@ -823,14 +823,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  |
             //  d3 (X)
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d1d3 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1d3"), };
-            var r1d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d1d3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1d3"), };
+            var r1d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
             var r2d1 = r1d1;
 
             r0.requiredDataCookers.Add(r0d1.Path);
@@ -929,14 +929,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             //  d3
             //
 
-            var r0 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0"), };
-            var r1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r1"), };
-            var r2 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r2"), };
+            var r0 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0"), };
+            var r1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r1"), };
+            var r2 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r2"), };
 
-            var r0d1 = new TestCompositeDataCookerReference { Path = new DataCookerPath("r0d1"), };
-            var r0d2 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d2"), };
-            var r0d1d3 = new TestSourceDataCookerReference { Path = new DataCookerPath("r0d1d3"), };
-            var r1d1 = new TestSourceDataCookerReference { Path = new DataCookerPath("r1d1"), };
+            var r0d1 = new TestCompositeDataCookerReference { Path = DataCookerPath.ForComposite("r0d1"), };
+            var r0d2 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d2"), };
+            var r0d1d3 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r0d1d3"), };
+            var r1d1 = new TestSourceDataCookerReference { Path = DataCookerPath.ForComposite("r1d1"), };
             var r2d1 = r1d1;
 
             r0.requiredDataCookers.Add(r0d1.Path);

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         : BaseSourceDataCooker<TestDataElement, TestDataContext, int>
     {
         public InternalSourceDataCooker()
-            : base(new DataCookerPath("SourceId", "CookerId"))
+            : base(DataCookerPath.ForSource("SourceId", "CookerId"))
         {
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerSchedulerTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerSchedulerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 0, Block: 0
             this.dataCooker1 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker1"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker1"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,
@@ -48,7 +48,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 0, Block: 0
             this.dataCooker4 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker4"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker4"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -62,7 +62,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 0, Block: 1
             this.dataCooker3 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker3"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker3"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -76,7 +76,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 1, Block: 0
             this.dataCooker2 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker2"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker2"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = EmptyDependencyTypes,
@@ -86,7 +86,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 1, Block: 1
             this.dataCooker5 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker5"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker5"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,
@@ -96,7 +96,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 1, Block: 2
             this.dataCooker6 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker6"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker6"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -110,7 +110,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             // Pass: 1, Block: 2
             this.dataCooker7 = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "Cooker7"),
+                Path = DataCookerPath.ForSource(SourceParserId, "Cooker7"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = new ReadOnlyDictionary<DataCookerPath, DataCookerDependencyType>(
@@ -202,7 +202,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var dataCookerA = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerA"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerA"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,
@@ -211,7 +211,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var dataCookerB = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerB"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerB"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,
@@ -220,7 +220,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var dataCookerC = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerC"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerC"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,
@@ -229,7 +229,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var dataCookerD = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerD"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerD"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.AsConsumed,
                 DependencyTypes = EmptyDependencyTypes,
@@ -243,7 +243,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var dataCookerE = new ValidSourceDataCookerWithoutDependencies
             {
-                Path = new DataCookerPath(SourceParserId, "CookerE"),
+                Path = DataCookerPath.ForSource(SourceParserId, "CookerE"),
                 Description = "Test data cooker",
                 DataProductionStrategy = DataProductionStrategy.PostSourceParsing,
                 DependencyTypes = EmptyDependencyTypes,

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceSessionTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceSessionTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var sourceDataCooker = new TestSourceDataCooker()
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker")
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker")
             };
 
             sourceSession.RegisterSourceDataCooker(sourceDataCooker);
@@ -90,28 +90,28 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var sourceDataCooker1 = new TestSourceDataCooker(dataCookerContext)
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker1"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker1"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 13, 45, 67 }),
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker1);
 
             var sourceDataCooker2 = new TestSourceDataCooker(dataCookerContext)
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker2"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker2"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 113, 145, 167, 1000 }),
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker2);
 
             var sourceDataCooker3 = new TestSourceDataCooker(dataCookerContext)
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker3"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker3"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 200, 250, 286, 1000 }),
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker3);
 
             var sourceDataCooker4 = new TestSourceDataCooker(dataCookerContext)
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker4"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker4"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 145, 316, 315, 301 }),
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker4);
@@ -231,14 +231,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var sourceDataCooker1 = new TestSourceDataCooker()
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker1"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker1"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 13, 45, 67 })
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker1);
 
             var sourceDataCooker2 = new TestSourceDataCooker()
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker2"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker2"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 113, 145, 167, 1000 }),
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker2);
@@ -269,14 +269,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var sourceDataCooker1 = new TestSourceDataCooker()
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker1"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker1"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() { 13, 45, 67 })
             };
             sourceSession.RegisterSourceDataCooker(sourceDataCooker1);
 
             var sourceDataCooker2 = new TestSourceDataCooker()
             {
-                Path = new DataCookerPath(sourceParser.Id, "TestSourceDataCooker2"),
+                Path = DataCookerPath.ForSource(sourceParser.Id, "TestSourceDataCooker2"),
                 DataKeys = new ReadOnlyHashSet<int>(new HashSet<int>() {}),
                 Options = SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCookerOptions.ReceiveAllDataElements,
             };

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionSelectorTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionSelectorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         private static readonly IDictionary<DataCookerPath, TestCompositeDataCookerReference> CompositeCookersByPath
             = new Dictionary<DataCookerPath, TestCompositeDataCookerReference>();
 
-        private static readonly DataCookerPath Source1Cooker1Path = new DataCookerPath("Source1", "SourceCooker1");
+        private static readonly DataCookerPath Source1Cooker1Path = DataCookerPath.ForSource("Source1", "SourceCooker1");
 
         static TableExtensionSelectorTests()
         {
@@ -44,31 +44,31 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             {
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source1", "SourceCooker1"),
+                    Path = DataCookerPath.ForSource("Source1", "SourceCooker1"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source2", "SourceCooker0"),
+                    Path = DataCookerPath.ForSource("Source2", "SourceCooker0"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source2", "SourceCooker10"),
+                    Path = DataCookerPath.ForSource("Source2", "SourceCooker10"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source2", "SourceCooker13"),
+                    Path = DataCookerPath.ForSource("Source2", "SourceCooker13"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source1", "SourceCooker41"),
+                    Path = DataCookerPath.ForSource("Source1", "SourceCooker41"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source1", "SourceCooker356"),
+                    Path = DataCookerPath.ForSource("Source1", "SourceCooker356"),
                 },
                 new TestSourceDataCookerReference
                 {
-                    Path = new DataCookerPath("Source4", "SourceCooker_Woah!"),
+                    Path = DataCookerPath.ForSource("Source4", "SourceCooker_Woah!"),
                 },
             };
 
@@ -84,19 +84,19 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             {
                 new TestCompositeDataCookerReference
                 {
-                    Path = new DataCookerPath(string.Empty, "CompositeCooker1"),
+                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker1"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = new DataCookerPath(string.Empty, "CompositeCooker2"),
+                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker2"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = new DataCookerPath(string.Empty, "CompositeCooker3"),
+                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker3"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = new DataCookerPath(string.Empty, "CompositeCooker33"),
+                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker33"),
                 },
             };
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionSelectorTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionSelectorTests.cs
@@ -84,19 +84,19 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             {
                 new TestCompositeDataCookerReference
                 {
-                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker1"),
+                    Path = DataCookerPath.ForComposite("CompositeCooker1"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker2"),
+                    Path = DataCookerPath.ForComposite("CompositeCooker2"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker3"),
+                    Path = DataCookerPath.ForComposite("CompositeCooker3"),
                 },
                 new TestCompositeDataCookerReference
                 {
-                    Path = DataCookerPath.ForSource(string.Empty, "CompositeCooker33"),
+                    Path = DataCookerPath.ForComposite("CompositeCooker33"),
                 },
             };
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/DisposableCompositeDataCooker.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/DisposableCompositeDataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.TestClasses
     {
         public DisposableCompositeDataCooker()
         {
-            this.Path = new DataCookerPath(nameof(DisposableCompositeDataCooker));
+            this.Path = DataCookerPath.ForComposite(nameof(DisposableCompositeDataCooker));
             this.RequiredDataCookers = new List<DataCookerPath>();
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/DisposableSourceDataCooker.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/DisposableSourceDataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.TestClasses
     {
         public DisposableSourceDataCooker()
         {
-            this.Path = new DataCookerPath(nameof(DisposableSourceDataCooker));
+            this.Path = DataCookerPath.ForComposite(nameof(DisposableSourceDataCooker));
             this.RequiredDataCookers = new List<DataCookerPath>();
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestCompositeDataCooker.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestCompositeDataCooker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.TestClasses
     {
         public TestCompositeDataCooker()
         {
-            this.Path = new DataCookerPath(nameof(TestCompositeDataCooker));
+            this.Path = DataCookerPath.ForComposite(nameof(TestCompositeDataCooker));
             this.RequiredDataCookers = new List<DataCookerPath>();
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestDataCookerReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestDataCookerReference.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.TestClasses
         protected TestDataCookerReference(bool useDataExtensionDependencyState)
             : base(useDataExtensionDependencyState)
         {
-            this.Path = new DataCookerPath(
+            this.Path = DataCookerPath.ForComposite(
                 string.Concat(
                     this.GetType().Name,
                     " ",

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/Dependency/DataExtensionDependencyState.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/Dependency/DataExtensionDependencyState.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Depende
 
             foreach (var requiredDataCookerPath in this.target.RequiredDataCookers)
             {
-                IDataCookerReference dataCookerReference = null;
+                IDataCookerReference dataCookerReference;
 
                 var sourceId = requiredDataCookerPath.SourceParserId;
                 if (string.IsNullOrWhiteSpace(sourceId))
@@ -308,7 +308,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Depende
                     this.dependencyReferences.AddRequiredSourceDataCookerPath(requiredCookerReference.Path);
                 }
 
-                this.ProcessRequiredExtension(dataCookerReference, requiredDataCookerPath.CookerPath, availableDataExtensions);
+                this.ProcessRequiredExtension(dataCookerReference, requiredDataCookerPath.ToString(), availableDataExtensions);
             }
         }
 

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Performance.SDK.Extensibility
         ///     <paramref name="dataCookerId"/> is null.
         /// </exception>
         private DataCookerPath(string dataCookerId)
-            : this(EmptySourceParserId, dataCookerId)
         {
             Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
 
@@ -117,7 +116,7 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// </exception>
         public static DataCookerPath ForComposite(string dataCookerId)
         {
-            return DataCookerPath.ForComposite(dataCookerId);
+            return new DataCookerPath(dataCookerId);
         }
 
         /// <summary>
@@ -137,7 +136,7 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// </exception>
         public static DataCookerPath ForSource(string sourceParserId, string dataCookerId)
         {
-            return DataCookerPath.ForSource(sourceParserId, dataCookerId);
+            return new DataCookerPath(sourceParserId, dataCookerId);
         }
 
         /// <summary>

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
@@ -154,9 +154,9 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// </summary>
         public string DataCookerId { get; }
 
-        ///// <summary>
-        ///// Gets the combination of the source parser Id and the data cooker Id.
-        ///// </summary>
+        /// <summary>
+        /// Gets the combination of the source parser Id and the data cooker Id.
+        /// </summary>
         [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
         public string CookerPath
         {
@@ -333,7 +333,7 @@ namespace Microsoft.Performance.SDK.Extensibility
         ///     True for a well formed path, false otherwise.
         /// </returns>
         [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
-        internal static bool IsWellFormed(string cookerPath)
+        public static bool IsWellFormed(string cookerPath)
         {
             if (string.IsNullOrWhiteSpace(cookerPath))
             {

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCookerPath.cs
@@ -15,16 +15,18 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     Describes the format of a data cooker path.
         /// </summary>
-        //[Obsolete("Fully qualified data cooker paths will no longer be supported in SDK v1.0.0 release candidate 1")]
-        //public static string Format => "SourceId/CookerId";
+        [Obsolete("Fully qualified data cooker paths will no longer be supported in SDK v1.0.0 release candidate 1")]
+        public static string Format => "SourceId/CookerId";
 
         /// <summary>
         ///     If the data cooker is not a source data cooker, this is the source parser Id.
         /// </summary>
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
         public const string EmptySourceParserId = "";
 
         /// <summary>
-        ///     Creates a new <see cref="DataCookerType.CompositeDataCooker"/> path.
+        ///     Constructor without an empty source parser id.
+        ///     Used for composite data cookers.
         /// </summary>
         /// <param name="dataCookerId">
         ///     The ID of the data cooker.
@@ -35,29 +37,21 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="dataCookerId"/> is null.
         /// </exception>
-        private DataCookerPath(string dataCookerId)
+        [Obsolete("This constructor will be removed by SDK v1.0.0 release candidate 1. Please use DataCookerPath.ForComposite or DataCookerPath.ForSource instead.")]
+        public DataCookerPath(string dataCookerId)
+            : this(EmptySourceParserId, dataCookerId)
         {
-            Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
-
-            if (dataCookerId.Contains("/"))
-            {
-                throw new ArgumentException("This value may not contain a '/'.", nameof(dataCookerId));
-            }
-
-            this.SourceParserId = DataCookerPath.EmptySourceParserId;
-            this.DataCookerId = string.Intern(dataCookerId);
-            this.CookerPath = Create(DataCookerPath.EmptySourceParserId, dataCookerId);
-            this.DataCookerType = DataCookerType.CompositeDataCooker;
         }
 
         /// <summary>
-        ///     Creates a new <see cref="DataCookerType.SourceDataCooker"/> path.
+        ///     Constructor that takes a source parser id. If that ID is not empty, this
+        ///     is used for source data cookers. If it is empty, this is used with composite data cookers.
         /// </summary>
         /// <param name="sourceParserId">
-        ///     The ID of the source parser.
+        ///     Source parser Id.
         /// </param>
         /// <param name="dataCookerId">
-        ///     The ID of the data cooker.
+        ///     Data cooker Id.
         /// </param>
         /// <exception cref="ArgumentException">
         ///     One or more of the parameters is empty or composed only of whitespace.
@@ -65,9 +59,10 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <exception cref="ArgumentNullException">
         ///     One or more of the parameters is null.
         /// </exception>
-        private DataCookerPath(string sourceParserId, string dataCookerId)
+        [Obsolete("This constructor will be removed by SDK v1.0.0 release candidate 1. Please use DataCookerPath.ForComposite or DataCookerPath.ForSource instead.")]
+        public DataCookerPath(string sourceParserId, string dataCookerId)
         {
-            Guard.NotNullOrWhiteSpace(sourceParserId, nameof(sourceParserId));
+            Guard.NotNull(sourceParserId, nameof(sourceParserId));
             Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
 
             if (sourceParserId.Contains("/"))
@@ -83,7 +78,7 @@ namespace Microsoft.Performance.SDK.Extensibility
             this.SourceParserId = string.Intern(sourceParserId);
             this.DataCookerId = string.Intern(dataCookerId);
             this.CookerPath = Create(sourceParserId, dataCookerId);
-            this.DataCookerType = DataCookerType.SourceDataCooker;
+            this.DataCookerType = string.IsNullOrWhiteSpace(sourceParserId) ? DataCookerType.CompositeDataCooker : DataCookerType.SourceDataCooker;
         }
 
         /// <summary>
@@ -162,8 +157,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         ///// <summary>
         ///// Gets the combination of the source parser Id and the data cooker Id.
         ///// </summary>
-        // This will eventually be made internal only
-        internal string CookerPath
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public string CookerPath
         {
             get;
         }
@@ -242,23 +237,24 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     The parsed <see cref="DataCookerPath"/>.
         /// </returns>
-        //public static DataCookerPath Parse(string cookerPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static DataCookerPath Parse(string cookerPath)
+        {
+            Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
 
-        //    var split = cookerPath.Split('/');
-        //    if (split.Length == 1)
-        //    {
-        //        return DataCookerPath.ForComposite(split[0]);
-        //    }
+            var split = cookerPath.Split('/');
+            if (split.Length == 1)
+            {
+                return DataCookerPath.ForComposite(split[0]);
+            }
 
-        //    if (split.Length == 2)
-        //    {
-        //        return DataCookerPath.ForSource(split[0], split[1]);
-        //    }
+            if (split.Length == 2)
+            {
+                return DataCookerPath.ForSource(split[0], split[1]);
+            }
 
-        //    throw new FormatException();
-        //}
+            throw new FormatException();
+        }
 
         /// <summary>
         ///     Generates a data cooker path given a source parser Id and a data cooker Id.
@@ -272,7 +268,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     The created data cooker path.
         /// </returns>
-        internal static string Create(string sourceParserId, string dataCookerId)
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use ForSource or ForComposite.")]
+        public static string Create(string sourceParserId, string dataCookerId)
         {
             Guard.NotNull(sourceParserId, nameof(sourceParserId));
             Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
@@ -289,18 +286,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Source parser Id.
         /// </returns>
-        //public static string GetSourceParserId(string cookerPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string GetSourceParserId(string cookerPath)
+        {
+            Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
 
-        //    var tokens = SplitPath(cookerPath);
-        //    if (tokens != null)
-        //    {
-        //        return tokens[0];
-        //    }
+            var tokens = SplitPath(cookerPath);
+            if (tokens != null)
+            {
+                return tokens[0];
+            }
 
-        //    return string.Empty;
-        //}
+            return string.Empty;
+        }
 
         /// <summary>
         ///     Returns the data cooker Id from a data cooker path.
@@ -311,18 +309,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data cooker Id.
         /// </returns>
-        //public static string GetDataCookerId(string cookerPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string GetDataCookerId(string cookerPath)
+        {
+            Guard.NotNullOrWhiteSpace(cookerPath, nameof(cookerPath));
 
-        //    var tokens = SplitPath(cookerPath);
-        //    if (tokens != null)
-        //    {
-        //        return tokens[1];
-        //    }
+            var tokens = SplitPath(cookerPath);
+            if (tokens != null)
+            {
+                return tokens[1];
+            }
 
-        //    return string.Empty;
-        //}
+            return string.Empty;
+        }
 
         /// <summary>
         ///     Determines if a data cooker path has a proper form.
@@ -333,25 +332,27 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     True for a well formed path, false otherwise.
         /// </returns>
-        //internal static bool IsWellFormed(string cookerPath)
-        //{
-        //    if (string.IsNullOrWhiteSpace(cookerPath))
-        //    {
-        //        return false;
-        //    }
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        internal static bool IsWellFormed(string cookerPath)
+        {
+            if (string.IsNullOrWhiteSpace(cookerPath))
+            {
+                return false;
+            }
 
-        //    return SplitPath(cookerPath) != null;
-        //}
+            return SplitPath(cookerPath) != null;
+        }
 
-        //private static string[] SplitPath(string cookerPath)
-        //{
-        //    var tokens = cookerPath.Split('/');
-        //    if (tokens.Length == 2)
-        //    {
-        //        return tokens;
-        //    }
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        private static string[] SplitPath(string cookerPath)
+        {
+            var tokens = cookerPath.Split('/');
+            if (tokens.Length == 2)
+            {
+                return tokens;
+            }
 
-        //    return null;
-        //}
+            return null;
+        }
     }
 }

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCookerType.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCookerType.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.SourceParsing;
+
+namespace Microsoft.Performance.SDK.Extensibility
+{
+    /// <summary>
+    ///     The type of a <see cref="IDataCooker"/>.
+    /// </summary>
+    public enum DataCookerType
+    {
+        /// <summary>
+        ///     An <see cref="IDataCooker"/> that directly receives input from an
+        ///     <see cref="ISourceParser{T, TContext, TKey}"/> and/or one or more
+        ///     <see cref="SourceDataCooker"/>s targeting the same <see cref="ISourceParser{T, TContext, TKey}"/>.
+        /// </summary>
+        SourceDataCooker,
+
+        /// <summary>
+        ///     An <see cref="IDataCooker"/> that consumes events from one or more
+        ///     other <see cref="IDataCooker"/>.
+        /// </summary>
+        CompositeDataCooker,
+    }
+}

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCooking/SourceDataCooking/BaseSourceDataCooker.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCooking/SourceDataCooking/BaseSourceDataCooker.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking
         ///     This cooker's ID.
         /// </param>
         protected BaseSourceDataCooker(string sourceId, string cookerId)
-            : this(new DataCookerPath(sourceId, cookerId))
+            : this(DataCookerPath.ForSource(sourceId, cookerId))
         {
         }
 

--- a/src/Microsoft.Performance.SDK/Extensibility/DataOutputPath.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataOutputPath.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     Describes the format of a data output path.
         /// </summary>
-        public static string Format => "[DataCookerPath]/OutputId";
+        //[Obsolete("Fully qualified data output paths will no longer be supported in SDK v1.0.0")]
+        //public static string Format => "[DataCookerPath]/OutputId";
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DataOutputPath"/>
@@ -26,19 +27,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     DataOutputPath object which represents the provided string path.
         /// </returns>
-        public static DataOutputPath Create(
-            string path)
-        {
-            Guard.NotNullOrWhiteSpace(path, nameof(path));
+        //public static DataOutputPath Create(
+        //    string path)
+        //{
+        //    Guard.NotNullOrWhiteSpace(path, nameof(path));
 
-            var success = TryGetConstituents(path, out var sourceId, out var cookerId, out var outputId);
-            if (!success)
-            {
-                throw new ArgumentException("Invalid data output path", nameof(path));
-            }
+        //    var success = TryGetConstituents(path, out var sourceId, out var cookerId, out var outputId);
+        //    if (!success)
+        //    {
+        //        throw new ArgumentException("Invalid data output path", nameof(path));
+        //    }
 
-            return Create(sourceId, cookerId, outputId);
-        }
+        //    return Create(sourceId, cookerId, outputId);
+        //}
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DataOutputPath"/>
@@ -57,14 +58,53 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     DataOutputPath object combined from the given parameters.
         /// </returns>
-        public static DataOutputPath Create(
+        /// <exception cref="ArgumentException">
+        ///     One or more of the parameters is empty or composed only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     One or more of the parameters is null.
+        /// </exception>
+        public static DataOutputPath CreateForSourceCooker(
             string sourceParserId, 
             string dataCookerId, 
             string dataOutputId)
         {
+            Guard.NotNullOrWhiteSpace(sourceParserId, nameof(sourceParserId));
+            Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
             Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
 
-            var dataCookerPath = new DataCookerPath(sourceParserId, dataCookerId);
+            var dataCookerPath = DataCookerPath.ForSource(sourceParserId, dataCookerId);
+
+            return new DataOutputPath(dataCookerPath, dataOutputId);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DataOutputPath"/>
+        ///     struct with the given data cooker ID and output ID.
+        /// </summary>
+        /// <param name="dataCookerId">
+        ///     Data cooker Id.
+        /// </param>
+        /// <param name="dataOutputId">
+        ///     Data output Id.
+        /// </param>
+        /// <returns>
+        ///     DataOutputPath object combined from the given parameters.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     One or more of the parameters is empty or composed only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     One or more of the parameters is null.
+        /// </exception>
+        public static DataOutputPath CreateForCompositeCooker(
+            string dataCookerId,
+            string dataOutputId)
+        {
+            Guard.NotNullOrWhiteSpace(dataCookerId, nameof(dataCookerId));
+            Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
+
+            var dataCookerPath = DataCookerPath.ForComposite(dataCookerId);
 
             return new DataOutputPath(dataCookerPath, dataOutputId);
         }
@@ -79,6 +119,12 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <param name="outputId">
         ///     Data output Id.
         /// </param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="outputId"/> is empty or composed only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="outputId"/> is null.
+        /// </exception>
         public DataOutputPath(DataCookerPath cookerPath, string outputId)
         {
             Guard.NotNullOrWhiteSpace(outputId, nameof(outputId));
@@ -105,6 +151,10 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     Gets the identifier of the source parser associated with this data.
         /// </summary>
+        /// <remarks>
+        ///     This may be null or <see cref="string.Empty"/> if this <see cref="DataOutputPath"/>
+        ///     is for a composite cooker.
+        /// </remarks>
         public string SourceParserId => CookerPath.SourceParserId;
 
         /// <summary>
@@ -115,7 +165,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     The complete path to the data output.
         /// </summary>
-        public string Path => this.CookerPath.CookerPath + "/" + this.OutputId;
+        // This will eventually need to be internal only
+        internal string Path => this.CookerPath.CookerPath + "/" + this.OutputId;
 
         /// <summary>
         ///     Generates a data cooker path given a source parser Id and a data cooker Id.
@@ -132,12 +183,12 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     The path.
         /// </returns>
-        public static string Combine(string sourceParserId, string dataCookerId, string dataOutputId)
-        {
-            Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
+        //internal static string Combine(string sourceParserId, string dataCookerId, string dataOutputId)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
 
-            return DataCookerPath.Create(sourceParserId, dataCookerId) + "/" + dataOutputId;
-        }
+        //    return DataCookerPath.Create(sourceParserId, dataCookerId) + "/" + dataOutputId;
+        //}
 
         /// <summary>
         ///     Returns the source parser Id from a data output path.
@@ -148,18 +199,18 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Source parser Id.
         /// </returns>
-        public static string GetSourceId(string dataOutputPath)
-        {
-            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        //public static string GetSourceId(string dataOutputPath)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-            var tokens = SplitPath(dataOutputPath);
-            if (tokens != null)
-            {
-                return tokens[0];
-            }
+        //    var tokens = SplitPath(dataOutputPath);
+        //    if (tokens != null)
+        //    {
+        //        return tokens[0];
+        //    }
 
-            return string.Empty;
-        }
+        //    return string.Empty;
+        //}
 
         /// <summary>
         ///     Returns the data cooker Id from a data output path.
@@ -170,18 +221,18 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data cooker Id.
         /// </returns>
-        public static string GetDataCookerId(string dataOutputPath)
-        {
-            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        //public static string GetDataCookerId(string dataOutputPath)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-            var tokens = SplitPath(dataOutputPath);
-            if (tokens != null)
-            {
-                return tokens[1];
-            }
+        //    var tokens = SplitPath(dataOutputPath);
+        //    if (tokens != null)
+        //    {
+        //        return tokens[1];
+        //    }
 
-            return string.Empty;
-        }
+        //    return string.Empty;
+        //}
 
         /// <summary>
         ///     Returns the data output Id from a data output path.
@@ -192,18 +243,18 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data output Id.
         /// </returns>
-        public static string GetDataOutputId(string dataOutputPath)
-        {
-            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        //public static string GetDataOutputId(string dataOutputPath)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-            var tokens = SplitPath(dataOutputPath);
-            if (tokens != null)
-            {
-                return tokens[2];
-            }
+        //    var tokens = SplitPath(dataOutputPath);
+        //    if (tokens != null)
+        //    {
+        //        return tokens[2];
+        //    }
 
-            return string.Empty;
-        }
+        //    return string.Empty;
+        //}
 
         /// <summary>
         ///     Returns the data cooker path from a data output path.
@@ -214,18 +265,18 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data cooker path.
         /// </returns>
-        public static DataCookerPath GetDataCookerPath(string dataOutputPath)
-        {
-            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        //public static DataCookerPath GetDataCookerPath(string dataOutputPath)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-            var tokens = SplitPath(dataOutputPath);
-            if (tokens != null)
-            {
-                return new DataCookerPath(tokens[0], tokens[1]);
-            }
+        //    var tokens = SplitPath(dataOutputPath);
+        //    if (tokens != null)
+        //    {
+        //        return DataCookerPath.ForSource(tokens[0], tokens[1]);
+        //    }
 
-            throw new ArgumentException("Not a valid data output path.", nameof(dataOutputPath));
-        }
+        //    throw new ArgumentException("Not a valid data output path.", nameof(dataOutputPath));
+        //}
 
         /// <summary>
         ///     Splits a data output path into individual identifiers.
@@ -245,28 +296,28 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     true if the path was parsed; false otherwise.
         /// </returns>
-        public static bool TryGetConstituents(
-            string dataOutputPath, 
-            out string sourceParserId, 
-            out string dataCookerId, 
-            out string dataOutputId)
-        {
-            sourceParserId = string.Empty;
-            dataCookerId = string.Empty;
-            dataOutputId = string.Empty;
+        //public static bool TryGetConstituents(
+        //    string dataOutputPath, 
+        //    out string sourceParserId, 
+        //    out string dataCookerId, 
+        //    out string dataOutputId)
+        //{
+        //    sourceParserId = string.Empty;
+        //    dataCookerId = string.Empty;
+        //    dataOutputId = string.Empty;
 
-            var tokens = SplitPath(dataOutputPath);
-            if (tokens != null)
-            {
-                sourceParserId = tokens[0];
-                dataCookerId = tokens[1];
-                dataOutputId = tokens[2];
+        //    var tokens = SplitPath(dataOutputPath);
+        //    if (tokens != null)
+        //    {
+        //        sourceParserId = tokens[0];
+        //        dataCookerId = tokens[1];
+        //        dataOutputId = tokens[2];
 
-                return true;
-            }
+        //        return true;
+        //    }
 
-            return false;
-        }
+        //    return false;
+        //}
 
         /// <summary>
         ///     Determines if a data output path has a proper form.
@@ -277,15 +328,15 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     True for a well formed path, false otherwise.
         /// </returns>
-        public static bool IsWellFormed(string dataOutputPath)
-        {
-            if (string.IsNullOrWhiteSpace(dataOutputPath))
-            {
-                return false;
-            }
+        //public static bool IsWellFormed(string dataOutputPath)
+        //{
+        //    if (string.IsNullOrWhiteSpace(dataOutputPath))
+        //    {
+        //        return false;
+        //    }
 
-            return SplitPath(dataOutputPath) != null;
-        }
+        //    return SplitPath(dataOutputPath) != null;
+        //}
 
         /// <inheritdoc />
         public override string ToString()
@@ -293,15 +344,15 @@ namespace Microsoft.Performance.SDK.Extensibility
             return this.Path;
         }
 
-        private static string[] SplitPath(string outputPath)
-        {
-            var tokens = outputPath.Split('/');
-            if (tokens.Length == 3)
-            {
-                return tokens;
-            }
+        //private static string[] SplitPath(string outputPath)
+        //{
+        //    var tokens = outputPath.Split('/');
+        //    if (tokens.Length == 3)
+        //    {
+        //        return tokens;
+        //    }
 
-            return null;
-        }
+        //    return null;
+        //}
     }
 }

--- a/src/Microsoft.Performance.SDK/Extensibility/DataOutputPath.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataOutputPath.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     Describes the format of a data output path.
         /// </summary>
-        //[Obsolete("Fully qualified data output paths will no longer be supported in SDK v1.0.0")]
-        //public static string Format => "[DataCookerPath]/OutputId";
+        [Obsolete("Fully qualified data output paths will no longer be supported in SDK v1.0.0")]
+        public static string Format => "[DataCookerPath]/OutputId";
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DataOutputPath"/>
@@ -27,19 +27,50 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     DataOutputPath object which represents the provided string path.
         /// </returns>
-        //public static DataOutputPath Create(
-        //    string path)
-        //{
-        //    Guard.NotNullOrWhiteSpace(path, nameof(path));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use ForSource or ForComposite.")]
+        public static DataOutputPath Create(
+            string path)
+        {
+            Guard.NotNullOrWhiteSpace(path, nameof(path));
 
-        //    var success = TryGetConstituents(path, out var sourceId, out var cookerId, out var outputId);
-        //    if (!success)
-        //    {
-        //        throw new ArgumentException("Invalid data output path", nameof(path));
-        //    }
+            var success = TryGetConstituents(path, out var sourceId, out var cookerId, out var outputId);
+            if (!success)
+            {
+                throw new ArgumentException("Invalid data output path", nameof(path));
+            }
 
-        //    return Create(sourceId, cookerId, outputId);
-        //}
+            return Create(sourceId, cookerId, outputId);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DataOutputPath"/>
+        ///     struct with the given source parser ID, data cooker ID, and
+        ///     output ID.
+        /// </summary>
+        /// <param name="sourceParserId">
+        ///     Source parser Id.
+        /// </param>
+        /// <param name="dataCookerId">
+        ///     Data cooker Id.
+        /// </param>
+        /// <param name="dataOutputId">
+        ///     Data output Id.
+        /// </param>
+        /// <returns>
+        ///     DataOutputPath object combined from the given parameters.
+        /// </returns>
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use ForSource or ForComposite.")]
+        public static DataOutputPath Create(
+            string sourceParserId,
+            string dataCookerId,
+            string dataOutputId)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
+
+            var dataCookerPath = new DataCookerPath(sourceParserId, dataCookerId);
+
+            return new DataOutputPath(dataCookerPath, dataOutputId);
+        }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DataOutputPath"/>
@@ -64,7 +95,7 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <exception cref="ArgumentNullException">
         ///     One or more of the parameters is null.
         /// </exception>
-        public static DataOutputPath CreateForSourceCooker(
+        public static DataOutputPath ForSource(
             string sourceParserId, 
             string dataCookerId, 
             string dataOutputId)
@@ -97,7 +128,7 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <exception cref="ArgumentNullException">
         ///     One or more of the parameters is null.
         /// </exception>
-        public static DataOutputPath CreateForCompositeCooker(
+        public static DataOutputPath ForComposite(
             string dataCookerId,
             string dataOutputId)
         {
@@ -165,8 +196,8 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <summary>
         ///     The complete path to the data output.
         /// </summary>
-        // This will eventually need to be internal only
-        internal string Path => this.CookerPath.CookerPath + "/" + this.OutputId;
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public string Path => this.CookerPath.CookerPath + "/" + this.OutputId;
 
         /// <summary>
         ///     Generates a data cooker path given a source parser Id and a data cooker Id.
@@ -183,12 +214,13 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     The path.
         /// </returns>
-        //internal static string Combine(string sourceParserId, string dataCookerId, string dataOutputId)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string Combine(string sourceParserId, string dataCookerId, string dataOutputId)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputId, nameof(dataOutputId));
 
-        //    return DataCookerPath.Create(sourceParserId, dataCookerId) + "/" + dataOutputId;
-        //}
+            return DataCookerPath.Create(sourceParserId, dataCookerId) + "/" + dataOutputId;
+        }
 
         /// <summary>
         ///     Returns the source parser Id from a data output path.
@@ -199,18 +231,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Source parser Id.
         /// </returns>
-        //public static string GetSourceId(string dataOutputPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string GetSourceId(string dataOutputPath)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-        //    var tokens = SplitPath(dataOutputPath);
-        //    if (tokens != null)
-        //    {
-        //        return tokens[0];
-        //    }
+            var tokens = SplitPath(dataOutputPath);
+            if (tokens != null)
+            {
+                return tokens[0];
+            }
 
-        //    return string.Empty;
-        //}
+            return string.Empty;
+        }
 
         /// <summary>
         ///     Returns the data cooker Id from a data output path.
@@ -221,18 +254,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data cooker Id.
         /// </returns>
-        //public static string GetDataCookerId(string dataOutputPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string GetDataCookerId(string dataOutputPath)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-        //    var tokens = SplitPath(dataOutputPath);
-        //    if (tokens != null)
-        //    {
-        //        return tokens[1];
-        //    }
+            var tokens = SplitPath(dataOutputPath);
+            if (tokens != null)
+            {
+                return tokens[1];
+            }
 
-        //    return string.Empty;
-        //}
+            return string.Empty;
+        }
 
         /// <summary>
         ///     Returns the data output Id from a data output path.
@@ -243,18 +277,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data output Id.
         /// </returns>
-        //public static string GetDataOutputId(string dataOutputPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static string GetDataOutputId(string dataOutputPath)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-        //    var tokens = SplitPath(dataOutputPath);
-        //    if (tokens != null)
-        //    {
-        //        return tokens[2];
-        //    }
+            var tokens = SplitPath(dataOutputPath);
+            if (tokens != null)
+            {
+                return tokens[2];
+            }
 
-        //    return string.Empty;
-        //}
+            return string.Empty;
+        }
 
         /// <summary>
         ///     Returns the data cooker path from a data output path.
@@ -265,18 +300,19 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     Data cooker path.
         /// </returns>
-        //public static DataCookerPath GetDataCookerPath(string dataOutputPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static DataCookerPath GetDataCookerPath(string dataOutputPath)
+        {
+            Guard.NotNullOrWhiteSpace(dataOutputPath, nameof(dataOutputPath));
 
-        //    var tokens = SplitPath(dataOutputPath);
-        //    if (tokens != null)
-        //    {
-        //        return DataCookerPath.ForSource(tokens[0], tokens[1]);
-        //    }
+            var tokens = SplitPath(dataOutputPath);
+            if (tokens != null)
+            {
+                return DataCookerPath.ForSource(tokens[0], tokens[1]);
+            }
 
-        //    throw new ArgumentException("Not a valid data output path.", nameof(dataOutputPath));
-        //}
+            throw new ArgumentException("Not a valid data output path.", nameof(dataOutputPath));
+        }
 
         /// <summary>
         ///     Splits a data output path into individual identifiers.
@@ -296,28 +332,29 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     true if the path was parsed; false otherwise.
         /// </returns>
-        //public static bool TryGetConstituents(
-        //    string dataOutputPath, 
-        //    out string sourceParserId, 
-        //    out string dataCookerId, 
-        //    out string dataOutputId)
-        //{
-        //    sourceParserId = string.Empty;
-        //    dataCookerId = string.Empty;
-        //    dataOutputId = string.Empty;
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static bool TryGetConstituents(
+            string dataOutputPath,
+            out string sourceParserId,
+            out string dataCookerId,
+            out string dataOutputId)
+        {
+            sourceParserId = string.Empty;
+            dataCookerId = string.Empty;
+            dataOutputId = string.Empty;
 
-        //    var tokens = SplitPath(dataOutputPath);
-        //    if (tokens != null)
-        //    {
-        //        sourceParserId = tokens[0];
-        //        dataCookerId = tokens[1];
-        //        dataOutputId = tokens[2];
+            var tokens = SplitPath(dataOutputPath);
+            if (tokens != null)
+            {
+                sourceParserId = tokens[0];
+                dataCookerId = tokens[1];
+                dataOutputId = tokens[2];
 
-        //        return true;
-        //    }
+                return true;
+            }
 
-        //    return false;
-        //}
+            return false;
+        }
 
         /// <summary>
         ///     Determines if a data output path has a proper form.
@@ -328,15 +365,16 @@ namespace Microsoft.Performance.SDK.Extensibility
         /// <returns>
         ///     True for a well formed path, false otherwise.
         /// </returns>
-        //public static bool IsWellFormed(string dataOutputPath)
-        //{
-        //    if (string.IsNullOrWhiteSpace(dataOutputPath))
-        //    {
-        //        return false;
-        //    }
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        public static bool IsWellFormed(string dataOutputPath)
+        {
+            if (string.IsNullOrWhiteSpace(dataOutputPath))
+            {
+                return false;
+            }
 
-        //    return SplitPath(dataOutputPath) != null;
-        //}
+            return SplitPath(dataOutputPath) != null;
+        }
 
         /// <inheritdoc />
         public override string ToString()
@@ -344,15 +382,16 @@ namespace Microsoft.Performance.SDK.Extensibility
             return this.Path;
         }
 
-        //private static string[] SplitPath(string outputPath)
-        //{
-        //    var tokens = outputPath.Split('/');
-        //    if (tokens.Length == 3)
-        //    {
-        //        return tokens;
-        //    }
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1")]
+        private static string[] SplitPath(string outputPath)
+        {
+            var tokens = outputPath.Split('/');
+            if (tokens.Length == 3)
+            {
+                return tokens;
+            }
 
-        //    return null;
-        //}
+            return null;
+        }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/RequiresCompositeCookerAttribute.cs
+++ b/src/Microsoft.Performance.SDK/Processing/RequiresCompositeCookerAttribute.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.SDK.Extensibility;
+using System;
+
+namespace Microsoft.Performance.SDK.Processing
+{
+    /// <summary>
+    /// This attribute is used on a class with static properties that return <see cref="TableDescriptor"/>
+    /// or on individual <see cref="TableDescriptor"/> static properties to indicate that a 
+    /// table described by the <see cref="TableDescriptor"/> requires the identified composite data cooker.
+    /// </summary>
+    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class RequiresCompositeCookerAttribute
+        : RequiresCookerAttribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RequiresCompositeCookerAttribute"/>
+        ///     class.
+        /// </summary>
+        /// <param name="dataCookerId">
+        ///     The ID of the composite data cooker.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="dataCookerId"/> is empty or composed only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="dataCookerId"/> is null.
+        /// </exception>
+        public RequiresCompositeCookerAttribute(string dataCookerId)
+        {
+            this.RequiredDataCookerPath = DataCookerPath.ForComposite(dataCookerId);
+        }
+    }
+}

--- a/src/Microsoft.Performance.SDK/Processing/RequiresCookerAttribute.cs
+++ b/src/Microsoft.Performance.SDK/Processing/RequiresCookerAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Performance.SDK.Extensibility;
-using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using System;
 
 namespace Microsoft.Performance.SDK.Processing
@@ -12,78 +11,77 @@ namespace Microsoft.Performance.SDK.Processing
     /// or on individual <see cref="TableDescriptor"/> static properties to indicate that a 
     /// table described by the <see cref="TableDescriptor"/> requires a data cooker.
     /// </summary>
-    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public class RequiresCookerAttribute
+    public abstract class RequiresCookerAttribute
         : Attribute
     {
         /// <summary>
         /// Constructor that takes a data cooker path.
         /// </summary>
         /// <param name="dataCookerPath">Identifies the required data cooker</param>
-        public RequiresCookerAttribute(string dataCookerPath)
-        {
-            Guard.NotNullOrWhiteSpace(dataCookerPath, nameof(dataCookerPath));
+        //public RequiresCookerAttribute(string dataCookerPath)
+        //{
+        //    Guard.NotNullOrWhiteSpace(dataCookerPath, nameof(dataCookerPath));
 
-            if (!DataCookerPath.IsWellFormed(dataCookerPath))
-            {
-                throw new ArgumentException($"{nameof(dataCookerPath)} is not a valid identifier.");
-            }
+        //    if (!DataCookerPath.IsWellFormed(dataCookerPath))
+        //    {
+        //        throw new ArgumentException($"{nameof(dataCookerPath)} is not a valid identifier.");
+        //    }
 
-            this.RequiredDataCookerPath = new DataCookerPath(
-                DataCookerPath.GetSourceParserId(dataCookerPath), 
-                DataCookerPath.GetDataCookerId(dataCookerPath));
-        }
+        //    this.RequiredDataCookerPath = new DataCookerPath(
+        //        DataCookerPath.GetSourceParserId(dataCookerPath), 
+        //        DataCookerPath.GetDataCookerId(dataCookerPath));
+        //}
 
         /// <summary>
         /// Constructor that takes a data cooker path.
         /// </summary>
         /// <param name="dataCookerPath">Identifies the required data cooker</param>
-        public RequiresCookerAttribute(DataCookerPath dataCookerPath)
-        {
-            this.RequiredDataCookerPath = dataCookerPath;
-        }
+        //public RequiresCookerAttribute(DataCookerPath dataCookerPath)
+        //{
+        //    this.RequiredDataCookerPath = dataCookerPath;
+        //}
 
         /// <summary>
         /// Constructor that takes a type which implements <see cref="IDataCookerDescriptor"/>.
         /// </summary>
         /// <param name="dataCookerType">Identifies the required data cooker</param>
-        public RequiresCookerAttribute(Type dataCookerType)
-        {
-            Guard.NotNull(dataCookerType, nameof(dataCookerType));
+        //public RequiresCookerAttribute(Type dataCookerType)
+        //{
+        //    Guard.NotNull(dataCookerType, nameof(dataCookerType));
 
-            if (!dataCookerType.IsPublicAndInstantiatableOfType(typeof(IDataCookerDescriptor)))
-            {
-                throw new ArgumentException($"Cannot instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
-            }
+        //    if (!dataCookerType.IsPublicAndInstantiatableOfType(typeof(IDataCookerDescriptor)))
+        //    {
+        //        throw new ArgumentException($"Cannot instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
+        //    }
 
-            // There must be an empty, public constructor
-            var constructor = dataCookerType.GetConstructor(Type.EmptyTypes);
-            if (constructor == null || !constructor.IsPublic)
-            {
-                throw new ArgumentException($"Type {dataCookerType} lacks an empty public constructor.");
-            }
+        //    // There must be an empty, public constructor
+        //    var constructor = dataCookerType.GetConstructor(Type.EmptyTypes);
+        //    if (constructor == null || !constructor.IsPublic)
+        //    {
+        //        throw new ArgumentException($"Type {dataCookerType} lacks an empty public constructor.");
+        //    }
 
-            IDataCookerDescriptor cookerDescriptor = null;
-            try
-            {
-                cookerDescriptor = Activator.CreateInstance(dataCookerType) as IDataCookerDescriptor;
-            }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.", e);
-            }
+        //    IDataCookerDescriptor cookerDescriptor = null;
+        //    try
+        //    {
+        //        cookerDescriptor = Activator.CreateInstance(dataCookerType) as IDataCookerDescriptor;
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.", e);
+        //    }
 
-            if (cookerDescriptor == null)
-            {
-                throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
-            }
+        //    if (cookerDescriptor == null)
+        //    {
+        //        throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
+        //    }
 
-            this.RequiredDataCookerPath = new DataCookerPath(cookerDescriptor.Path);
-        }
+        //    this.RequiredDataCookerPath = DataCookerPath.ForComposite(cookerDescriptor.Path);
+        //}
 
         /// <summary>
         /// Path to a required data cooker for the given table.
         /// </summary>
-        public DataCookerPath RequiredDataCookerPath { get; }
+        public DataCookerPath RequiredDataCookerPath { get; protected set; }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/RequiresCookerAttribute.cs
+++ b/src/Microsoft.Performance.SDK/Processing/RequiresCookerAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using System;
 
 namespace Microsoft.Performance.SDK.Processing
@@ -11,73 +12,82 @@ namespace Microsoft.Performance.SDK.Processing
     /// or on individual <see cref="TableDescriptor"/> static properties to indicate that a 
     /// table described by the <see cref="TableDescriptor"/> requires a data cooker.
     /// </summary>
-    public abstract class RequiresCookerAttribute
+    [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use RequiresSourceCooker or RequiresCompositeCooker attributes instead.")]
+    public class RequiresCookerAttribute
         : Attribute
     {
-        /// <summary>
-        /// Constructor that takes a data cooker path.
-        /// </summary>
-        /// <param name="dataCookerPath">Identifies the required data cooker</param>
-        //public RequiresCookerAttribute(string dataCookerPath)
-        //{
-        //    Guard.NotNullOrWhiteSpace(dataCookerPath, nameof(dataCookerPath));
-
-        //    if (!DataCookerPath.IsWellFormed(dataCookerPath))
-        //    {
-        //        throw new ArgumentException($"{nameof(dataCookerPath)} is not a valid identifier.");
-        //    }
-
-        //    this.RequiredDataCookerPath = new DataCookerPath(
-        //        DataCookerPath.GetSourceParserId(dataCookerPath), 
-        //        DataCookerPath.GetDataCookerId(dataCookerPath));
-        //}
+        // Placeholder so deriving classes can call a constructor. When this class is made abstract this can be removed.
+        protected RequiresCookerAttribute()
+        {
+        }
 
         /// <summary>
         /// Constructor that takes a data cooker path.
         /// </summary>
         /// <param name="dataCookerPath">Identifies the required data cooker</param>
-        //public RequiresCookerAttribute(DataCookerPath dataCookerPath)
-        //{
-        //    this.RequiredDataCookerPath = dataCookerPath;
-        //}
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use RequiresSourceCooker or RequiresCompositeCooker attributes instead.")]
+        public RequiresCookerAttribute(string dataCookerPath)
+        {
+            Guard.NotNullOrWhiteSpace(dataCookerPath, nameof(dataCookerPath));
+
+            if (!DataCookerPath.IsWellFormed(dataCookerPath))
+            {
+                throw new ArgumentException($"{nameof(dataCookerPath)} is not a valid identifier.");
+            }
+
+            this.RequiredDataCookerPath = new DataCookerPath(
+                DataCookerPath.GetSourceParserId(dataCookerPath),
+                DataCookerPath.GetDataCookerId(dataCookerPath));
+        }
+
+        /// <summary>
+        /// Constructor that takes a data cooker path.
+        /// </summary>
+        /// <param name="dataCookerPath">Identifies the required data cooker</param>
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use RequiresSourceCooker or RequiresCompositeCooker attributes instead.")]
+        public RequiresCookerAttribute(DataCookerPath dataCookerPath)
+        {
+            this.RequiredDataCookerPath = dataCookerPath;
+        }
 
         /// <summary>
         /// Constructor that takes a type which implements <see cref="IDataCookerDescriptor"/>.
         /// </summary>
         /// <param name="dataCookerType">Identifies the required data cooker</param>
-        //public RequiresCookerAttribute(Type dataCookerType)
-        //{
-        //    Guard.NotNull(dataCookerType, nameof(dataCookerType));
+        [Obsolete("This will be removed by SDK v1.0.0 release candidate 1. Please use RequiresSourceCooker or RequiresCompositeCooker attributes instead.")]
+        public RequiresCookerAttribute(Type dataCookerType)
+        {
+            Guard.NotNull(dataCookerType, nameof(dataCookerType));
 
-        //    if (!dataCookerType.IsPublicAndInstantiatableOfType(typeof(IDataCookerDescriptor)))
-        //    {
-        //        throw new ArgumentException($"Cannot instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
-        //    }
+            if (!dataCookerType.IsPublicAndInstantiatableOfType(typeof(IDataCookerDescriptor)))
+            {
+                throw new ArgumentException($"Cannot instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
+            }
 
-        //    // There must be an empty, public constructor
-        //    var constructor = dataCookerType.GetConstructor(Type.EmptyTypes);
-        //    if (constructor == null || !constructor.IsPublic)
-        //    {
-        //        throw new ArgumentException($"Type {dataCookerType} lacks an empty public constructor.");
-        //    }
+            // There must be an empty, public constructor
+            var constructor = dataCookerType.GetConstructor(Type.EmptyTypes);
+            if (constructor == null || !constructor.IsPublic)
+            {
+                throw new ArgumentException($"Type {dataCookerType} lacks an empty public constructor.");
+            }
 
-        //    IDataCookerDescriptor cookerDescriptor = null;
-        //    try
-        //    {
-        //        cookerDescriptor = Activator.CreateInstance(dataCookerType) as IDataCookerDescriptor;
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.", e);
-        //    }
+            IDataCookerDescriptor cookerDescriptor = null;
+            try
+            {
+                cookerDescriptor = Activator.CreateInstance(dataCookerType) as IDataCookerDescriptor;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.", e);
+            }
 
-        //    if (cookerDescriptor == null)
-        //    {
-        //        throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
-        //    }
+            if (cookerDescriptor == null)
+            {
+                throw new ArgumentException($"Unable to instantiate type {dataCookerType} as an {nameof(IDataCookerDescriptor)}.");
+            }
 
-        //    this.RequiredDataCookerPath = DataCookerPath.ForComposite(cookerDescriptor.Path);
-        //}
+            this.RequiredDataCookerPath = new DataCookerPath(cookerDescriptor.Path);
+        }
 
         /// <summary>
         /// Path to a required data cooker for the given table.

--- a/src/Microsoft.Performance.SDK/Processing/RequiresSourceCookerAttribute.cs
+++ b/src/Microsoft.Performance.SDK/Processing/RequiresSourceCookerAttribute.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.SDK.Extensibility;
+using System;
+
+namespace Microsoft.Performance.SDK.Processing
+{
+    /// <summary>
+    /// This attribute is used on a class with static properties that return <see cref="TableDescriptor"/>
+    /// or on individual <see cref="TableDescriptor"/> static properties to indicate that a 
+    /// table described by the <see cref="TableDescriptor"/> requires the identified source data cooker.
+    /// </summary>
+    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class RequiresSourceCookerAttribute
+        : RequiresCookerAttribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RequiresSourceCookerAttribute"/>
+        ///     class.
+        /// </summary>
+        /// <param name="sourceParserId">
+        ///     The ID of the source parser.
+        /// </param>
+        /// <param name="dataCookerId">
+        ///     The ID of the data cooker.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     One or more of the parameters is empty or composed only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     One or more of the parameters is null.
+        /// </exception>
+        public RequiresSourceCookerAttribute(string sourceParserId, string dataCookerId)
+        {
+            this.RequiredDataCookerPath = DataCookerPath.ForSource(sourceParserId, dataCookerId);
+        }
+    }
+}

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite1Cooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite1Cooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Composites
         : CookedDataReflector,
           ICompositeDataCookerDescriptor
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(nameof(Composite1Cooker));
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForComposite(nameof(Composite1Cooker));
 
         public Composite1Cooker()
             : base(DataCookerPath)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite2Cooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite2Cooker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Composites
         : CookedDataReflector,
           ICompositeDataCookerDescriptor
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(nameof(Composite2Cooker));
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForComposite(nameof(Composite2Cooker));
 
         public Composite2Cooker()
             : base(DataCookerPath)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite3Cooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite3Cooker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Composites
         : CookedDataReflector,
           ICompositeDataCookerDescriptor
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(nameof(Composite3Cooker));
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForComposite(nameof(Composite3Cooker));
 
         public Composite3Cooker()
             : base(DataCookerPath)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite4Cooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Composites/Composite4Cooker.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Composites
         : CookedDataReflector,
           ICompositeDataCookerDescriptor
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(nameof(Composite4Cooker));
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForComposite(nameof(Composite4Cooker));
 
         public Composite4Cooker()
             : base(DataCookerPath)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source1DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source1DataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
     public sealed class Source1DataCooker
         : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForSource(
             nameof(Source123Parser),
             nameof(Source1DataCooker));
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source2DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source2DataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
     public sealed class Source2DataCooker
         : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForSource(
             nameof(Source123Parser),
             nameof(Source2DataCooker));
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source3DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source3DataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
     public sealed class Source3DataCooker
         : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForSource(
             nameof(Source123Parser),
             nameof(Source3DataCooker));
         private ICookedDataRetrieval dependencyRetrieval;

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4DataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source4
     public sealed class Source4DataCooker
         : BaseSourceDataCooker<Source4DataObject, EngineTestContext, int>
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForSource(
             nameof(Source4Parser),
             nameof(Source4DataCooker));
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataCooker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
     public sealed class Source5DataCooker
         : BaseSourceDataCooker<Source5DataObject, EngineTestContext, int>
     {
-        public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
+        public static readonly DataCookerPath DataCookerPath = DataCookerPath.ForSource(
             nameof(Source5Parser),
             nameof(Source5DataCooker));
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/BuildTableTestSuite.json
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/BuildTableTestSuite.json
@@ -1,44 +1,44 @@
 {
-    "description": "test cases for ToolkitEngine.BuildTable",
-    "testCases": [
-      {
-        "id": "0001",
-        "description": "Test table with 1 Source Cooker builds correctly",
-        "tablesToEnable": [
-          "8BE4C87A-CC9A-441A-8173-67414D4C4F68"
-        ],
-        "filePaths": [
-          "TestData/source123_test_data.s123d",
-          "TestData/source4_test_data.s4d",
-          "TestData/source5_test_data.s5d"
-        ],
-        "expectedOutputs": {
-          "8BE4C87A-CC9A-441A-8173-67414D4C4F68": [
-            {
-              "key": 1,
-              "id": 1,
-              "data": "Source4Row1"
-            },
-            {
-              "key": 2,
-              "id": 2,
-              "data": "Source4Row2"
-            },
-            {
-              "key": 3,
-              "id": 3,
-              "data": "Source4Row3"
-            },
-            {
-              "key": 4,
-              "id": 4,
-              "data": "Source4Row4"
-            }
-          ]
-        },
-        "throwingTables": [
-          "BA8B08F5-58F6-4F5D-9C01-BD4801918500"
+  "description": "test cases for ToolkitEngine.BuildTable",
+  "testCases": [
+    {
+      "id": "0001",
+      "description": "Test table with 1 Source Cooker builds correctly",
+      "tablesToEnable": [
+        "8BE4C87A-CC9A-441A-8173-67414D4C4F68"
+      ],
+      "filePaths": [
+        "TestData/source123_test_data.s123d",
+        "TestData/source4_test_data.s4d",
+        "TestData/source5_test_data.s5d"
+      ],
+      "expectedOutputs": {
+        "8BE4C87A-CC9A-441A-8173-67414D4C4F68": [
+          {
+            "key": 1,
+            "id": 1,
+            "data": "Source4Row1"
+          },
+          {
+            "key": 2,
+            "id": 2,
+            "data": "Source4Row2"
+          },
+          {
+            "key": 3,
+            "id": 3,
+            "data": "Source4Row3"
+          },
+          {
+            "key": 4,
+            "id": 4,
+            "data": "Source4Row4"
+          }
         ]
-      }
-    ]
+      },
+      "throwingTables": [
+        "BA8B08F5-58F6-4F5D-9C01-BD4801918500"
+      ]
+    }
+  ]
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/EngineProcessTestDtos.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/EngineProcessTestDtos.cs
@@ -34,8 +34,11 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestData
         [DataMember(Name = "filePaths")]
         public string[] FilePaths { get; set; }
 
-        [DataMember(Name = "cookersToEnable")]
-        public string[] CookersToEnable { get; set; }
+        [DataMember(Name = "sourceCookersToEnable")]
+        public EngineProcessDataCookerPathDto[] SourceCookersToEnable { get; set; }
+
+        [DataMember(Name = "compositeCookersToEnable")]
+        public EngineProcessDataCookerPathDto[] CompositeCookersToEnable { get; set; }
 
         [DataMember(Name = "expectedOutputs")]
         public Dictionary<string, Dictionary<string, string>[]> ExpectedOutputs { get; set; }
@@ -47,5 +50,15 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestData
         {
             return this.Id + ": " + this.Description;
         }
+    }
+
+    [DataContract]
+    public class EngineProcessDataCookerPathDto
+    {
+        [DataMember(Name = "sourceParserId")]
+        public string SourceParserId { get; set; }
+
+        [DataMember(Name = "dataCookerId")]
+        public string DataCookerId { get; set; }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/ProcessTestSuite.json
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestData/ProcessTestSuite.json
@@ -4,8 +4,11 @@
         {
             "id": "0001",
             "description": "Test One Source Cooker processes correctly",
-            "cookersToEnable": [
-                "Source4Parser/Source4DataCooker"
+            "sourceCookersToEnable": [
+                {
+                    "sourceParserId": "Source4Parser",
+                    "dataCookerId": "Source4DataCooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -52,8 +55,11 @@
         {
             "id": "0002",
             "description": "Test A source cooker that depends on other source cookers",
-            "cookersToEnable": [
-                "Source123Parser/Source3DataCooker"
+            "sourceCookersToEnable": [
+                {
+                    "sourceParserId": "Source123Parser",
+                    "dataCookerId": "Source3DataCooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -109,8 +115,10 @@
         {
             "id": "0003",
             "description": "Test one composite cooker that depends on one source cooker.",
-            "cookersToEnable": [
-                "/Composite2Cooker"
+            "compositeCookersToEnable": [
+                {
+                    "dataCookerId": "Composite2Cooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -167,15 +175,17 @@
         {
             "id": "0004",
             "description": "Test one composite cooker that depends on one source cooker and one composite cooker",
-            "comments":[
+            "comments": [
                 "Note that a composite cooker does not have to be enabled.",
                 "A composite cooker will always be available as long as all",
                 "of its dependencies are available. Thus, we get the side effect",
                 "of potentially more than just the cooker that you are interested",
                 "in being available."
             ],
-            "cookersToEnable": [
-                "/Composite3Cooker"
+            "compositeCookersToEnable": [
+                {
+                    "dataCookerId": "Composite3Cooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -260,8 +270,10 @@
             "id": "0005",
             "description": "Test one composite cooker that depends on two composite cookers",
             "debugBreak": true,
-            "cookersToEnable": [
-                "/Composite4Cooker"
+            "compositeCookersToEnable": [
+                {
+                    "dataCookerId": "Composite4Cooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -349,14 +361,18 @@
             },
             "throwingOutputs": []
         },
-
-
         {
             "id": "0006",
             "description": "Test Many Source Cookers process correctly",
-            "cookersToEnable": [
-                "Source123Parser/Source1DataCooker",
-                "Source123Parser/Source2DataCooker"
+            "sourceCookersToEnable": [
+                {
+                    "sourceParserId": "Source123Parser",
+                    "dataCookerId": "Source1DataCooker"
+                },
+                {
+                    "sourceParserId": "Source123Parser",
+                    "dataCookerId": "Source2DataCooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",
@@ -394,11 +410,19 @@
         {
             "id": "0007",
             "description": "Test Enabling Everything",
-            "cookersToEnable": [
-                "/Composite1Cooker",
-                "/Composite2Cooker",
-                "/Composite3Cooker",
-                "/Composite4Cooker",
+            "compositeCookersToEnable": [
+                {
+                    "dataCookerId": "Composite1Cooker"
+                },
+                {
+                    "dataCookerId": "Composite2Cooker"
+                },
+                {
+                    "dataCookerId": "Composite3Cooker"
+                },
+                {
+                    "dataCookerId": "Composite4Cooker"
+                }
             ],
             "filePaths": [
                 "TestData/source123_test_data.s123d",

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -120,7 +121,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         {
             protected override void RunCore()
             {
-                var expectedSourceCookerPath = new DataCookerPath("SourceId", "CookerId");
+                var expectedSourceCookerPath = DataCookerPath.ForSource("SourceId", "CookerId");
 
                 var engine = Engine.Create();
 
@@ -777,7 +778,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void EnableCooker_NotKnown_Throws()
         {
-            var cooker = new DataCookerPath("not-there-id");
+            var cooker = DataCookerPath.ForComposite("not-there-id");
 
             var e = Assert.ThrowsException<CookerNotFoundException>(() => this.Sut.EnableCooker(cooker));
             Assert.AreEqual(cooker, e.DataCookerPath);
@@ -824,7 +825,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void TryEnableCooker_NotKnown_False()
         {
-            var cooker = new DataCookerPath("not-there-id");
+            var cooker = DataCookerPath.ForComposite("not-there-id");
 
             Assert.IsFalse(this.Sut.TryEnableCooker(cooker));
         }
@@ -1190,9 +1191,15 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 System.Diagnostics.Debugger.Break();
             }
 
-            foreach (var cooker in testCase.CookersToEnable)
+            foreach (var cooker in testCase.SourceCookersToEnable)
             {
-                var cookerPath = DataCookerPath.Parse(cooker);
+                var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
+                Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+            }
+
+            foreach (var cooker in testCase.CompositeCookersToEnable)
+            {
+                var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
                 Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
             }
 
@@ -1205,9 +1212,10 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             foreach (var expectedData in testCase.ExpectedOutputs)
             {
-                var dataOutputPathRaw = expectedData.Key;
+                string dataOutputPathRaw = expectedData.Key;
                 var expectedDataPoints = expectedData.Value;
-                var dataOutputPath = DataOutputPath.Create(dataOutputPathRaw);
+
+                DataOutputPath dataOutputPath = Parse(dataOutputPathRaw); 
 
                 Assert.IsTrue(
                     results.TryQueryOutput(dataOutputPath, out object data), "Output for {0} not found.", dataOutputPathRaw);
@@ -1260,7 +1268,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             foreach (var dataOutputPathRaw in testCase.ThrowingOutputs)
             {
-                var dataOutputPath = DataOutputPath.Create(dataOutputPathRaw);
+                DataOutputPath dataOutputPath = Parse(dataOutputPathRaw);
                 Assert.IsFalse(
                     results.TryQueryOutput(dataOutputPath, out var _),
                     "Output should not have been available: {0}",
@@ -1303,10 +1311,16 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                     Versioning = new FakeVersionChecker(),
                 });
 
-            foreach (var cooker in testCase.CookersToEnable)
+            foreach (var cooker in testCase.SourceCookersToEnable)
             {
-                var cookerPath = DataCookerPath.Parse(cooker);
-                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
+                Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+            }
+
+            foreach (var cooker in testCase.CompositeCookersToEnable)
+            {
+                var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
+                Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
             }
 
             foreach (var file in testCase.FilePaths)
@@ -1320,7 +1334,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             {
                 var dataOutputPathRaw = expectedData.Key;
                 var expectedDataPoints = expectedData.Value;
-                var dataOutputPath = DataOutputPath.Create(dataOutputPathRaw);
+                DataOutputPath dataOutputPath = Parse(dataOutputPathRaw);
 
                 Assert.IsTrue(
                     results.TryQueryOutput(dataOutputPath, out object data), "Output for {0} not found.", dataOutputPathRaw);
@@ -1373,7 +1387,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             foreach (var dataOutputPathRaw in testCase.ThrowingOutputs)
             {
-                var dataOutputPath = DataOutputPath.Create(dataOutputPathRaw);
+                DataOutputPath dataOutputPath = Parse(dataOutputPathRaw);
                 Assert.IsFalse(
                     results.TryQueryOutput(dataOutputPath, out var _),
                     "Output should not have been available: {0}",
@@ -1505,6 +1519,28 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                     Extension,
                     Path.GetExtension(dataSource.Uri.LocalPath));
             }
+        }
+
+        public static DataOutputPath Parse(string dataCookerOutputPath)
+        {
+            var split = dataCookerOutputPath.Split('/');
+            Debug.Assert(split.Length == 3);
+
+            string parserId = split[0];
+            string cookerId = split[1];
+            string outputId = split[2];
+
+            DataCookerPath dataCookerPath;
+            if (string.IsNullOrWhiteSpace(parserId))
+            {
+                dataCookerPath = DataCookerPath.ForComposite(cookerId);
+            }
+            else
+            {
+                dataCookerPath = DataCookerPath.ForSource(parserId, cookerId);
+            }
+
+            return new DataOutputPath(dataCookerPath, outputId);
         }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -1191,13 +1191,13 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 System.Diagnostics.Debugger.Break();
             }
 
-            foreach (var cooker in testCase.SourceCookersToEnable)
+            foreach (var cooker in testCase.SourceCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
                 Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
             }
 
-            foreach (var cooker in testCase.CompositeCookersToEnable)
+            foreach (var cooker in testCase.CompositeCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
                 Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
@@ -1311,16 +1311,16 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                     Versioning = new FakeVersionChecker(),
                 });
 
-            foreach (var cooker in testCase.SourceCookersToEnable)
+            foreach (var cooker in testCase.SourceCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
-                Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
             }
 
-            foreach (var cooker in testCase.CompositeCookersToEnable)
+            foreach (var cooker in testCase.CompositeCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
-                Assert.IsTrue(this.Sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
             }
 
             foreach (var file in testCase.FilePaths)

--- a/src/Microsoft.Performance.Toolkit.Engine/EngineException.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/EngineException.cs
@@ -83,12 +83,6 @@ namespace Microsoft.Performance.Toolkit.Engine
             this.DataCookerPath = dataCookerPath;
         }
 
-        /// <inheritdoc />
-        protected CookerNotFoundException(SerializationInfo info, StreamingContext context)
-        {
-            this.DataCookerPath = new DataCookerPath(info.GetString(nameof(DataCookerPath)));
-        }
-
         /// <summary>
         ///     Gets the requested cooker path that is the cause of this error.
         /// </summary>
@@ -98,7 +92,7 @@ namespace Microsoft.Performance.Toolkit.Engine
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue(nameof(DataCookerPath), this.DataCookerPath.CookerPath);
+            info.AddValue(nameof(DataCookerPath), this.DataCookerPath.ToString());
         }
 
         /// <inheritdoc />
@@ -153,14 +147,6 @@ namespace Microsoft.Performance.Toolkit.Engine
             : base($"The requested data '{dataOutputPath}' was not found", inner)
         {
             this.DataOutputPath = dataOutputPath;
-        }
-
-        /// <inheritdoc />
-        protected DataOutputNotFoundException(SerializationInfo info, StreamingContext context)
-        {
-            this.DataOutputPath = new DataOutputPath(
-                new DataCookerPath(info.GetString(nameof(CookerPath))),
-                info.GetString(nameof(OutputId)));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR simplifies the API of `DataCookerPath` and `DataOutputPath`. It marks any methods, properties, or constructors exposing the `"[sourceParserId]\[cookerId]\[outputName]"` strings we use as internal representation as obsolete. Additionally, it exposes new methods on these classes:

- `DataCookerPath.ForComposite`
- `DataCookerPath.ForSource`
- `DataOutputPath.ForComposite`
- `DataOutputPath.ForSource`

which users should call instead.

Most files touched in this PR are for updating tests to use the new API.

This PR also updates the migration docs.