### PR TITLE
Surface discoverer in AvailablePlugin

### DIFF
--- a/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core.NuGet/NuGetPluginDiscoverer.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core.NuGet/NuGetPluginDiscoverer.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core.NuGet
                         packageMetadata.Title,
                         packageMetadata.Description,
                         this.pluginSource.Uri,
-                        Guid.Parse(PluginManagerConstants.NuGet));
+                        Guid.Parse(PluginManagerConstants.NuGet),
+                        this);
 
                     result.Add(plugin);
                 }
@@ -105,7 +106,8 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core.NuGet
                         packageMetadata.Title,
                         packageMetadata.Description,
                         this.pluginSource.Uri,
-                        Guid.Parse(PluginManagerConstants.NuGet));
+                        Guid.Parse(PluginManagerConstants.NuGet),
+                        this);
 
                 result.Add(plugin);
             }

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/AvailablePlugin.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/AvailablePlugin.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core
             string displayName,
             string description,
             Uri packageUri,
-            Guid fetcherTypeId) 
+            Guid fetcherTypeId,
+            IPluginDiscoverer discoverer) 
         {
             this.Identity = pluginIdentity;
             this.PluginSource = pluginSource;
@@ -28,6 +29,7 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core
             this.Description = description;
             this.PluginPackageUri = packageUri;
             this.FetcherTypeId = fetcherTypeId;
+            this.PluginDiscoverer = discoverer;
         }
 
         /// <summary>
@@ -59,5 +61,10 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core
         ///     Gets the Guid which identifies the platform (NuGet, Github etc.) the plugin package is hosted on.
         /// </summary>
         public Guid FetcherTypeId { get; }
+
+        /// <summary>
+        ///     Gets the discoverer that this plugin is discovered by.
+        /// </summary>
+        public IPluginDiscoverer PluginDiscoverer { get; }
     }
 }

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/Manager/IPluginsManager.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/Manager/IPluginsManager.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Performance.Toolkit.PluginsManager.Core.Discovery;
 using Microsoft.Performance.Toolkit.PluginsManager.Core.Extensibility;
+using Microsoft.Performance.Toolkit.PluginsManager.Core.Packaging.Metadata;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,5 +81,21 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core.Manager
         ///     The directory to load resource assemblies from.
         /// </param>
         void LoadAdditionalPluginResources(string directory);
+
+        /// <summary>
+        ///     Gets the metadata of an available plugin.
+        /// </summary>
+        /// <param name="availablePlugin">
+        ///     A discovered plugin.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     Signals that the caller wishes to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     The metadata of a plugin.
+        /// </returns>
+        Task<PluginMetadata> GetAvailablePluginMetadata(
+            AvailablePlugin availablePlugin,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/Manager/PluginsManager.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.PluginsManager.Core/Manager/PluginsManager.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.Toolkit.PluginsManager.Core.Discovery;
 using Microsoft.Performance.Toolkit.PluginsManager.Core.Extensibility;
+using Microsoft.Performance.Toolkit.PluginsManager.Core.Packaging.Metadata;
 using Microsoft.Performance.Toolkit.PluginsManager.Core.Transport;
 
 namespace Microsoft.Performance.Toolkit.PluginsManager.Core.Manager
@@ -129,20 +130,18 @@ namespace Microsoft.Performance.Toolkit.PluginsManager.Core.Manager
 
             if (this.PluginSources.Contains(availablePlugin.PluginSource))
             {
-                foreach (IPluginDiscoverer discoverer in this.discoverersManager.GetDiscoverersFromSource(availablePlugin.PluginSource).AsQueryable())
-                {
-                    IReadOnlyCollection<AvailablePlugin> plugins = await discoverer.DiscoverAllVersionsOfPlugin(
-                        availablePlugin.Identity,
-                        cancellationToken);
-
-                    if (plugins.Any())
-                    {
-                        return plugins;
-                    }
-                }
+                return await availablePlugin.PluginDiscoverer.DiscoverAllVersionsOfPlugin(
+                    availablePlugin.Identity,
+                    cancellationToken);
             }
-
+            
             return Array.Empty<AvailablePlugin>();
+        }
+
+        /// <inheritdoc />
+        public async Task<PluginMetadata> GetAvailablePluginMetadata(AvailablePlugin availablePlugin, CancellationToken cancellationToken)
+        {
+            return await availablePlugin.PluginDiscoverer.GetPluginMetadataAsync(availablePlugin.Identity, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Stores which discoverer the AvailablePlugin is created from. This way it supports getting other versions and metadata directly from this discoverer without having to go back and look for the right discoverer.