### PR TITLE
Update projects to use .net6/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.x'
     - name: Setup NBGV
       uses: dotnet/nbgv@v0.4
       with:
-        toolVersion: 3.3.37
+        toolVersion: 3.5.119
     - name: Restore dependencies
       run: dotnet restore "${{ github.workspace }}/src/SDK.sln"
     - name: Build solution

--- a/.github/workflows/main_build_status.yml
+++ b/.github/workflows/main_build_status.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.x'
     - name: Setup NBGV
       uses: dotnet/nbgv@v0.4
       with:
-        toolVersion: 3.3.37
+        toolVersion: 3.5.119
     - name: Restore dependencies
       run: dotnet restore "${{ github.workspace }}/src/SDK.sln"
     - name: Build solution

--- a/.github/workflows/main_tests_status.yml
+++ b/.github/workflows/main_tests_status.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.x'
     - name: Setup NBGV
       uses: dotnet/nbgv@v0.4
       with:
-        toolVersion: 3.3.37
+        toolVersion: 3.5.119
     - name: Restore dependencies
       run: dotnet restore "${{ github.workspace }}/src/SDK.sln"
     - name: Build solution

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+	  <PackageReference Update="MSTest.TestAdapter" Version="2.2.7" />
+	  <PackageReference Update="MSTest.TestFramework" Version="2.2.7" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
     <Content Remove="Plugins\MockProcessingSources\**\*.*" />
   </ItemGroup>
 

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Performance.SDK.Runtime.NetCoreApp</AssemblyName>
     <RootNamespace>Microsoft.Performance.SDK.Runtime.NetCoreApp</RootNamespace>
     <Authors>Microsoft</Authors>

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Microsoft.Performance.SDK.Runtime.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Microsoft.Performance.SDK.Runtime.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Performance.SDK.Tests/Microsoft.Performance.SDK.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Tests/Microsoft.Performance.SDK.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Performance.Testing/Microsoft.Performance.Testing.csproj
+++ b/src/Microsoft.Performance.Testing/Microsoft.Performance.Testing.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests.Driver/Microsoft.Performance.Toolkit.Engine.Tests.Driver.csproj
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests.Driver/Microsoft.Performance.Toolkit.Engine.Tests.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/Microsoft.Performance.Toolkit.Engine.Tests.csproj
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/Microsoft.Performance.Toolkit.Engine.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
netcoreapp3.1 projects now support net6.0.
test projects are moved completely to net6.0.

