### PR TITLE
Add build samples step to PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,5 @@ jobs:
       run: dotnet build "${{ github.workspace }}/src/SDK.sln" --no-restore -c Release
     - name: Run tests
       run: dotnet test "${{ github.workspace }}/src/SDK.sln" -c Release --filter "TestCategory~Unit|TestCategory~Integration|TestCategory~Functional" --no-build --verbosity normal
+    - name: Build samples
+      run: ls "${{ github.workspace }}/samples/**/*.sln" | % { dotnet build $_.FullName -c Release }


### PR DESCRIPTION
This will make sure we don't break our samples when we update them for new SDK releases.