### PR TITLE
Remove isInternalTable from TableDescriptor constructor

### DIFF
--- a/documentation/Migration/Update-1.0.0-rc1.md
+++ b/documentation/Migration/Update-1.0.0-rc1.md
@@ -281,9 +281,9 @@ This was moved from the SDK namespace to SDK.Runtime.
 
 - Internal table constructor arguments and properties have been removed from `TableAttribute`.
 
-- An `isInternalTable` constructor argument and an `IsInternalTable` property were added to `TableDescriptor`.
+- The runtime will now determine if a table needs to be marked as internal.
 
-Internal tables provide processing sources a way to create tables that require data cookers but do not declare build table actions. If using internal tables today, please update the table attribute and table descriptor appropriately.
+- Extensions tables, those that require data cookers, must provide a build table method.
 
 ### Engine Execution Results
 

--- a/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorBaseWithSourceParserTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorBaseWithSourceParserTests.cs
@@ -30,48 +30,9 @@ namespace Microsoft.Performance.SDK.Tests
                     "Test Table with Requirements",
                     "This table has required data extensions",
                     "Other",
-                    isMetadataTable: false,
-                    isInternalTable: true,
+                    isMetadataTable: true,
                     requiredDataCookers: new List<DataCookerPath> { RequiredDataCooker })
             { Type = typeof(TestTable1) };
