### PR TITLE
Make ApplicationEnvironment's serializer non-customizable

### DIFF
--- a/documentation/Migration/Update-1.0.0-rc1.md
+++ b/documentation/Migration/Update-1.0.0-rc1.md
@@ -31,6 +31,7 @@ The following references must be changed:
 - `ViewportRelativePercent` -> `VisibleDomainRelativePercent`
 - `Projection.ClipTimeToViewport` -> `Projection.ClipTimeToVisibleDomain`
 - `Projection.AggregateInViewport` -> `Projection.AggregateInVisibleDomain`
+- `ISerializer` -> `ITableConfigurationsSerializer`
 
 ## Obsolete Members
 

--- a/src/Microsoft.Performance.SDK.Runtime/ApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/ApplicationEnvironment.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Extensibility.SourceParsing;
 using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Runtime.DTO;
 using Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCookers;
-using System;
 
 namespace Microsoft.Performance.SDK.Runtime
 {
@@ -27,9 +28,6 @@ namespace Microsoft.Performance.SDK.Runtime
         /// <param name="tableDataSynchronizer">
         ///     Used to synchronize table data changes with the user interface.
         /// </param>
-        /// <param name="serializer">
-        ///     Used to serialize/deserialize data (e.g. table configurations).
-        /// </param>
         /// <param name="dataCookers">
         ///     A repository of source data cookers.
         /// </param>
@@ -43,7 +41,6 @@ namespace Microsoft.Performance.SDK.Runtime
             string applicationName,
             string runtimeName,
             ITableDataSynchronization tableDataSynchronizer,
-            ISerializer serializer,
             ISourceDataCookerRepository dataCookers,
             ISourceSessionFactory sourceSessionFactory,
             IMessageBox messageBox)
@@ -51,7 +48,6 @@ namespace Microsoft.Performance.SDK.Runtime
             // application and runtime names may be null
 
             Guard.NotNull(tableDataSynchronizer, nameof(tableDataSynchronizer));
-            Guard.NotNull(serializer, nameof(serializer));
             Guard.NotNull(dataCookers, nameof(dataCookers));
             Guard.NotNull(sourceSessionFactory, nameof(sourceSessionFactory));
             Guard.NotNull(messageBox, nameof(messageBox));
@@ -64,7 +60,7 @@ namespace Microsoft.Performance.SDK.Runtime
             // _CDS_
             // todo:when tests are ready, consider checking that columnController is not null
 
-            this.Serializer = serializer;
+            this.Serializer = new TableConfigurationsSerializer();
             this.TableDataSynchronizer = tableDataSynchronizer;
             this.SourceDataCookerFactoryRetrieval = dataCookers;
             this.SourceSessionFactory = sourceSessionFactory;
@@ -80,7 +76,7 @@ namespace Microsoft.Performance.SDK.Runtime
         public bool IsInteractive { get; set; }
 
         /// <inheritdoc />
-        public ISerializer Serializer { get; }
+        public ITableConfigurationsSerializer Serializer { get; }
 
         /// <inheritdoc />
         public ITableDataSynchronization TableDataSynchronizer { get; }

