### PR TITLE
Add HasTableRowDetailsGenerator property to TableBuilder

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/TableBuilder.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/TableBuilder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Performance.SDK.Runtime
         private readonly List<TableConfiguration> builtInTableConfigurations;
         private readonly List<TableCommand> commands;
         private readonly IReadOnlyList<TableCommand> commandsRO;
-       
+
         // Maps a row to a collection of row detail entry
         private Func<int, IEnumerable<TableRowDetailEntry>> tableDetailsGenerator;
 
@@ -71,6 +71,14 @@ namespace Microsoft.Performance.SDK.Runtime
 
         /// <inheritdoc />
         public TableDetailsGeneratorCallback TableDetailsBuilder => this.DefaultTableDetailsBuilder;
+
+        public bool HasTableRowDetailsGenerator
+        {
+            get
+            {
+                return this.tableDetailsGenerator != null;
+            }
+        }
 
         /// <inheritdoc />
         public ITableBuilder AddTableCommand(string name, TableCommandCallback callback)


### PR DESCRIPTION
Currently consumers of the runtime have no way of knowing if a table can potentially have row details without explicitly calling the `TableDetailsBuilder`. Adding a `HasTableRowDetailsGenerator` can let consumers know if it's at least possible for the `TableDetailsBuilder` to return information (i.e. if they should even bother calling it).