-
-            public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
-            {
-            }
-        }
-
-        [Table]
-        public static class NoBuildActionInternalTestTable1
-        {
-            public static readonly string SourceParserId = "SourceId1";
-
-            public static TableDescriptor TableDescriptor = new TableDescriptor(
-                    Guid.Parse("{CFBE73E8-DBC6-4A76-9F98-B4F2C1D4816D}"),
-                    "Test Table without a build method.",
-                    "This table has no required data extensions",
-                    "Other",
-                    isMetadataTable: false,
-                    isInternalTable: true)
-            { Type = typeof(NoBuildActionInternalTestTable1) };
-        }
-
-        [Table]
-        public static class NoBuildActionInternalTestTable2
-        {
-            public static readonly string SourceParserId = "SourceId1";
-
-            public static readonly DataCookerPath RequiredDataCooker =
-                DataCookerPath.ForSource(SourceParserId, "CookerId1");
-
-            public static TableDescriptor TableDescriptor = new TableDescriptor(
-                    Guid.Parse("{87C11CDF-5D35-49AC-8FFD-6E34D1930A35}"),
-                    "Test Table without a build method",
-                    "This table has required data extensions",
-                    "Other",
-                    isMetadataTable: false,
-                    isInternalTable: true,
-                    requiredDataCookers: new List<DataCookerPath> { RequiredDataCooker })
-            { Type = typeof(NoBuildActionInternalTestTable2) };
 
             public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
             {
@@ -93,8 +54,7 @@ namespace Microsoft.Performance.SDK.Tests
                     "Test Table with Requirements",
                     "This table has required data extensions",
                     "Other",
-                    isMetadataTable: false,
-                    isInternalTable: true,
+                    isMetadataTable: true,
                     requiredDataCookers: new List<DataCookerPath> { RequiredDataCooker1, RequiredDataCooker2 })
             { Type = typeof(InvalidInternalTestTable) };
 
@@ -133,43 +93,6 @@ namespace Microsoft.Performance.SDK.Tests
             var enabledTables = cdp.ExtensibilitySupport.GetEnabledInternalTables();
             Assert.AreEqual(1, enabledTables.Count());
             Assert.AreEqual(typeof(TestTable1), enabledTables.First().Type);
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void InternalTableWithNoBuildMethodIsEnabled()
-        {
-            var sourceCooker = new TestSourceDataCooker()
-            { Path = TestTable1.RequiredDataCooker };
-
-            var sourceCookerReference = new TestSourceDataCookerReference(false)
-            {
-                Path = sourceCooker.Path,
-                availability = DataExtensionAvailability.Available,
-                createInstance = () => sourceCooker,
-            };
-
-            var internalTables = new Dictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>>();
-            internalTables.Add(TestTable1.TableDescriptor, TestTable1.BuildTable);
-            internalTables.Add(NoBuildActionInternalTestTable1.TableDescriptor, null);
-            internalTables.Add(NoBuildActionInternalTestTable2.TableDescriptor, null);
-
-            var extensions = new TestDataExtensionRepository();
-            extensions.sourceCookersByPath.Add(sourceCookerReference.Path, sourceCookerReference);
-
-            var cdp = TestCustomDataProcessor.CreateTestCustomDataProcessor(TestTable1.SourceParserId, internalTables, extensions);
-
-            // Make sure the table is marked as registered in the base class
-            Assert.AreEqual(3, cdp.EnabledTableDescriptors.Count);
-            Assert.IsTrue(cdp.EnabledTableDescriptors.Select(t => t.Type).Contains(typeof(TestTable1)));
-            Assert.IsTrue(cdp.EnabledTableDescriptors.Select(t => t.Type).Contains(typeof(NoBuildActionInternalTestTable1)));
-            Assert.IsTrue(cdp.EnabledTableDescriptors.Select(t => t.Type).Contains(typeof(NoBuildActionInternalTestTable2)));
-
-            // NoBuildActionInternalTestTable1 doesn't have any required cookers, so it won't show up here
-            var enabledTables = cdp.ExtensibilitySupport.GetEnabledInternalTables();
-            Assert.AreEqual(2, enabledTables.Count());
-            Assert.IsTrue(enabledTables.Select(t => t.Type).Contains(typeof(TestTable1)));
-            Assert.IsTrue(enabledTables.Select(t => t.Type).Contains(typeof(NoBuildActionInternalTestTable2)));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Tests/StubTables.cs
+++ b/src/Microsoft.Performance.SDK.Tests/StubTables.cs
@@ -1,122 +1,121 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+
 namespace Microsoft.Performance.SDK.Tests
 {
-    //[Table]
-    //internal sealed class StubDataTableOne
-    //{
-    //    public bool TryCreateTable(ITableBuilder tableBuilder)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+    [Table]
+    internal sealed class StubDataTableOne
+    {
+        public bool TryCreateTable(ITableBuilder tableBuilder)
+        {
+            throw new NotImplementedException();
+        }
 
-    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-    //        Guid.Parse("{F3F7B534-5DC5-40FB-93D9-07FDAC073A13}"),
-    //        "Name0",
-    //        "Description",
-    //        "Category",
-    //        isInternalTable: true);
+        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+            Guid.Parse("{F3F7B534-5DC5-40FB-93D9-07FDAC073A13}"),
+            "Name0",
+            "Description",
+            "Category");
 
-    //    public static bool BuildTableWasCalled { get; private set; }
+        public static bool BuildTableWasCalled { get; private set; }
 
-    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-    //    {
-    //        BuildTableWasCalled = true;
-    //    }
-    //}
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+        {
+            BuildTableWasCalled = true;
+        }
+    }
 
-    //[Table]
-    //internal sealed class StubDataTableTwo
-    //{
-    //    public bool TryCreateTable(ITableBuilder tableBuilder)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+    [Table]
+    internal sealed class StubDataTableTwo
+    {
+        public bool TryCreateTable(ITableBuilder tableBuilder)
+        {
+            throw new NotImplementedException();
+        }
 
-    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-    //        Guid.Parse("{677CA54E-45D2-46B1-80BE-6DBA96597435}"),
-    //        "Name1",
-    //        "Description",
-    //        "Category",
-    //        isInternalTable: true);
+        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+            Guid.Parse("{677CA54E-45D2-46B1-80BE-6DBA96597435}"),
+            "Name1",
+            "Description",
+            "Category");
 
-    //    public static bool BuildTableWasCalled { get; private set; }
+        public static bool BuildTableWasCalled { get; private set; }
 
-    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-    //    {
-    //        BuildTableWasCalled = true;
-    //    }
-    //}
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+        {
+            BuildTableWasCalled = true;
+        }
+    }
 
-    //[Table]
-    //internal sealed class StubDataTableThree
-    //{
-    //    public bool TryCreateTable(ITableBuilder tableBuilder)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+    [Table]
+    internal sealed class StubDataTableThree
+    {
+        public bool TryCreateTable(ITableBuilder tableBuilder)
+        {
+            throw new NotImplementedException();
+        }
 
-    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-    //        Guid.Parse("{96D8DD5E-C0FC-4681-85E2-CFAFD1A0803C}"),
-    //        "Name2",
-    //        "Description",
-    //        "Category",
-    //        isInternalTable: true);
+        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+            Guid.Parse("{96D8DD5E-C0FC-4681-85E2-CFAFD1A0803C}"),
+            "Name2",
+            "Description",
+            "Category");
 
-    //    public static bool BuildTableWasCalled { get; private set; }
+        public static bool BuildTableWasCalled { get; private set; }
 
-    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-    //    {
-    //        BuildTableWasCalled = true;
-    //    }
-    //}
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+        {
+            BuildTableWasCalled = true;
+        }
+    }
 