--- a/src/Microsoft.Performance.SDK.Runtime/DTO/TableConfigurationsSerializer.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/DTO/TableConfigurationsSerializer.cs
@@ -13,14 +13,14 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.SDK.Runtime.DTO
 {
     /// <summary>
-    ///     Used to de/serialize table configurations from/to a stream.
+    ///     Used to de/serialize <see cref="TableConfigurations"/> instances from/to a stream.
     /// </summary>
     public class TableConfigurationsSerializer
-        : ISerializer
+        : ITableConfigurationsSerializer
     {
         private const string indentChars = "    ";
 
-        private static Lazy<(double Version, Type PrebuiltConfigType)[]> versionToTypeLazy 
+        private static Lazy<(double Version, Type PrebuiltConfigType)[]> versionToTypeLazy
             = new Lazy<(double Version, Type PrebuiltConfigType)[]>(() =>
             {
                 var assembly = typeof(PrebuiltConfigurationsBase).Assembly;

--- a/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/Tables/TableExtensionReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Extensibility/DataExtensions/Tables/TableExtensionReference.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Tables
           ITableExtensionReference,
           IEquatable<TableExtensionReference>
     {
-        private static ISerializer tableConfigSerializer = new TableConfigurationsSerializer();
+        private static ITableConfigurationsSerializer tableConfigSerializer = new TableConfigurationsSerializer();
 
         private TableDescriptor tableDescriptor;
         private Action<ITableBuilder, IDataExtensionRetrieval> buildTableAction;
@@ -169,7 +169,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Tables
         ///     <list type="bullet">
         ///         <item>
         ///             must expose a valid <see cref="TableDescriptor"/>.
-        ///             See <see cref="TableDescriptorFactory.TryCreate(Type, ISerializer, out TableDescriptor)"/>
+        ///             See <see cref="TableDescriptorFactory.TryCreate(Type, ITableConfigurationsSerializer, out TableDescriptor)"/>
         ///             for details on how a table is to expose a descriptor.
         ///         </item>
         ///     </list>
@@ -236,7 +236,7 @@ namespace Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Tables
         ///     <list type="bullet">
         ///         <item>
         ///             must expose a valid <see cref="TableDescriptor"/>.
-        ///             See <see cref="TableDescriptorFactory.TryCreate(Type, ISerializer, out TableDescriptor)"/>
+        ///             See <see cref="TableDescriptorFactory.TryCreate(Type, ITableConfigurationsSerializer, out TableDescriptor)"/>
         ///             for details on how a table is to expose a descriptor.
         ///         </item>
         ///     </list>

--- a/src/Microsoft.Performance.SDK.Tests/FakeTableProvider.cs
+++ b/src/Microsoft.Performance.SDK.Tests/FakeTableProvider.cs
@@ -12,15 +12,15 @@ namespace Microsoft.Performance.SDK.Tests
     {
         public FakeTableProvider()
         {
-            this.DiscoverCalls = new List<ISerializer>();
+            this.DiscoverCalls = new List<ITableConfigurationsSerializer>();
             this.DiscoverReturnValue = Array.Empty<DiscoveredTable>();
         }
 
-        public List<ISerializer> DiscoverCalls { get; }
+        public List<ITableConfigurationsSerializer> DiscoverCalls { get; }
 
         public IEnumerable<DiscoveredTable> DiscoverReturnValue { get; set; }
 
-        public IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer)
+        public IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer)
         {
             this.DiscoverCalls.Add(tableConfigSerializer);
             return this.DiscoverReturnValue;

--- a/src/Microsoft.Performance.SDK.Tests/ProcessingSourceTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ProcessingSourceTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Performance.SDK.Tests
     [TestClass]
     public class ProcessingSourceTests
     {
-        private ISerializer serializer = new FakeSerializer();
+        private ITableConfigurationsSerializer serializer = new FakeSerializer();
         private IApplicationEnvironment applicationEnvironment = new StubApplicationEnvironment() { Serializer = new FakeSerializer() };
 
         [TestCleanup]

--- a/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Performance.SDK.Tests
     [TestClass]
     public class TableDescriptorFactoryTests
     {
-        private static ISerializer serializer = new FakeSerializer();
+        private static ITableConfigurationsSerializer serializer = new FakeSerializer();
 
         [TestMethod]
         [UnitTest]

--- a/src/Microsoft.Performance.SDK.Tests/TableDescriptorUtils.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TableDescriptorUtils.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.SDK.Tests
     internal static class TableDescriptorUtils
     {
         internal static List<TableDescriptor> CreateTableDescriptors(
-            ISerializer serializer,
+            ITableConfigurationsSerializer serializer,
             params Type[] types)
         {
             CreateTableDescriptors(serializer, out var descriptors, out _, out _, types);
@@ -21,7 +21,7 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         internal static void CreateTableDescriptors(
-            ISerializer serializer,
+            ITableConfigurationsSerializer serializer,
             out List<TableDescriptor> descriptors,
             out List<Action<ITableBuilder, IDataExtensionRetrieval>> buildActions,
             out List<bool> isInternal,

--- a/src/Microsoft.Performance.SDK.Tests/TestClasses/TestApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TestClasses/TestApplicationEnvironment.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Performance.SDK.Tests.TestClasses
 
         public bool IsInteractive { get; set; }
 
-        public ISerializer Serializer { get; set; }
+        public ITableConfigurationsSerializer Serializer { get; set; }
 
         public ITableDataSynchronization TableDataSynchronizer { get; set; }
 

--- a/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironment.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Extensibility.SourceParsing;
-using System;
 
 namespace Microsoft.Performance.SDK.Processing
 {
@@ -34,9 +34,9 @@ namespace Microsoft.Performance.SDK.Processing
         bool IsInteractive { get; }
 
         /// <summary>
-        ///     Gets the serializer to use for deserializing table configurations.
+        ///     Gets the serializer to use for deserializing <see cref="TableConfiguration"/> instances.
         /// </summary>
-        ISerializer Serializer { get; }
+        ITableConfigurationsSerializer Serializer { get; }
 
         /// <summary>
         ///     Provides the interface to be used to notify that data in

--- a/src/Microsoft.Performance.SDK/Processing/ITableConfigurationsSerializer.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ITableConfigurationsSerializer.cs
@@ -7,10 +7,10 @@ using System.IO;
 namespace Microsoft.Performance.SDK.Processing
 {
     /// <summary>
-    ///     Used to perform serialization operations against <see cref="TableConfiguration"/>
+    ///     Used to perform serialization operations against <see cref="TableConfigurations"/>
     ///     instances.
     /// </summary>
-    public interface ISerializer
+    public interface ITableConfigurationsSerializer
     {
         /// <summary>
         ///     Deserializes the content of a <see cref="Stream"/> into a collection

--- a/src/Microsoft.Performance.SDK/Processing/ITableProvider.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ITableProvider.cs
@@ -21,6 +21,6 @@ namespace Microsoft.Performance.SDK.Processing
         ///     A collection of tables. Each <see cref="DiscoveredTable"/> in the collection must have
         ///     a unique <see cref="TableDescriptor"/>.
         /// </returns>
-        IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer);
+        IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer);
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ProcessingSource.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ProcessingSource.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Performance.SDK.Processing
             return null;
         }
 
-        private void InitializeAllTables(ISerializer tableConfigSerializer)
+        private void InitializeAllTables(ITableConfigurationsSerializer tableConfigSerializer)
         {
             Debug.Assert(tableConfigSerializer != null);
 

--- a/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Performance.SDK.Processing
         public static TableConfigurations GetPrebuiltTableConfigurations(
             Type tableType,
             Guid tableId,
-            ISerializer serializer)
+            ITableConfigurationsSerializer serializer)
         {
             return GetPrebuiltTableConfigurations(tableType, tableId, serializer, null);
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Performance.SDK.Processing
         public static TableConfigurations GetPrebuiltTableConfigurations(
             Type tableType,
             Guid tableId,
-            ISerializer serializer,
+            ITableConfigurationsSerializer serializer,
             ILogger logger)
         {
             Guard.NotNull(serializer, nameof(serializer));
@@ -136,7 +136,7 @@ namespace Microsoft.Performance.SDK.Processing
         private static TableConfigurations GetPrebuiltConfigurationFromExternalFile(
             Type tableType,
             Guid tableId,
-            ISerializer serializer,
+            ITableConfigurationsSerializer serializer,
             ILogger logger)
         {
             var tableAttribute = tableType.GetCustomAttribute<PrebuiltConfigurationsFilePathAttribute>();
@@ -203,7 +203,7 @@ namespace Microsoft.Performance.SDK.Processing
         private static TableConfigurations GetPrebuiltConfigurationFromEmbeddedResource(
             Type tableType,
             Guid tableId,
-            ISerializer serializer,
+            ITableConfigurationsSerializer serializer,
             ILogger logger)
         {
             var tableAttribute = tableType.GetCustomAttribute<PrebuiltConfigurationsEmbeddedResourceAttribute>();

--- a/src/Microsoft.Performance.SDK/Processing/TableDescriptorFactory.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDescriptorFactory.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// </returns>
         public static bool TryCreate(
             Type type,
-            ISerializer tableConfigSerializer,
+            ITableConfigurationsSerializer tableConfigSerializer,
             out TableDescriptor tableDescriptor)
         {
             return TryCreate(type, tableConfigSerializer, out tableDescriptor, out var buildTableAction);
@@ -98,7 +98,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// </returns>
         public static bool TryCreate(
             Type type,
-            ISerializer tableConfigSerializer,
+            ITableConfigurationsSerializer tableConfigSerializer,
             out TableDescriptor tableDescriptor,
             out Action<ITableBuilder, IDataExtensionRetrieval> buildTableAction)
         {
@@ -148,7 +148,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// </returns>
         public static bool TryCreate(
             Type type,
-            ISerializer tableConfigSerializer,
+            ITableConfigurationsSerializer tableConfigSerializer,
             out TableDescriptor tableDescriptor,
             out Action<ITableBuilder, IDataExtensionRetrieval> buildTableAction,
             out Func<IDataExtensionRetrieval, bool> isDataAvailableFunc)
@@ -208,7 +208,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// </returns>
         public static bool TryCreate(
             Type type,
-            ISerializer tableConfigSerializer,
+            ITableConfigurationsSerializer tableConfigSerializer,
             ILogger logger,
             out TableDescriptor tableDescriptor,
             out Action<ITableBuilder, IDataExtensionRetrieval> buildTableAction,
@@ -276,7 +276,7 @@ namespace Microsoft.Performance.SDK.Processing
         private static TableDescriptor GetTableDescriptor(
             Type type,
             string propertyName,
-            ISerializer tableConfigSerializer,
+            ITableConfigurationsSerializer tableConfigSerializer,
             ILogger logger)
         {
             Debug.Assert(type != null, $"Parameter {nameof(type)} cannot be null.");

--- a/src/Microsoft.Performance.SDK/Processing/TableDiscovery.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDiscovery.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Performance.SDK.Processing
         private static IEnumerable<DiscoveredTable> DoAssemblyDiscovery(
             IEnumerable<Assembly> assemblies,
             Func<Type, bool> typeFilter,
-            ISerializer tableConfigSerializer)
+            ITableConfigurationsSerializer tableConfigSerializer)
         {
             Debug.Assert(assemblies != null);
             Debug.Assert(typeFilter != null);
@@ -186,7 +186,7 @@ namespace Microsoft.Performance.SDK.Processing
                 this.assembly = assembly;
             }
 
-            public IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer)
+            public IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer)
             {
                 return DoAssemblyDiscovery(new[] { assembly, }, _ => true, tableConfigSerializer);
             }
@@ -208,7 +208,7 @@ namespace Microsoft.Performance.SDK.Processing
                 this.assemblies = assemblies;
             }
 
-            public IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer)
+            public IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer)
             {
                 return DoAssemblyDiscovery(
                     this.assemblies,

--- a/src/Microsoft.Performance.Testing.SDK/FakeSerializer.cs
+++ b/src/Microsoft.Performance.Testing.SDK/FakeSerializer.cs
@@ -9,7 +9,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.Testing.SDK
 {
     public sealed class FakeSerializer
-        : ISerializer
+        : ITableConfigurationsSerializer
     {
         public IEnumerable<TableConfigurations> DeserializeTableConfigurations(Stream stream)
         {

--- a/src/Microsoft.Performance.Testing.SDK/StubApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.Testing.SDK/StubApplicationEnvironment.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Performance.Testing.SDK
 
         public bool IsInteractive { get; set; }
 
-        public ISerializer Serializer { get; set; }
+        public ITableConfigurationsSerializer Serializer { get; set; }
 
         public ITableDataSynchronization TableDataSynchronizer { get; set; }
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
         private sealed class Discovery
             : ITableProvider
         {
-            public IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer)
+            public IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer)
             {
                 return new HashSet<DiscoveredTable>
                 {

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataSource.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
             private static readonly ITableProvider DefaultProvider
                 = TableDiscovery.CreateForAssembly(typeof(Source5DataSource).Assembly);
 
-            public IEnumerable<DiscoveredTable> Discover(ISerializer tableConfigSerializer)
+            public IEnumerable<DiscoveredTable> Discover(ITableConfigurationsSerializer tableConfigSerializer)
             {
                 var tables = new HashSet<DiscoveredTable>(DefaultProvider.Discover(tableConfigSerializer));
                 tables.Add(

--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -12,7 +12,6 @@ using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.SDK.Runtime;
-using Microsoft.Performance.SDK.Runtime.DTO;
 using Microsoft.Performance.SDK.Runtime.Extensibility;
 using Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions;
 using Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Repository;
@@ -758,7 +757,6 @@ namespace Microsoft.Performance.Toolkit.Engine
                     applicationName: applicationName,
                     runtimeName: runtimeName,
                     new RuntimeTableSynchronizer(),
-                    new TableConfigurationsSerializer(),
                     instance.Extensions,
                     instance.Factory.CreateSourceSessionFactory(),
                     createInfo.IsInteractive


### PR DESCRIPTION
Also rename `ISerializer` to `ITableConfigurationsSerializer`