### PR TITLE
Rename abstract classes that do not need Base in their name

### DIFF
--- a/documentation/Migration/Overview.md
+++ b/documentation/Migration/Overview.md
@@ -3,3 +3,4 @@
 These documents outline how to update your code due to breaking changes between major versions.
 
 - [Updating to 0.109.*](./Update-0.109.md)
+- [Updating to 1.0.0-RC1](./Update-1.0.0-rc1.md)

--- a/documentation/Migration/Update-1.0.0-rc1.md
+++ b/documentation/Migration/Update-1.0.0-rc1.md
@@ -1,0 +1,15 @@
+# Abstract
+
+This document outlines major code changes that might be needed when updating from 
+Preview Version 0.109.\* to 1.0.0 Relase Candidate 1\*.
+# Breaking Changes
+
+There are a number of breaking changes in this version; please see the release notes for a list of these changes.
+
+## Renamed Classes
+The following references must be changed:
+- `BaseSourceDataCooker` -> `SourceDataCooker`
+- `SourceParserBase` -> `SourceParser`
+- `BaseDataColumn` -> `DataColumn`
+- `CustomDataProcessorBase` -> `CustomDataProcessor`
+- `CustomDataProcessorBaseWithSourceParser` -> `CustomDataProcessorWithSourceParser`

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookers/ValidSourceDataCooker.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookers/ValidSourceDataCooker.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Runtime.Tests.Extensibility.DataTypes;
 namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.DataCookers
 {
     public class ValidSourceDataCooker
-        : BaseSourceDataCooker<TestDataElement, TestDataContext, int>
+        : SourceDataCooker<TestDataElement, TestDataContext, int>
     {
         public ValidSourceDataCooker() 
             : base("SourceId", "CookerId")

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 {
     internal class InternalSourceDataCooker
-        : BaseSourceDataCooker<TestDataElement, TestDataContext, int>
+        : SourceDataCooker<TestDataElement, TestDataContext, int>
     {
         public InternalSourceDataCooker()
             : base(new DataCookerPath("SourceId", "CookerId"))
@@ -42,7 +42,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
     }
 
     public class NoEmptyPublicConstructorSourceDataCooker
-        : BaseSourceDataCooker<TestDataElement, TestDataContext, int>
+        : SourceDataCooker<TestDataElement, TestDataContext, int>
     {
         public NoEmptyPublicConstructorSourceDataCooker(string sourceId, string cookerId)
             : base(sourceId, cookerId)
@@ -63,7 +63,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
     }
 
     public class NoPublicConstructorSourceDataCooker
-        : BaseSourceDataCooker<TestDataElement, TestDataContext, int>
+        : SourceDataCooker<TestDataElement, TestDataContext, int>
     {
         internal NoPublicConstructorSourceDataCooker()
             : base("SourceId", "CookerId")

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestCustomDataProcessor.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TestClasses/TestCustomDataProcessor.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility.TestClasses
 {
     public class TestCustomDataProcessor
-        : CustomDataProcessorBaseWithSourceParser<TestRecord, TestParserContext, int>
+        : CustomDataProcessorWithSourceParser<TestRecord, TestParserContext, int>
     {
         internal static TestCustomDataProcessor CreateTestCustomDataProcessor(
             string sourceParserId = "TestSourceParser")

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/MetadataTableBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/MetadataTableBuilderTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddColumnAdds()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
                 new ColumnMetadata(Guid.NewGuid(), "name"),
                 new UIHints { Width = 100, },
                 Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -118,7 +118,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddColumnReturnsBuilder()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
                new ColumnMetadata(Guid.NewGuid(), "name"),
                new UIHints { Width = 100, },
                Projection.CreateUsingFuncAdaptor(i => "test"));

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddColumnAdds()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
                 new ColumnMetadata(Guid.NewGuid(), "name"),
                 new UIHints { Width = 200, },
                 Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -79,7 +79,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddColumnReturnsBuilder()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
                new ColumnMetadata(Guid.NewGuid(), "name"),
                new UIHints { Width = 200, },
                Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -91,7 +91,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnOldNullThrows()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -104,7 +104,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnNewNullThrows()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -117,7 +117,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnWithSelfNoOps()
         {
-            var column = new BaseDataColumn<string>(
+            var column = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -133,12 +133,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnThatExistsReplaces()
         {
-            var columnOld = new BaseDataColumn<string>(
+            var columnOld = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
 
-            var columnNew = new BaseDataColumn<string>(
+            var columnNew = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -154,12 +154,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnThatDoesNotExistAdds()
         {
-            var columnNotThere = new BaseDataColumn<string>(
+            var columnNotThere = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
 
-            var columnNew = new BaseDataColumn<string>(
+            var columnNew = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
@@ -174,12 +174,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ReplaceColumnReturnsBuilder()
         {
-            var columnOld = new BaseDataColumn<string>(
+            var columnOld = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
 
-            var columnNew = new BaseDataColumn<string>(
+            var columnNew = new DataColumn<string>(
               new ColumnMetadata(Guid.NewGuid(), "name"),
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/CompositeDataCookerReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/CompositeDataCookerReference.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCoo
     ///     Represents a reference to a composite data cooker.
     /// </summary>
     internal sealed class CompositeDataCookerReference
-        : BaseDataCookerReference<CompositeDataCookerReference>,
+        : DataCookerReference<CompositeDataCookerReference>,
           ICompositeDataCookerReference
     {
         /// <summary>

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/DataCookerReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/DataCookerReference.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCoo
     /// <typeparam name="TDerived">
     ///     The class deriving from this type.
     /// </typeparam>
-    internal abstract class BaseDataCookerReference<TDerived>
+    internal abstract class DataCookerReference<TDerived>
         : DataExtensionReference<TDerived>
-          where TDerived : BaseDataCookerReference<TDerived>
+          where TDerived : DataCookerReference<TDerived>
     {
         private DataCookerPath path;
         private string description;
@@ -26,21 +26,21 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCoo
         private bool isDisposed;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseDataCookerReference{TDerived}"/>
+        ///     Initializes a new instance of the <see cref="DataCookerReference{TDerived}"/>
         ///     class for the given <see cref="Type"/>.
         /// </summary>
         /// <param name="type">
         ///     The <see cref="Type"/> of cooker referenced by this instance.
         ///     It is expected that <see cref="Type"/>is a calid cooker <see cref="Type"/>.
         /// </param>
-        protected BaseDataCookerReference(Type type)
+        protected DataCookerReference(Type type)
             : base(type)
         {
             this.isDisposed = false;
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseDataCookerReference{TDerived}"/>
+        ///     Initializes a new instance of the <see cref="DataCookerReference{TDerived}"/>
         ///     class as a copy of the given reference.
         /// </summary>
         /// <param name="other">
@@ -49,7 +49,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCoo
         /// <exception cref="System.ObjectDisposedException">
         ///     <paramref name="other"/> is disposed.
         /// </exception>
-        protected BaseDataCookerReference(DataExtensionReference<TDerived> other)
+        protected DataCookerReference(DataExtensionReference<TDerived> other)
             : base(other)
         {
         }

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/SourceDataCookerReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/DataCookers/SourceDataCookerReference.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCoo
     ///     This class provides a way to create an instance of a particular data extension.
     /// </summary>
     internal sealed class SourceDataCookerReference
-        : BaseDataCookerReference<SourceDataCookerReference>,
+        : DataCookerReference<SourceDataCookerReference>,
           ISourceDataCookerReference
     {
         private List<IDataCookerDescriptor> instances = new List<IDataCookerDescriptor>();

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/SourceProcessingSession.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/SourceProcessingSession.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility
     ///     Data element key type.
     /// </typeparam>
     internal class SourceProcessingSession<T, TContext, TKey>
-        : BaseSourceProcessingSession<T, TContext, TKey>
+        : SourceProcessingSessionBase<T, TContext, TKey>
         where T : IKeyedDataType<TKey>
     {
         private static readonly int InvalidPass = -1;

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/SourceProcessingSessionBase.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/SourceProcessingSessionBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility
     /// <typeparam name="TKey">
     ///     Data element key type.
     /// </typeparam>
-    internal abstract class BaseSourceProcessingSession<T, TContext, TKey>
+    internal abstract class SourceProcessingSessionBase<T, TContext, TKey>
         : ISourceProcessingSession<T, TContext, TKey>
           where T : IKeyedDataType<TKey>
     {
@@ -45,7 +45,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility
 
         private readonly IEqualityComparer<TKey> keyEqualityComparer;
 
-        protected BaseSourceProcessingSession(
+        protected SourceProcessingSessionBase(
             ISourceParser<T, TContext, TKey> sourceParser, 
             IEqualityComparer<TKey> comparer)
         {

--- a/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorTests.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Performance.SDK.Tests
 {
     [TestClass]
-    public class CustomDataProcessorBaseTests
+    public class CustomDataProcessorTests
     {
         private ProcessorOptions Options { get; set; }
         private IApplicationEnvironment ApplicationEnvironment { get; set; }
@@ -135,7 +135,7 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         private sealed class MockProcessor
-            : CustomDataProcessorBase
+            : CustomDataProcessor
         {
             public MockProcessor(
                 ProcessorOptions options,

--- a/src/Microsoft.Performance.SDK/Extensibility/DataCooking/SourceDataCooking/SourceDataCooker.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/DataCooking/SourceDataCooking/SourceDataCooker.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking
     /// <typeparam name="TKey">
     ///     Identifier for the <see cref="Type"/> of data element.
     /// </typeparam>
-    public abstract class BaseSourceDataCooker<T, TContext, TKey>
+    public abstract class SourceDataCooker<T, TContext, TKey>
         : CookedDataReflector,
           ISourceDataCooker<T, TContext, TKey>
         where T : IKeyedDataType<TKey>
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseSourceDataCooker{T, TContext, TKey}"/>
+        ///     Initializes a new instance of the <see cref="SourceDataCooker{T, TContext, TKey}"/>
         ///     class for the given cooker.
         /// </summary>
         /// <param name="sourceId">
@@ -35,20 +35,20 @@ namespace Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking
         /// <param name="cookerId">
         ///     This cooker's ID.
         /// </param>
-        protected BaseSourceDataCooker(string sourceId, string cookerId)
+        protected SourceDataCooker(string sourceId, string cookerId)
             : this(new DataCookerPath(sourceId, cookerId))
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseSourceDataCooker{T, TContext, TKey}"/>
+        ///     Initializes a new instance of the <see cref="SourceDataCooker{T, TContext, TKey}"/>
         ///     class for the given cooker.
         /// </summary>
         /// </param>
         /// <param name="dataCookerPath">
         ///     This cooker's path.
         /// </param>
-        protected BaseSourceDataCooker(DataCookerPath dataCookerPath)
+        protected SourceDataCooker(DataCookerPath dataCookerPath)
             : base(dataCookerPath)
         {
             this.Path = dataCookerPath;

--- a/src/Microsoft.Performance.SDK/Extensibility/SourceParsing/SourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Extensibility/SourceParsing/SourceParser.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Performance.SDK.Extensibility.SourceParsing
     /// <typeparam name="TKey">
     ///     Type that will be used to key data from the source for distribution.
     /// </typeparam>
-    public abstract class SourceParserBase<T, TContext, TKey>
+    public abstract class SourceParser<T, TContext, TKey>
         : ISourceParser<T, TContext, TKey> 
           where T : IKeyedDataType<TKey>
     {

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessor.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Performance.SDK.Processing
     ///     simplifies some of the management of tables and processing.
     ///     This class is meant to be used in conjunction with <see cref="CustomDataSourceBase"/>.
     /// </summary>
-    public abstract class CustomDataProcessorBase
+    public abstract class CustomDataProcessor
         : ICustomDataProcessor,
           IDataDerivedTables
     {
@@ -26,10 +26,10 @@ namespace Microsoft.Performance.SDK.Processing
             dataDerivedTables = new Dictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>>();
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CustomDataProcessorBase"/>
+        ///     Initializes a new instance of the <see cref="CustomDataProcessor"/>
         ///     class.
         /// </summary>
-        protected CustomDataProcessorBase(
+        protected CustomDataProcessor(
             ProcessorOptions options,
             IApplicationEnvironment applicationEnvironment,
             IProcessorEnvironment processorEnvironment,

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Performance.SDK.Processing
     /// <typeparam name="T">Type of data from the source to be processed</typeparam>
     /// <typeparam name="TContext">Type that contains context about the data from the source</typeparam>
     /// <typeparam name="TKey">Type that will be used to identify data from the source that is relevant to this extension</typeparam>
-    public abstract class CustomDataProcessorBaseWithSourceParser<T, TContext, TKey>
-        : CustomDataProcessorBase,
+    public abstract class CustomDataProcessorWithSourceParser<T, TContext, TKey>
+        : CustomDataProcessor,
           ICustomDataProcessorWithSourceParser<T, TContext, TKey> 
           where T : IKeyedDataType<TKey>
     {
@@ -38,7 +38,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// <param name="processorEnvironment">Processor environment</param>
         /// <param name="allTablesMapping">Maps table descriptors to possible build actions</param>
         /// <param name="metadataTables">Metadata tables</param>
-        protected CustomDataProcessorBaseWithSourceParser(
+        protected CustomDataProcessorWithSourceParser(
             ISourceParser<T, TContext, TKey> sourceParser,
             ProcessorOptions options,
             IApplicationEnvironment applicationEnvironment,
@@ -65,7 +65,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// data processor as appropriate.
         /// </summary>
         /// <param name="other">An existing custom data processor</param>
-        protected CustomDataProcessorBaseWithSourceParser(CustomDataProcessorBaseWithSourceParser<T, TContext, TKey> other)
+        protected CustomDataProcessorWithSourceParser(CustomDataProcessorWithSourceParser<T, TContext, TKey> other)
             : this(
                   other.SourceParser,
                   other.Options,
@@ -166,7 +166,7 @@ namespace Microsoft.Performance.SDK.Processing
             return dataCooker.QueryOutput(dataOutputPath);
         }
 
-        /// <inheritdoc cref="CustomDataProcessorBase"/>
+        /// <inheritdoc cref="CustomDataProcessor"/>
         /// <summary>
         /// Adds to the base class functionality, validating that the <see cref="SourceParser"/> and
         /// <see cref="SourceProcessingSession"/> have been initialized, and then uses the <see cref="SourceProcessingSession"/>

--- a/src/Microsoft.Performance.SDK/Processing/DataColumn.cs
+++ b/src/Microsoft.Performance.SDK/Processing/DataColumn.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Performance.SDK.Processing
     /// <typeparam name="T">
     ///     The <see cref="Type"/> of data projected by this column.
     /// </typeparam>
-    public class BaseDataColumn<T>
+    public class DataColumn<T>
         : IDataColumn<T>
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseDataColumn{T}" />
+        ///     Initializes a new instance of the <see cref="DataColumn{T}" />
         ///     class.
         /// </summary>
         /// <param name="metadata">
@@ -34,7 +34,7 @@ namespace Microsoft.Performance.SDK.Processing
         ///     - or -
         ///     <paramref name="projection"/> is <c>null</c>.
         /// </exception>
-        public BaseDataColumn(
+        public DataColumn(
             ColumnMetadata metadata,
             UIHints displayHints,
             IProjection<int, T> projection)
@@ -43,7 +43,7 @@ namespace Microsoft.Performance.SDK.Processing
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseDataColumn{T}" />
+        ///     Initializes a new instance of the <see cref="DataColumn{T}" />
         ///     class.
         /// </summary>
         /// <param name="configuration">
@@ -57,7 +57,7 @@ namespace Microsoft.Performance.SDK.Processing
         ///     - or -
         ///     <paramref name="projection"/> is <c>null</c>.
         /// </exception>
-        public BaseDataColumn(
+        public DataColumn(
             ColumnConfiguration configuration,
             IProjection<int, T> projection)
         {

--- a/src/Microsoft.Performance.SDK/Processing/HeirarchicalDataColumn.cs
+++ b/src/Microsoft.Performance.SDK/Processing/HeirarchicalDataColumn.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Performance.SDK.Processing
     ///     The <see cref="Type"/> of data exposed by this column.
     /// </typeparam>
     public class HierarchicalDataColumn<T>
-        : BaseDataColumn<T>,
+        : DataColumn<T>,
           IHierarchicalDataColumn<T>
     {
         /// <summary>

--- a/src/Microsoft.Performance.SDK/Processing/TableBuilderExtensions.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableBuilderExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Performance.SDK.Processing
             Guard.NotNull(self, nameof(self));
             Guard.NotNull(projection, nameof(projection));
 
-            return self.AddColumn(new BaseDataColumn<T>(column, projection));
+            return self.AddColumn(new DataColumn<T>(column, projection));
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Microsoft.Performance.SDK.Processing
             Guard.NotNull(old, nameof(old));
             Guard.NotNull(newProjection, nameof(newProjection));
 
-            var newColumn = new BaseDataColumn<T>(old.Configuration, newProjection);
+            var newColumn = new DataColumn<T>(old.Configuration, newProjection);
             return self.ReplaceColumn(old, newColumn);
         }
     }

--- a/src/Microsoft.Performance.Testing/Fixture.cs
+++ b/src/Microsoft.Performance.Testing/Fixture.cs
@@ -8,13 +8,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Performance.Testing
 {
-    public abstract class BaseFixture
+    public abstract class Fixture
     {
         private readonly List<DirectoryInfo> temporaryDirectories;
 
         public TestContext TestContext { get; set; }
 
-        protected BaseFixture()
+        protected Fixture()
         {
             this.temporaryDirectories = new List<DirectoryInfo>();
         }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Parser.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Parser.cs
@@ -13,7 +13,7 @@ using Microsoft.Performance.SDK.Runtime;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 {
     public sealed class Source123Parser
-        : SourceParserBase<Source123DataObject, EngineTestContext, int>
+        : SourceParser<Source123DataObject, EngineTestContext, int>
     {
         private readonly List<string> filePaths;
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Processor.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123Processor.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 {
     public sealed class Source123Processor
-        : CustomDataProcessorBaseWithSourceParser<Source123DataObject, EngineTestContext, int>
+        : CustomDataProcessorWithSourceParser<Source123DataObject, EngineTestContext, int>
     {
         public Source123Processor(
             ISourceParser<Source123DataObject, EngineTestContext, int> sourceParser, 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source1DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source1DataCooker.cs
@@ -11,7 +11,7 @@ using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 {
     public sealed class Source1DataCooker
-        : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
+        : SourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
         public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
             nameof(Source123Parser),

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source2DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source2DataCooker.cs
@@ -11,7 +11,7 @@ using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 {
     public sealed class Source2DataCooker
-        : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
+        : SourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
         public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
             nameof(Source123Parser),

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source3DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source3DataCooker.cs
@@ -11,7 +11,7 @@ using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 {
     public sealed class Source3DataCooker
-        : BaseSourceDataCooker<Source123DataObject, EngineTestContext, int>
+        : SourceDataCooker<Source123DataObject, EngineTestContext, int>
     {
         public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
             nameof(Source123Parser),

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4DataCooker.cs
@@ -11,7 +11,7 @@ using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source4
 {
     public sealed class Source4DataCooker
-        : BaseSourceDataCooker<Source4DataObject, EngineTestContext, int>
+        : SourceDataCooker<Source4DataObject, EngineTestContext, int>
     {
         public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
             nameof(Source4Parser),

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4Parser.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4Parser.cs
@@ -13,7 +13,7 @@ using Microsoft.Performance.SDK.Runtime;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source4
 {
     public sealed class Source4Parser
-        : SourceParserBase<Source4DataObject, EngineTestContext, int>
+        : SourceParser<Source4DataObject, EngineTestContext, int>
     {
         private readonly List<string> filePaths;
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4Processor.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source4/Source4Processor.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source4
 {
     public sealed class Source4Processor
-        : CustomDataProcessorBaseWithSourceParser<Source4DataObject, EngineTestContext, int>
+        : CustomDataProcessorWithSourceParser<Source4DataObject, EngineTestContext, int>
     {
         public Source4Processor(
             ISourceParser<Source4DataObject, EngineTestContext, int> sourceParser, 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataCooker.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataCooker.cs
@@ -11,7 +11,7 @@ using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
 {
     public sealed class Source5DataCooker
-        : BaseSourceDataCooker<Source5DataObject, EngineTestContext, int>
+        : SourceDataCooker<Source5DataObject, EngineTestContext, int>
     {
         public static readonly DataCookerPath DataCookerPath = new DataCookerPath(
             nameof(Source5Parser),

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5Parser.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5Parser.cs
@@ -13,7 +13,7 @@ using Microsoft.Performance.SDK.Runtime;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
 {
     public sealed class Source5Parser
-        : SourceParserBase<Source5DataObject, EngineTestContext, int>
+        : SourceParser<Source5DataObject, EngineTestContext, int>
     {
         private readonly List<string> filePaths;
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5Processor.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5Processor.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
 {
     public sealed class Source5Processor
-        : CustomDataProcessorBaseWithSourceParser<Source5DataObject, EngineTestContext, int>
+        : CustomDataProcessorWithSourceParser<Source5DataObject, EngineTestContext, int>
     {
         public Source5Processor(
             ISourceParser<Source5DataObject, EngineTestContext, int> sourceParser, 


### PR DESCRIPTION
This PR includes the following renames:
- `SDK.Extensibility.DataCooking.SourceDataCooking.BaseSourceDataCooker` -> `SourceDataCooker`
- `SDK.Extensibility.SourceParsing.SourceParserBase` -> `SourceParser`
- `SDK.Processing.BaseDataColumn` -> `DataColumn`
- `SDK.Processing.CustomDataProcessorBase` -> `CustomDataProcessor`
- `SDK.Processing.CustomDataProcessorBaseWithSourceParser` -> `CustomDataProcessorWithSourceParser`
- `SDK.Runtime.Extensibility.BaseSourceProcessingSession` -> `SourceProcessingSessionBase`
- `SDK.Runtime.Extensibility.DataExtensions.DataCookers.BaseDataCookerReference` -> `DataCookerReference`
- `Testing.BaseFixture` -> `Fixture`

A new document for migrating to SDK v1.0.0 release candidate 1 is created, listing any changes above for classes **not** inside the `SDK.Runtime` or `Testing` namespace.