-    //[Table]
-    //internal sealed class StubMetadataTableOne
-    //{
-    //    public bool TryCreateTable(ITableBuilder tableBuilder)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+    [Table]
+    internal sealed class StubMetadataTableOne
+    {
+        public bool TryCreateTable(ITableBuilder tableBuilder)
+        {
+            throw new NotImplementedException();
+        }
 
-    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-    //        Guid.Parse("{824C0827-40E8-4DE7-ACD2-C6614E916D86}"),
-    //        "Metadata1",
-    //        "Description",
-    //        TableDescriptor.DefaultCategory,
-    //        true,
-    //        isInternalTable: true);
+        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+            Guid.Parse("{824C0827-40E8-4DE7-ACD2-C6614E916D86}"),
+            "Metadata1",
+            "Description",
+            TableDescriptor.DefaultCategory,
+            true);
 
-    //    public static bool BuildTableWasCalled { get; private set; }
+        public static bool BuildTableWasCalled { get; private set; }
 
-    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-    //    {
-    //        BuildTableWasCalled = true;
-    //    }
-    //}
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+        {
+            BuildTableWasCalled = true;
+        }
+    }
 
-    //[Table]
-    //internal sealed class StubMetadataTableTwo
-    //{
-    //    public bool TryCreateTable(ITableBuilder tableBuilder)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
+    [Table]
+    internal sealed class StubMetadataTableTwo
+    {
+        public bool TryCreateTable(ITableBuilder tableBuilder)
+        {
+            throw new NotImplementedException();
+        }
 
-    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-    //        Guid.Parse("{2072CA7C-79F0-4FA5-9DBD-1453D117629F}"),
-    //        "Metadata2",
-    //        "Description",
-    //        TableDescriptor.DefaultCategory,
-    //        true,
-    //        isInternalTable: true);
+        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+            Guid.Parse("{2072CA7C-79F0-4FA5-9DBD-1453D117629F}"),
+            "Metadata2",
+            "Description",
+            TableDescriptor.DefaultCategory,
+            true);
 
-    //    public static bool BuildTableWasCalled { get; private set; }
+        public static bool BuildTableWasCalled { get; private set; }
 
-    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-    //    {
-    //        BuildTableWasCalled = true;
-    //    }
-    //}
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+        {
+            BuildTableWasCalled = true;
+        }
+    }
 }

--- a/src/Microsoft.Performance.SDK.Tests/StubTables.cs
+++ b/src/Microsoft.Performance.SDK.Tests/StubTables.cs
@@ -1,126 +1,122 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using Microsoft.Performance.SDK.Extensibility;
-using Microsoft.Performance.SDK.Processing;
-
 namespace Microsoft.Performance.SDK.Tests
 {
-    [Table]
-    internal sealed class StubDataTableOne
-    {
-        public bool TryCreateTable(ITableBuilder tableBuilder)
-        {
-            throw new NotImplementedException();
-        }
+    //[Table]
+    //internal sealed class StubDataTableOne
+    //{
+    //    public bool TryCreateTable(ITableBuilder tableBuilder)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
 
-        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-            Guid.Parse("{F3F7B534-5DC5-40FB-93D9-07FDAC073A13}"),
-            "Name0",
-            "Description",
-            "Category",
-            isInternalTable: true);
+    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+    //        Guid.Parse("{F3F7B534-5DC5-40FB-93D9-07FDAC073A13}"),
+    //        "Name0",
+    //        "Description",
+    //        "Category",
+    //        isInternalTable: true);
 
-        public static bool BuildTableWasCalled { get; private set; }
+    //    public static bool BuildTableWasCalled { get; private set; }
 
-        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-        {
-            BuildTableWasCalled = true;
-        }
-    }
+    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+    //    {
+    //        BuildTableWasCalled = true;
+    //    }
+    //}
 
