### PR TITLE
Delay creation of source processing session.

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -45,8 +45,9 @@ namespace Microsoft.Performance.SDK.Processing
 
             this.SourceParser = sourceParser;
 
+            var sourceSessionFactory = applicationEnvironment.SourceSessionFactory;
             this.sourceProcessingSession = new Lazy<ISourceProcessingSession<T, TContext, TKey>>(
-                () => this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this),
+                () => sourceSessionFactory.CreateSourceSession(this),
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 

--- a/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CustomDataProcessorWithSourceParser.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Performance.SDK.Processing
           ICustomDataProcessorWithSourceParser<T, TContext, TKey>
           where T : IKeyedDataType<TKey>
     {
+        private readonly Lazy<ISourceProcessingSession<T, TContext, TKey>> sourceProcessingSession;
+
         /// <summary>
         /// This constructor will setup the data processor so that it can use the data extension framework - allowing
         /// table and data cookers both internally and external to this plugin.
@@ -42,7 +44,10 @@ namespace Microsoft.Performance.SDK.Processing
             Guard.NotNull(sourceParser, nameof(sourceParser));
 
             this.SourceParser = sourceParser;
-            this.SourceProcessingSession = this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this);
+
+            this.sourceProcessingSession = new Lazy<ISourceProcessingSession<T, TContext, TKey>>(
+                () => this.ApplicationEnvironment.SourceSessionFactory.CreateSourceSession(this),
+                LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
         /// <summary>
@@ -64,7 +69,8 @@ namespace Microsoft.Performance.SDK.Processing
         public ISourceParser<T, TContext, TKey> SourceParser { get; }
 
         /// <inheritdoc cref="ICustomDataProcessorWithSourceParser{T,TContext,TKey}"/>
-        public ISourceProcessingSession<T, TContext, TKey> SourceProcessingSession { get; }
+        public ISourceProcessingSession<T, TContext, TKey> SourceProcessingSession
+            => this.sourceProcessingSession.Value;
 
         /// <inheritdoc cref="ICustomDataProcessorWithSourceParser"/>
         public string SourceParserId => this.SourceParser.Id;


### PR DESCRIPTION
'this' is passed into CreateSourceSession, but this was being called from the constructor of an abstract class. If the source processing session factory, or the implementation of that interface, relies on something in the class to be initialized, then this would break.

Making the creation of the source processing session lazy means that we don't introduce any breaking changes while allowing more flexibility in the generation/implementation of ISourceProcessingSession.