### PR TITLE
Validate inputs to PluginsLoader.TryLoadPlugin(s) methods

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Plugins/PluginsLoaderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Plugins/PluginsLoaderTests.cs
@@ -125,6 +125,48 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
             }
         }
         
+        [TestMethod]
+        [UnitTest]
+        public void NullDirectoryThrows()
+        {
+            (var loader, _) = Setup(true);
+            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugin(null, out _));
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void NullDirectoriesThrows()
+        {
+            (var loader, _) = Setup(true);
+            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugins(null, out _));
+        }
+        
+        [TestMethod]
+        [UnitTest]
+        public void NullDirectoryInDirectoriesThrows()
+        {
+            (var loader, _) = Setup(true);
+            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugins(new List<string>() { "foo", null }, out _));
+        }
+        
+        [TestMethod]
+        [UnitTest]
+        public void EmptyStringFailsToLoad()
+        {
+            (var loader, var consumer) = Setup(true);
+            var success = loader.TryLoadPlugin(string.Empty, out _);
+            Assert.IsFalse(success);
+        }
+        
+        [TestMethod]
+        [UnitTest]
+        public void EmptyDirectoriesLoads()
+        {
+            (var loader, _) = Setup(true);
+            var success = loader.TryLoadPlugins(new List<string>(), out _);
+            Assert.IsTrue(success);
+        }
+        
         //
         // Invalid folder schema tests
         //

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Plugins/PluginsLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Plugins/PluginsLoader.cs
@@ -179,6 +179,9 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins
         /// <exception cref="ObjectDisposedException">
         ///     This instance is disposed.
         /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="directory"/> is null.
+        /// </exception>
         public bool TryLoadPlugin(string directory, out ErrorInfo error)
         {
             this.ThrowIfDisposed();
@@ -195,16 +198,19 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins
         }
 
         /// <summary>
-        ///     Asynchronous version of <see cref="TryLoadPlugin(string)"/>
+        ///     Asynchronous version of <see cref="TryLoadPlugin(string, out ErrorInfo)"/>
         /// </summary>
         /// <exception cref="ObjectDisposedException">
         ///     This instance is disposed.
         /// </exception>
-        public async Task<(bool, IDictionary<string, ErrorInfo>)> TryLoadPluginAsync(IEnumerable<string> directories)
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="directory"/> is null.
+        /// </exception>
+        public async Task<(bool, IDictionary<string, ErrorInfo>)> TryLoadPluginAsync(IEnumerable<string> directory)
         {
             this.ThrowIfDisposed();
             IDictionary<string, ErrorInfo> taskErrors = null;
-            var task = Task.Run(() => this.TryLoadPlugins(directories, out taskErrors));
+            var task = Task.Run(() => this.TryLoadPlugins(directory, out taskErrors));
             var result = await task;
             return (result, taskErrors);
         }
@@ -235,26 +241,61 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins
         /// <exception cref="ObjectDisposedException">
         ///     This instance is disposed.
         /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     Either <paramref name="directories"/> or one of its elements is null.
+        /// </exception>
         public bool TryLoadPlugins(IEnumerable<string> directories, out IDictionary<string, ErrorInfo> failed)
         {
+            Guard.NotNull(directories, nameof(directories));
+            foreach (string dir in directories)
+            {
+                Guard.NotNull(dir, nameof(directories));
+            }
+            
+            failed = new Dictionary<string, ErrorInfo>();
+
+            if (!directories.Any())
+            {
+                return true;
+            }
+
             this.ThrowIfDisposed();
             lock (this.mutex)
             {
-                failed = new Dictionary<string, ErrorInfo>();
+                int nLoaded = 0;
+
                 var oldPlugins = new HashSet<ProcessingSourceReference>(this.extensionRoot.ProcessingSources);
                 foreach (var dir in directories)
                 {
+                    ErrorInfo emptyErrorInfo = new ErrorInfo(ErrorCodes.InvalidArgument, ErrorCodes.InvalidArgument.Description)
+                    {
+                        Target = dir,
+                    };
+
+                    Guard.NotNull(dir, nameof(directories));
+                    
+                    if (string.IsNullOrWhiteSpace(dir))
+                    {
+                        failed.Add(dir, emptyErrorInfo);
+                        continue;
+                    }
+                    
                     if (!this.extensionDiscovery.ProcessAssemblies(dir, out var error))
                     {
                         failed.Add(dir, error);
                         continue;
                     }
                 }
-
-                // TODO: this does redundant work re-finalizing processing sources
-                // loaded by previous calls to this method. The extension repository
-                // should get refactored to avoid this redundant work.
-                this.extensionRoot.FinalizeDataExtensions();
+                
+                // If nothing was able to be loaded above, skip finalizing 
+                if (this.extensionRoot.IsLoaded)
+                {
+                    // TODO: this does redundant work re-finalizing processing sources
+                    // loaded by previous calls to this method. The extension repository
+                    // should get refactored to avoid this redundant work.
+                    
+                    this.extensionRoot.FinalizeDataExtensions();
+                }
 
                 foreach (var source in this.extensionRoot.ProcessingSources.Except(oldPlugins))
                 {
@@ -271,6 +312,9 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins
         /// </summary>
         /// <exception cref="ObjectDisposedException">
         ///     This instance is disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     Either <paramref name="directories"/> or one of its elements is null.
         /// </exception>
         public Task<(bool, IDictionary<string, ErrorInfo>)> TryLoadPluginsAsync(IEnumerable<string> directories)
         {


### PR DESCRIPTION
1. Ensures we do not crash when loading an empty set of directories
2. Validates given strings are not null
3. Return an `InvalidArgument` `ErrorCode` if a specified directory consists only of whitespace