-    [Table]
-    internal sealed class StubDataTableTwo
-    {
-        public bool TryCreateTable(ITableBuilder tableBuilder)
-        {
-            throw new NotImplementedException();
-        }
+    //[Table]
+    //internal sealed class StubDataTableTwo
+    //{
+    //    public bool TryCreateTable(ITableBuilder tableBuilder)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
 
-        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-            Guid.Parse("{677CA54E-45D2-46B1-80BE-6DBA96597435}"),
-            "Name1",
-            "Description",
-            "Category",
-            isInternalTable: true);
+    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+    //        Guid.Parse("{677CA54E-45D2-46B1-80BE-6DBA96597435}"),
+    //        "Name1",
+    //        "Description",
+    //        "Category",
+    //        isInternalTable: true);
 
-        public static bool BuildTableWasCalled { get; private set; }
+    //    public static bool BuildTableWasCalled { get; private set; }
 
-        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-        {
-            BuildTableWasCalled = true;
-        }
-    }
+    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+    //    {
+    //        BuildTableWasCalled = true;
+    //    }
+    //}
 
-    [Table]
-    internal sealed class StubDataTableThree
-    {
-        public bool TryCreateTable(ITableBuilder tableBuilder)
-        {
-            throw new NotImplementedException();
-        }
+    //[Table]
+    //internal sealed class StubDataTableThree
+    //{
+    //    public bool TryCreateTable(ITableBuilder tableBuilder)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
 
-        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-            Guid.Parse("{96D8DD5E-C0FC-4681-85E2-CFAFD1A0803C}"),
-            "Name2",
-            "Description",
-            "Category",
-            isInternalTable: true);
+    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+    //        Guid.Parse("{96D8DD5E-C0FC-4681-85E2-CFAFD1A0803C}"),
+    //        "Name2",
+    //        "Description",
+    //        "Category",
+    //        isInternalTable: true);
 
-        public static bool BuildTableWasCalled { get; private set; }
+    //    public static bool BuildTableWasCalled { get; private set; }
 
-        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-        {
-            BuildTableWasCalled = true;
-        }
-    }
+    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+    //    {
+    //        BuildTableWasCalled = true;
+    //    }
+    //}
 
-    [Table]
-    internal sealed class StubMetadataTableOne
-    {
-        public bool TryCreateTable(ITableBuilder tableBuilder)
-        {
-            throw new NotImplementedException();
-        }
+    //[Table]
+    //internal sealed class StubMetadataTableOne
+    //{
+    //    public bool TryCreateTable(ITableBuilder tableBuilder)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
 
-        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-            Guid.Parse("{824C0827-40E8-4DE7-ACD2-C6614E916D86}"),
-            "Metadata1",
-            "Description",
-            TableDescriptor.DefaultCategory,
-            true,
-            isInternalTable: true);
+    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+    //        Guid.Parse("{824C0827-40E8-4DE7-ACD2-C6614E916D86}"),
+    //        "Metadata1",
+    //        "Description",
+    //        TableDescriptor.DefaultCategory,
+    //        true,
+    //        isInternalTable: true);
 
-        public static bool BuildTableWasCalled { get; private set; }
+    //    public static bool BuildTableWasCalled { get; private set; }
 
-        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-        {
-            BuildTableWasCalled = true;
-        }
-    }
+    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+    //    {
+    //        BuildTableWasCalled = true;
+    //    }
+    //}
 
-    [Table]
-    internal sealed class StubMetadataTableTwo
-    {
-        public bool TryCreateTable(ITableBuilder tableBuilder)
-        {
-            throw new NotImplementedException();
-        }
+    //[Table]
+    //internal sealed class StubMetadataTableTwo
+    //{
+    //    public bool TryCreateTable(ITableBuilder tableBuilder)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
 
-        public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
-            Guid.Parse("{2072CA7C-79F0-4FA5-9DBD-1453D117629F}"),
-            "Metadata2",
-            "Description",
-            TableDescriptor.DefaultCategory,
-            true,
-            isInternalTable: true);
+    //    public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+    //        Guid.Parse("{2072CA7C-79F0-4FA5-9DBD-1453D117629F}"),
+    //        "Metadata2",
+    //        "Description",
+    //        TableDescriptor.DefaultCategory,
+    //        true,
+    //        isInternalTable: true);
 
