### PR TITLE
SDK.Runtime.NetCoreApp supports net6.0.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Performance.SDK.Runtime.NetCoreApp</AssemblyName>
     <RootNamespace>Microsoft.Performance.SDK.Runtime.NetCoreApp</RootNamespace>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
As netcoreapp3.1 is no longer supported, we add support for .net6.