-        public static bool BuildTableWasCalled { get; private set; }
+    //    public static bool BuildTableWasCalled { get; private set; }
 
-        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
-        {
-            BuildTableWasCalled = true;
-        }
-    }
+    //    public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval cookedData)
+    //    {
+    //        BuildTableWasCalled = true;
+    //    }
+    //}
 }

--- a/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Performance.SDK.Tests
                 "Name",
                 "Description",
                 "Category",
-                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("blah", "blahblah") });
+                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("SourceParser1", "CookerA") });
 
             public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
             {
@@ -332,7 +332,7 @@ namespace Microsoft.Performance.SDK.Tests
                 "Name",
                 "Description",
                 "Category",
-                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("blah", "blahblah") });
+                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("SourceParser1", "CookerB") });
         }
     }
 }

--- a/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TableDescriptorFactoryTests.cs
@@ -91,6 +91,34 @@ namespace Microsoft.Performance.SDK.Tests
             AssertAttributeTranslated(TableWithSubAttribute.Descriptor, descriptor);
         }
 
+        [TestMethod]
+        [UnitTest]
+        public void TryCreateExtensionTableDescriptor()
+        {
+            var result = TableDescriptorFactory.TryCreate
+                (typeof(ExtensionTable),
+                serializer,
+                out TableDescriptor descriptor);
+
+            Assert.IsTrue(result);
+            Assert.IsNotNull(descriptor);
+
+            AssertAttributeTranslated(ExtensionTable.TableDescriptor, descriptor);
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void TryCreateExtensionTableDescriptorWithNoBuildMethod()
+        {
+            var result = TableDescriptorFactory.TryCreate
+                (typeof(ExtensionTableNoBuildMethod),
+                serializer,
+                out TableDescriptor descriptor);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(descriptor);
+        }
+
         private static void AssertAttributeTranslated(
             TableDescriptor original,
             TableDescriptor returned)
@@ -279,6 +307,32 @@ namespace Microsoft.Performance.SDK.Tests
                 "Name",
                 "Description",
                 "Category");
+        }
+
+        [Table]
+        public sealed class ExtensionTable
+        {
+            public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+                Guid.Parse("{DEC27D7E-D77F-4D64-B055-2A5AAE44E2F9}"),
+                "Name",
+                "Description",
+                "Category",
+                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("blah", "blahblah") });
+
+            public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval dataRetrieval)
+            {
+            }
+        }
+
+        [Table]
+        public sealed class ExtensionTableNoBuildMethod
+        {
+            public static TableDescriptor TableDescriptor { get; } = new TableDescriptor(
+                Guid.Parse("{F2237762-AE04-4E2D-924B-AC381FFD3E26}"),
+                "Name",
+                "Description",
+                "Category",
+                requiredDataCookers: new DataCookerPath[] { DataCookerPath.ForSource("blah", "blahblah") });
         }
     }
 }

--- a/src/Microsoft.Performance.SDK.Tests/TestClasses/TestCustomDataProcessor.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TestClasses/TestCustomDataProcessor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
 using Microsoft.Performance.SDK.Extensibility.SourceParsing;
@@ -28,7 +29,7 @@ namespace Microsoft.Performance.SDK.Tests.TestClasses
 
         public static TestCustomDataProcessor CreateTestCustomDataProcessor(
             string sourceParserId,
-            Dictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>> internalTables,
+            Dictionary<TableDescriptor, Action<ITableBuilder, IDataExtensionRetrieval>> metadataTables,
             TestDataExtensionRepository extensionRepo = null)
         {
             var sourceParser = new TestSourceParser() { Id = sourceParserId };
@@ -56,8 +57,8 @@ namespace Microsoft.Performance.SDK.Tests.TestClasses
                 ProcessorOptions.Default,
                 applicationEnvironment,
                 processorEnvironment,
-                internalTables,
-                new List<TableDescriptor>());
+                metadataTables,
+                metadataTables.Select(kvp => kvp.Key));
 
             Assert.IsNotNull(extensibilitySupport);
 

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessor.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Performance.SDK.Processing
         {
             Guard.NotNull(metadataTableBuilderFactory, nameof(metadataTableBuilderFactory));
 
-            foreach (var kvp in this.TableDescriptorToBuildAction.Where(x => x.Key.IsMetadataTable))
+            foreach (var kvp in this.TableDescriptorToBuildAction.Where(x => x.Key.IsMetadataTable && !x.Key.RequiresDataExtensions()))
             {
                 var builder = metadataTableBuilderFactory.Create(kvp.Key);
                 Debug.Assert(builder != null);

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Performance.SDK.Processing
             this.SourceProcessingSession = this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this);
             this.extensibilitySupport = this.ProcessorEnvironment.CreateDataProcessorExtensibilitySupport(this);
 
-            EnableInternalTables(allTablesMapping.Keys);
+            EnableExtensionMetadataTables(metadataTables);
         }
 
         /// <summary>
@@ -372,9 +372,13 @@ namespace Microsoft.Performance.SDK.Processing
             this.OnAllCookersEnabled();
         }
 
-        private void EnableInternalTables(IEnumerable<TableDescriptor> tables)
+        /// <summary>
+        ///     This method enabled the source data cookers required by extension internal tables, only metadata tables for now.
+        /// </summary>
+        /// <param name="tables"></param>
+        private void EnableExtensionMetadataTables(IEnumerable<TableDescriptor> tables)
         {
-            foreach (var table in tables.Where(td => td.IsInternalTable && td.RequiresDataExtensions()))
+            foreach (var table in tables.Where(td => td.RequiresDataExtensions()))
             {
                 try
                 {

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -54,7 +54,13 @@ namespace Microsoft.Performance.SDK.Processing
             this.SourceProcessingSession = this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this);
             this.extensibilitySupport = this.ProcessorEnvironment.CreateDataProcessorExtensibilitySupport(this);
 
-            EnableInternalTables(allTablesMapping.Keys);
+            //
+            // TODO (160): InternalTables
+            // Commenting this out because we don't want to enable all tables by default. Tables should
+            // be enabled by manually calling EnableTable
+            //
+
+            //EnableInternalTables(allTablesMapping.Keys);
         }
 
         /// <summary>

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -54,13 +54,7 @@ namespace Microsoft.Performance.SDK.Processing
             this.SourceProcessingSession = this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this);
             this.extensibilitySupport = this.ProcessorEnvironment.CreateDataProcessorExtensibilitySupport(this);
 
-            //
-            // TODO (160): InternalTables
-            // Commenting this out because we don't want to enable all tables by default. Tables should
-            // be enabled by manually calling EnableTable
-            //
-
-            //EnableInternalTables(allTablesMapping.Keys);
+            EnableInternalTables(allTablesMapping.Keys);
         }
 
         /// <summary>
@@ -380,7 +374,7 @@ namespace Microsoft.Performance.SDK.Processing
 
         private void EnableInternalTables(IEnumerable<TableDescriptor> tables)
         {
-            foreach (var table in tables.Where(td => td.IsInternalTable))
+            foreach (var table in tables.Where(td => td.IsInternalTable && td.RequiresDataExtensions()))
             {
                 try
                 {

--- a/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
@@ -62,9 +62,6 @@ namespace Microsoft.Performance.SDK.Processing
         /// <param name="requiredDataProcessors">
         ///     Identifiers for data processors required to instantiate this table.
         /// </param>
-        /// <param name="isInternalTable">
-        ///     Whether the table is an internal table.
-        /// </param>
         /// <exception cref="ArgumentException">
         ///     <paramref name="guid"/> is whitespace.
         ///     - or -

--- a/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Performance.SDK.Extensibility;
-using Microsoft.Performance.SDK.Extensibility.DataProcessing;
 
 namespace Microsoft.Performance.SDK.Processing
 {
@@ -16,8 +15,8 @@ namespace Microsoft.Performance.SDK.Processing
     public sealed class TableDescriptor
         : IEquatable<TableDescriptor>,
           IDataCookerDependent //,
-          // TODO: __SDK_DP__
-          // IDataProcessorDependent
+                               // TODO: __SDK_DP__
+                               // IDataProcessorDependent
     {
         /// <summary>
         ///     The default table category name.
@@ -95,8 +94,7 @@ namespace Microsoft.Performance.SDK.Processing
             bool isMetadataTable = false,
             TableLayoutStyle defaultLayout = TableLayoutStyle.GraphAndTable,
             IEnumerable<DataCookerPath> requiredDataCookers = null,
-            IEnumerable<DataProcessorId> requiredDataProcessors = null,
-            bool isInternalTable = false)
+            IEnumerable<DataProcessorId> requiredDataProcessors = null)
         {
             Guard.NotDefault(guid, nameof(guid));
             Guard.NotNullOrWhiteSpace(name, nameof(name));
@@ -110,7 +108,7 @@ namespace Microsoft.Performance.SDK.Processing
             this.DefaultLayout = defaultLayout;
             this.IsMetadataTable = isMetadataTable;
             this.ExtendedData = new Dictionary<string, object>();
-            this.IsInternalTable = isInternalTable || this.IsMetadataTable;
+            this.IsInternalTable = this.IsMetadataTable;
 
             this.dataCookers = requiredDataCookers != null ? new HashSet<DataCookerPath>(requiredDataCookers) : new HashSet<DataCookerPath>();
             this.dataProcessors = requiredDataProcessors != null ? new HashSet<DataProcessorId>(requiredDataProcessors) : new HashSet<DataProcessorId>();

--- a/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDescriptor.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Performance.SDK.Processing
     /// </summary>
     public sealed class TableDescriptor
         : IEquatable<TableDescriptor>,
-          IDataCookerDependent //,
-                               // TODO: __SDK_DP__
-                               // IDataProcessorDependent
+          IDataCookerDependent
+    // TODO: __SDK_DP__
+    // IDataProcessorDependent
     {
         /// <summary>
         ///     The default table category name.

--- a/src/Microsoft.Performance.SDK/Processing/TableDescriptorFactory.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableDescriptorFactory.cs
@@ -265,6 +265,7 @@ namespace Microsoft.Performance.SDK.Processing
                     logger?.Error(
                         "The table {0} must add a buld table method since it is an extension table.",
                         type.FullName);
+                    tableDescriptor = null;
                     return false;
                 }
             }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source5/Source5DataSource.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.Toolkit.Engine.Tests.TestTables;
 
@@ -18,8 +17,6 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
     public sealed class Source5DataSource
         : ProcessingSource
     {
-        internal static readonly int BuildActionInt = 2600;
-
         public const string Extension = ".s5d";
 
         public Source5DataSource()
@@ -50,19 +47,6 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
                 Path.GetExtension(dataSource.Uri.LocalPath));
         }
 
-        /// <inheritdoc/>
-        /// This is used to establish the build action for internal table <see cref="Source5InternalTableNoBuildAction"/>.
-        protected override Action<ITableBuilder, IDataExtensionRetrieval> GetTableBuildAction(
-            Type type)
-        {
-            if (type == typeof(Source5InternalTableNoBuildAction))
-            {
-                return (builder, data) => Source5InternalTableNoBuildAction.BuildTableAction(builder, data, Source5DataSource.BuildActionInt);
-            }
-
-            return null;
-        }
-
         private sealed class Discovery
             : ITableProvider
         {
@@ -73,7 +57,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source5
             {
                 var tables = new HashSet<DiscoveredTable>(DefaultProvider.Discover(tableConfigSerializer));
                 tables.Add(
-                    new DiscoveredTable(Source5InternalTable.TableDescriptor, Source5InternalTable.BuildTableAction));
+                    new DiscoveredTable(Source5MetadataTable.TableDescriptor, Source5MetadataTable.BuildTableAction));
                 return tables;
             }
         }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/InvalidMetadataTable.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/InvalidMetadataTable.cs
@@ -9,11 +9,11 @@ using Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Composites;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestTables
 {
     [Table]
-    public static class InvalidInternalTable
+    public static class InvalidMetadataTable
     {
         // This table requires Composite1Cooker, which requires two different source parsers: Source123 & Source4.
-        // Because it spans source parsers, it isn't possible for it to retrieve all data it requires as an internal
-        // table.
+        // Because it spans source parsers, it isn't possible for it to retrieve all data it requires as an metadata
+        // (internal) table.
         //
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
@@ -21,7 +21,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestTables
             "Invalid Internal Table",
             "Consumes cookers from the given source parser.",
             "Engine",
-            isInternalTable: true,
+            isMetadataTable: true,
             requiredDataCookers: new[] { Composite1Cooker.DataCookerPath });
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/Source5MetadataTable.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/Source5MetadataTable.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestTables
     // Rather than using a TableAttribute, this is "discovered" by Source5Source and passed into the base class as
     // an additional table. This provides some additional test coverage.
     //
-    public static class Source5InternalTable
+    public static class Source5MetadataTable
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{708B0564-F9BA-49FA-A87C-3B25C5C7C84C}"),
             "Source5 Internal Table",
             "Used by the Engine Tests to test an internal table",
             "Engine",
-            isInternalTable: true,
+            isMetadataTable: true,
             requiredDataCookers: new[] { Composite2Cooker.DataCookerPath });
 
         public static readonly ColumnConfiguration ColumnOne =

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/Source5MetadataTable2.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestTables/Source5MetadataTable2.cs
@@ -12,14 +12,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Performance.Toolkit.Engine.Tests.TestTables
 {
     [Table]
-    public class Source5InternalTableNoBuildAction
+    public class Source5MetadataTable2
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{2C115535-882D-4B98-991A-E82527688E9C}"),
             "Source5 Internal Table No Build Action",
             "Used by the Engine Tests to test an internal table with no build action",
             "Engine",
-            isInternalTable: true,
+            isMetadataTable: true,
             requiredDataCookers: new[] { Source5DataCooker.DataCookerPath });
 
         public static readonly ColumnConfiguration ColumnOne =
@@ -28,12 +28,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestTables
         public static readonly ColumnConfiguration ColumnTwo =
             new ColumnConfiguration(new ColumnMetadata(Guid.NewGuid(), "Value"));
 
-        // This name is not the default to ensure that the build action won't be found automatically.
-        public static void BuildTableAction(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData, int x)
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
-            // Just a double check that we're getting extra data that we expect. Honestly, I don't know how this would fail.
-            Assert.AreEqual(Source5DataSource.BuildActionInt, x);
-
             // This table didn't require the composite cooker, and its data shouldn't be available.
             Assert.IsFalse(tableData.TryQueryOutput(Composite2Cooker.DataOutputPath, out List<Composite2Output> result));
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -563,12 +563,12 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             using var sut = Engine.Create(new EngineCreateInfo(dataSources.AsReadOnly()));
 
-            Assert.IsTrue(sut.TryEnableTable(Source5InternalTable.TableDescriptor));
-            Assert.IsFalse(sut.TryEnableTable(InvalidInternalTable.TableDescriptor));
+            Assert.IsTrue(sut.TryEnableTable(Source5MetadataTable.TableDescriptor));
+            Assert.IsFalse(sut.TryEnableTable(InvalidMetadataTable.TableDescriptor));
 
             var result = sut.Process();
 
-            var builtTable1 = result.BuildTable(Source5InternalTable.TableDescriptor);
+            var builtTable1 = result.BuildTable(Source5MetadataTable.TableDescriptor);
 
             Assert.AreEqual(1, builtTable1.RowCount);
             Assert.AreEqual(2, builtTable1.Columns.Count());
@@ -582,8 +582,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 Assert.AreEqual(5, builtTable1.Columns.ElementAt(i).Project(0));
             }
 
-            // This table was not explicitly enabled, but it's an internal table and should be available
-            var builtTable2 = result.BuildTable(Source5InternalTableNoBuildAction.TableDescriptor);
+            // This table was not explicitly enabled, but it's an metadata (internal) table and should be available
+            var builtTable2 = result.BuildTable(Source5MetadataTable2.TableDescriptor);
 
             Assert.AreEqual(5, builtTable2.RowCount);
             Assert.AreEqual(2, builtTable2.Columns.Count());


### PR DESCRIPTION
This will require that all extension tables, those that depend on data cookers, must implement a static build table method.

This fixes an issue where tables that don't depend on data cookers and didn't have a static build method weren't being instantiated.

This fixes an issue where metadata tables that require data cookers were throwing.

Additional & updated tests.

Migration document updated.