### PR TITLE
Add support for plugins manager resources reflection and loading

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/PluginManagerResourceReference.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/PluginManagerResourceReference.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using Microsoft.Performance.SDK.Runtime;
+using Microsoft.Performance.Toolkit.Plugins.Core.Extensibility;
+
+namespace Microsoft.Performance.SDK.Runtime
+{
+    /// <summary>
+    ///     Creates a <see cref="AssemblyTypeReferenceWithInstance{T, Derived}"/> 
+    ///     where T is <see cref="IPluginManagerResource"/> and Derived is <see cref="PluginManagerResourceReference"/>.
+    /// </summary>
+    public sealed class PluginManagerResourceReference
+         : AssemblyTypeReferenceWithInstance<IPluginManagerResource, PluginManagerResourceReference>
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PluginManagerResourceReference"/> class.
+        /// </summary>
+        /// <param name="type">
+        ///     The <see cref="Type"/> of instance being referenced by this instance.
+        /// </param>
+        /// <param name="metadata">
+        ///     The <see cref="IPluginManagerResource"/> metadata.
+        /// </param>
+        public PluginManagerResourceReference(
+            Type type,
+            PluginManagerResourceAttribute metadata)
+            : base(type)
+        {
+            Guard.NotNull(type, nameof(type));
+            Guard.NotNull(metadata, nameof(metadata));
+
+            this.Guid = metadata.Guid;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PluginManagerResourceReference"/>
+        ///     class with the given instance.
+        /// </summary>
+        /// <param name="instance">
+        ///     An existing instance of <see cref="IPluginManagerResource"/>
+        /// </param>
+        public PluginManagerResourceReference(IPluginManagerResource instance)
+            : base(instance.GetType(), () => instance)
+        {
+            Guard.NotNull(instance, nameof(instance));
+
+            this.Guid = instance.TryGetGuid();
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PluginManagerResourceReference"/>
+        ///     class as a copy of the given instance.
+        /// </summary>
+        /// <param name="other">
+        ///      The instance from which to make a copy.
+        /// </param>
+        public PluginManagerResourceReference(PluginManagerResourceReference other)
+            : base(other.Type)
+        {
+            Guard.NotNull(other, nameof(other));
+
+            other.ThrowIfDisposed();
+
+            this.Guid = other.Guid;
+        }
+
+        /// <summary>
+        ///     Tries to create an instance of <see cref="PluginManagerResourceReference"/> 
+        ///     based on the <paramref name="candidateType"/>.
+        /// </summary>
+        /// <param name="candidateType">
+        ///      Candidate <see cref="Type"/> for the <see cref="PluginManagerResourceReference"/>
+        /// </param>
+        /// <param name="reference">
+        ///      Out <see cref="PluginManagerResourceReference"/>
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if the <paramref name="candidateType"/> is valid and can create a instance of 
+        ///     <see cref="PluginManagerResourceReference"/>; <c>false</c> otherwise.
+        /// </returns>
+        public static bool TryCreateReference(
+            Type candidateType,
+            out PluginManagerResourceReference reference)
+        {
+            Guard.NotNull(candidateType, nameof(candidateType));
+
+            reference = null;
+            if (IsValidType(candidateType))
+            {
+                if (candidateType.TryGetEmptyPublicConstructor(out ConstructorInfo constructor))
+                {
+                    PluginManagerResourceAttribute metadataAttribute = candidateType.GetCustomAttribute<PluginManagerResourceAttribute>();
+                    if (metadataAttribute != null)
+                    {
+                        reference = new PluginManagerResourceReference(
+                            candidateType,
+                            metadataAttribute);
+                    }
+                }
+            }
+
+            return reference != null;
+        }
+
+        /// <summary>
+        ///     Gets the Guid of this <see cref="IPluginManagerResource"/>.
+        /// </summary>
+        public Guid Guid { get; }
+
+        /// <inheritdoc />
+        public override PluginManagerResourceReference CloneT()
+        {
+            return new PluginManagerResourceReference(this);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is PluginManagerResourceReference other &&
+                this.Guid.Equals(other.Guid);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return this.Guid.GetHashCode();
+        }
+    }
+}

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourceLoader.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourceLoader.cs
@@ -7,12 +7,13 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
 {
     /// <summary>
     ///     Represents a loader that facilitates the loading of <see cref="IPluginManagerResource"/>s.
+    ///     to its consumers.
     /// </summary>
     public interface IPluginManagerResourceLoader
     {
         /// <summary>
         ///     Tries to load <see cref="IPluginManagerResource"/>s from the given directory
-        ///     to the subscribed <see cref="IPluginManagerResourceRepository{T}">s.
+        ///     to the subscribed <see cref="IPluginManagerResourcesConsumer">s.
         /// <param name="directory">
         ///     The directoty to load resouces from.
         /// </param>
@@ -23,31 +24,27 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
         bool TryLoad(string directory);
 
         /// <summary>
-        ///     Registers a <see cref="IPluginManagerResourceRepository{T}"/> to receive all future loaded resources.
+        ///     Registers a <see cref="IPluginManagerResourcesConsumer}"/> to receive all future loaded resources
+        ///     and sends all previously loaded plugins to its <see cref="IPluginManagerResourcesConsumer.OnNewResourcesLoaded(
+        ///     System.Collections.Generic.IEnumerable{SDK.Runtime.PluginManagerResourceReference})"/> handler.
         /// </summary>
-        /// <typeparam name="T">
-        ///     The type of the resources stored in the given <paramref name="resourceRepository"/>.
-        /// </typeparam>
-        /// <param name="resourceRepository">
-        ///     The <see cref="IPluginManagerResourceRepository{T}"/> to be registered to this loader.
+        /// <param name="consumer">
+        ///     The <see cref="IPluginManagerResourcesConsumer"/> to be registered to this loader.
         /// </param>
         /// <returns>
-        ///     Whether or not the <paramref name="resourceRepository"/> is successfully subscribed.
+        ///     Whether or not the <paramref name="consumer"/> is successfully subscribed.
         /// </returns>
-        bool Subscribe<T>(IPluginManagerResourceRepository<T> resourceRepository) where T : class, IPluginManagerResource;
+        bool Subscribe(IPluginManagerResourcesConsumer consumer);
 
         /// <summary>
-        ///     Unregisters a <see cref="IPluginManagerResourceRepository{T}"/> from receiving future loaded resources.
+        ///     Unregisters a <see cref="IPluginManagerResourcesConsumer"/> from receiving future loaded resources.
         /// </summary>
-        /// <typeparam name="T">
-        ///     The type of the resources stored in the given <paramref name="resourceRepository"/>.
-        /// </typeparam>
-        /// <param name="resourceRepository">
-        ///     The <see cref="IPluginManagerResourceRepository{T}"/> to be unregistered from this loader.
+        /// <param name="consumer">
+        ///     The <see cref="IPluginManagerResourcesConsumer"/> to be unregistered from this loader.
         /// </param>
         /// <returns>
-        ///     Whether or not the <paramref name="resourceRepository"/> is successfully unsubscribed.
+        ///     Whether or not the <paramref name="consumer"/> is successfully unsubscribed.
         /// </returns>
-        bool Unsubscribe<T>(IPluginManagerResourceRepository<T> resourceRepository) where T : class, IPluginManagerResource;
+        bool Unsubscribe(IPluginManagerResourcesConsumer consumer);
     }
 }

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourceRepository.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourceRepository.cs
@@ -8,26 +8,18 @@ using Microsoft.Performance.Toolkit.Plugins.Core.Extensibility;
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
 {
     /// <summary>
-    ///     Represents a repository for storing a collection of <see cref=" IPluginManagerResource"/>.
+    ///     Represents a repository for storing a collection of <see cref=" IPluginManagerResource"/> of type <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">
     ///     The type of the resources stored in this repository.
     /// </typeparam>
     public interface IPluginManagerResourceRepository<T>
-        where T : class, IPluginManagerResource
+        where T : IPluginManagerResource
     {
         /// <summary>
-        ///     Gets all plugin resources contained in this repository.
+        ///     Gets all plugins manager resources contained in this repository.
         /// </summary>
-        IEnumerable<T> PluginResources { get; }
-
-        /// <summary>
-        ///     Adds new resources and notifies when they are added to the repository.
-        /// </summary>
-        /// <param name="loadedResources">
-        ///     The newly loaded resources.
-        /// </param>
-        void OnNewResourcesLoaded(IEnumerable<T> loadedResources);
+        IEnumerable<T> Resources { get; }
 
         /// <summary>
         ///    Raised when new resources are added to this repository.

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourcesConsumer.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/IPluginManagerResourcesConsumer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Performance.SDK.Runtime;
+
+namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
+{
+    /// <summary>
+    ///     Process a collection of <see cref="PluginManagerResourceReference"/> provided by the
+    ///     <see cref="IPluginManagerResourceLoader"/>.
+    /// </summary>
+    public interface IPluginManagerResourcesConsumer
+    {
+        /// <summary>
+        ///    Called when new resources are loaded.
+        /// </summary>
+        /// <param name="loadedResources">
+        ///    The newly loaded <see cref="PluginManagerResourceReference"/> from the <see cref="IPluginManagerResourceLoader"/>.
+        /// </param>
+        void OnNewResourcesLoaded(IEnumerable<PluginManagerResourceReference> loadedResources);
+    }
+}

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/NewResourcesEventArgs.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/NewResourcesEventArgs.cs
@@ -13,20 +13,22 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
     /// <typeparam name="T">
     ///     Resource type.
     /// </typeparam>
-    public class NewResourcesEventArgs<T> : EventArgs where T : IPluginManagerResource
+    public class NewResourcesEventArgs<T>
+        : EventArgs
+        where T : IPluginManagerResource
     {
         /// <summary>
         ///     Initializes a new <see cref="NewResourcesEventArgs"/>.
         /// </summary>
-        /// <param name="newPluginResources"></param>
-        public NewResourcesEventArgs(IEnumerable<T> newPluginResources)
+        /// <param name="newPluginManagerResources"></param>
+        public NewResourcesEventArgs(IEnumerable<T> newPluginManagerResources)
         {
-            this.NewPluginResources = newPluginResources;
+            this.NewPluginManagerResources = newPluginManagerResources;
         }
 
         /// <summary>
         ///     A collection of newly added resources.
         /// </summary>
-        public IEnumerable<T> NewPluginResources { get; }
+        public IEnumerable<T> NewPluginManagerResources { get; }
     }
 }

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginManagerResourceLoader.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginManagerResourceLoader.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Runtime;
+using Microsoft.Performance.SDK.Runtime.Discovery;
+
+namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
+{
+    /// <inheritdoc />
+    public sealed class PluginManagerResourceLoader
+        : IPluginManagerResourceLoader
+    {
+        private readonly object mutex = new object();
+        private readonly AssemblyExtensionDiscovery extensionDiscovery;
+
+        private readonly HashSet<IPluginManagerResourcesConsumer> subscribers;
+        private readonly PluginManagerResourceReflector resourcesReflector;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PluginManagerResourceLoader"/>
+        /// </summary>
+        /// <param name="assemblyLoader">
+        ///     Loads assemblies.
+        /// </param>
+        /// <param name="validatorFactory">
+        ///     Creates <see cref="IPreloadValidator"/> instances to make
+        ///     sure candidate assemblies are valid to even try to load.
+        ///     The function takes a collection of file names and returns
+        ///     a new <see cref="IPreloadValidator"/> instance. This function
+        ///     should never return <c>null</c>.
+        /// </param>
+        public PluginManagerResourceLoader(
+            IAssemblyLoader assemblyLoader,
+            Func<IEnumerable<string>, IPreloadValidator> validatorFactory)
+        {
+            this.subscribers = new HashSet<IPluginManagerResourcesConsumer>();
+            this.extensionDiscovery = new AssemblyExtensionDiscovery(assemblyLoader, validatorFactory);
+            this.resourcesReflector = new PluginManagerResourceReflector(this.extensionDiscovery);
+        }
+        
+        /// <inheritdoc />
+        public bool TryLoad(string directory)
+        {
+            Guard.NotNull(directory, nameof(directory));
+
+            lock (this.mutex)
+            {
+                var oldResources = new HashSet<PluginManagerResourceReference>(this.resourcesReflector.AllResources);
+
+                bool success = this.extensionDiscovery.ProcessAssemblies(directory, out ErrorInfo error);
+
+                IEnumerable<PluginManagerResourceReference> newResources = this.resourcesReflector.AllResources.Except(oldResources);
+                NotifyResourceLoaded(newResources);
+                
+                return success;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Subscribe(IPluginManagerResourcesConsumer consumer)
+        {
+            Guard.NotNull(consumer, nameof(consumer));
+
+            lock (this.mutex)
+            {
+                if (this.subscribers.Contains(consumer))
+                {
+                    return false;
+                }
+
+                // Notify consumer of exisiting resources.
+                consumer.OnNewResourcesLoaded(this.resourcesReflector.AllResources);
+                
+                this.subscribers.Add(consumer);
+
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Unsubscribe(IPluginManagerResourcesConsumer consumer)
+        {
+            Guard.NotNull(consumer, nameof(consumer));
+
+            lock (this.mutex)
+            {
+                return this.subscribers.Remove(consumer);
+            }
+        }
+        
+        private void NotifyResourceLoaded(IEnumerable<PluginManagerResourceReference> resources)
+        {
+            foreach (IPluginManagerResourcesConsumer subscriber in this.subscribers)
+            {
+                subscriber.OnNewResourcesLoaded(resources);
+            }
+        }
+    }
+}

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginManagerResourceReflector.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginManagerResourceReflector.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Performance.SDK.Runtime;
+using Microsoft.Performance.SDK.Runtime.Discovery;
+
+namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
+{
+    /// <summary>
+    ///     This class registers to with a provider to receive Types that might be
+    ///     <see cref="Plugins.Core.Extensibility.IPluginManagerResource"/>s.
+    ///     The types are evaluated and stored as a <see cref="PluginManagerResourceReference"/> when applicable.
+    /// </summary>
+    public sealed class PluginManagerResourceReflector
+        : IExtensionTypeObserver
+    {
+        private readonly Dictionary<Type, PluginManagerResourceReference> loadedResources;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PluginManagerResourceReflector"/>
+        ///     class, registering to receive updates from the given <see cref="IExtensionTypeProvider"/>
+        /// </summary>
+        /// <param name="extensionTypeProvider">
+        ///     The object doing extension discovery.
+        /// </param>
+        public PluginManagerResourceReflector(IExtensionTypeProvider extensionTypeProvider)
+        {
+            this.loadedResources = new Dictionary<Type, PluginManagerResourceReference>();
+            extensionTypeProvider.RegisterTypeConsumer(this);
+        }
+
+        /// <inheritdoc />
+        public void ProcessType(Type type, string sourceName)
+        {
+            if (PluginManagerResourceReference.TryCreateReference(type, out PluginManagerResourceReference reference))
+            {
+                try
+                {
+                    this.loadedResources.Add(type, reference);
+                }
+                catch { }
+            }
+        }
+
+        /// <inheritdoc />
+        public void DiscoveryStarted()
+        {
+        }
+
+        /// <inheritdoc />
+        public void DiscoveryComplete()
+        {
+        }
+
+        /// <summary>
+        ///     Gets all loaded <see cref="PluginManagerResourceReference"/>s observed by this object.
+        /// </summary>
+        public IEnumerable<PluginManagerResourceReference> AllResources
+        {
+            get
+            {
+                return this.loadedResources.Values;
+            }
+        }
+    }
+}

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/IPluginsManager.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/IPluginsManager.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         /// </param>
         void LoadAdditionalPluginResources(string directory);
 
-
         /// <summary>
         ///     Gets all available versions of a plugin by discovering from all plugin sources.
         /// </summary>

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/PluginsManager.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/PluginsManager.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Toolkit.Plugins.Core;
 using Microsoft.Performance.Toolkit.Plugins.Core.Discovery;
 using Microsoft.Performance.Toolkit.Plugins.Core.Extensibility;
@@ -34,6 +35,34 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         private readonly PluginRegistry pluginRegistry;
 
         private readonly string installationDir;
+        private readonly ILogger logger;
+
+        /// <summary>
+        ///     Initializes a plugin manager instance with a default <see cref="ILogger"/>.
+        /// </summary>
+        /// <param name="discovererProviderRepo">
+        ///     A repository of discoverer providers.
+        /// </param>
+        /// <param name="fetcherRepo">
+        ///     A repository of plugin fetchers.
+        /// </param>
+        /// <param name="resourceLoader">
+        ///     A loader that can load additional <see cref="IPluginManagerResource"/>s at run time.
+        /// </param>
+        /// <param name="pluginRegistry">
+        ///     A plugin registry this plugin manager will interact with.
+        /// </param>
+        /// <param name="installationDir">
+        ///     The directory where the plugins will be installed to.
+        /// </param>
+        public PluginsManager(
+            IPluginManagerResourceRepository<IPluginDiscovererProvider> discovererProviderRepo,
+            IPluginManagerResourceRepository<IPluginFetcher> fetcherRepo,
+            IPluginManagerResourceLoader resourceLoader,
+            PluginRegistry pluginRegistry,
+            string installationDir) : this(discovererProviderRepo, fetcherRepo, resourceLoader, pluginRegistry, installationDir, Logger.Create<PluginsManager>())
+        {
+        }
 
         /// <summary>
         ///     Initializes a plugin manager instance.
@@ -47,12 +76,22 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         /// <param name="resourceLoader">
         ///     A loader that can load additional <see cref="IPluginManagerResource"/>s at run time.
         /// </param>
+        /// <param name="pluginRegistry">
+        ///     A plugin registry this plugin manager will interact with.
+        /// </param>
+        /// <param name="installationDir">
+        ///     The directory where the plugins will be installed to.
+        /// </param>
+        /// <param name="logger">
+        ///     A logger used to log messages.
+        /// </param>
         public PluginsManager(
             IPluginManagerResourceRepository<IPluginDiscovererProvider> discovererProviderRepo,
             IPluginManagerResourceRepository<IPluginFetcher> fetcherRepo,
             IPluginManagerResourceLoader resourceLoader,
             PluginRegistry pluginRegistry,
-            string installationDir)
+            string installationDir,
+            ILogger logger)
         {
             this.resourceLoader = resourceLoader;
 
@@ -71,6 +110,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
             this.pluginRegistry = pluginRegistry;
             this.pluginInstaller = new PluginInstaller(pluginRegistry);
             this.installationDir = installationDir;
+            this.logger = logger;
         }
 
         /// <inheritdoc />

--- a/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/PluginsManager.cs
+++ b/src/PluginsManager/Microsoft.Performance.Toolkit.Plugins.Runtime/Manager/PluginsManager.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
     {
         private readonly IPluginManagerResourceLoader resourceLoader;
 
-        private readonly IPluginManagerResourceRepository<IPluginDiscovererProvider> discovererProviderRepository;
-        private readonly IPluginManagerResourceRepository<IPluginFetcher> pluginFetcherRepository;
+        private readonly PluginManagerResourceRepository<IPluginDiscovererProvider> discovererRepository;
+        private readonly PluginManagerResourceRepository<IPluginFetcher> fetcherRepository;
 
-        private readonly DiscoverersManager discoverersManager;
-
+        private readonly DiscovererSourcesManager discovererSourcesManager;
+        
         private readonly PluginInstaller pluginInstaller;
         private readonly PluginRegistry pluginRegistry;
 
@@ -40,11 +40,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         /// <summary>
         ///     Initializes a plugin manager instance with a default <see cref="ILogger"/>.
         /// </summary>
-        /// <param name="discovererProviderRepo">
-        ///     A repository of discoverer providers.
+        /// <param name="discovererProviders">
+        ///     A collection of discoverer providers.
         /// </param>
-        /// <param name="fetcherRepo">
-        ///     A repository of plugin fetchers.
+        /// <param name="fetchers">
+        ///     A collection of fetchers.
         /// </param>
         /// <param name="resourceLoader">
         ///     A loader that can load additional <see cref="IPluginManagerResource"/>s at run time.
@@ -56,22 +56,23 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         ///     The directory where the plugins will be installed to.
         /// </param>
         public PluginsManager(
-            IPluginManagerResourceRepository<IPluginDiscovererProvider> discovererProviderRepo,
-            IPluginManagerResourceRepository<IPluginFetcher> fetcherRepo,
+            IEnumerable<IPluginDiscovererProvider> discovererProviders,
+            IEnumerable<IPluginFetcher> fetchers,
             IPluginManagerResourceLoader resourceLoader,
             PluginRegistry pluginRegistry,
-            string installationDir) : this(discovererProviderRepo, fetcherRepo, resourceLoader, pluginRegistry, installationDir, Logger.Create<PluginsManager>())
+            string installationDir) 
+            : this(discovererProviders, fetchers, resourceLoader, pluginRegistry, installationDir, Logger.Create<PluginsManager>())
         {
         }
 
         /// <summary>
         ///     Initializes a plugin manager instance.
         /// </summary>
-        /// <param name="discovererProviderRepo">
-        ///     A repository of discoverer providers.
+        /// <param name="discovererProviders">
+        ///     A collection of discoverer providers.
         /// </param>
-        /// <param name="fetcherRepo">
-        ///     A repository of plugin fetchers.
+        /// <param name="fetchers">
+        ///     A collection of fetchers.
         /// </param>
         /// <param name="resourceLoader">
         ///     A loader that can load additional <see cref="IPluginManagerResource"/>s at run time.
@@ -86,52 +87,47 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
         ///     A logger used to log messages.
         /// </param>
         public PluginsManager(
-            IPluginManagerResourceRepository<IPluginDiscovererProvider> discovererProviderRepo,
-            IPluginManagerResourceRepository<IPluginFetcher> fetcherRepo,
+            IEnumerable<IPluginDiscovererProvider> discovererProviders,
+            IEnumerable<IPluginFetcher> fetchers,
             IPluginManagerResourceLoader resourceLoader,
             PluginRegistry pluginRegistry,
             string installationDir,
             ILogger logger)
         {
             this.resourceLoader = resourceLoader;
+            this.discovererRepository = new PluginManagerResourceRepository<IPluginDiscovererProvider>(discovererProviders);
+            this.fetcherRepository = new PluginManagerResourceRepository<IPluginFetcher>(fetchers);
 
-            this.discovererProviderRepository = discovererProviderRepo;
+            this.discovererSourcesManager = new DiscovererSourcesManager(this.discovererRepository, new DiscoverersFactory());
 
-            this.discoverersManager = new DiscoverersManager(
-                this.discovererProviderRepository,
-                new DiscoverersFactory());
-
-
-            this.pluginFetcherRepository = fetcherRepo;
-
-            this.resourceLoader.Subscribe(this.discovererProviderRepository);
-            this.resourceLoader.Subscribe(this.pluginFetcherRepository);
+            this.resourceLoader.Subscribe(this.discovererRepository);
+            this.resourceLoader.Subscribe(this.fetcherRepository);
 
             this.pluginRegistry = pluginRegistry;
             this.pluginInstaller = new PluginInstaller(pluginRegistry);
             this.installationDir = installationDir;
             this.logger = logger;
         }
-
+        
         /// <inheritdoc />
         public IEnumerable<PluginSource> PluginSources
         {
             get
             {
-                return this.discoverersManager.PluginSources;
+                return this.discovererSourcesManager.PluginSources;
             }
         }
 
         /// <inheritdoc />
         public void ClearPluginSources()
         {
-            this.discoverersManager.ClearPluginSources();
+            this.discovererSourcesManager.ClearPluginSources();
         }
 
         /// <inheritdoc />
         public void AddPluginSources(IEnumerable<PluginSource> sources)
         {
-            this.discoverersManager.AddPluginSources(sources);
+            this.discovererSourcesManager.AddPluginSources(sources);
         }
 
         /// <inheritdoc />
@@ -188,7 +184,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
                 throw new InvalidOperationException("Plugin source needs to be added to the manager before being performed discovery on.");
             }
 
-            IPluginDiscoverer[] discoverers = this.discoverersManager.GetDiscoverersFromSource(source).ToArray();
+            IPluginDiscoverer[] discoverers = this.discovererSourcesManager.GetDiscoverersFromSource(source).ToArray();
 
             var tasks = Task.WhenAll(discoverers.Select(d => d.DiscoverPluginsLatestAsync(cancellationToken)));
             try
@@ -263,7 +259,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
             PluginIdentity pluginIdentity,
             CancellationToken cancellationToken)
         {
-            IPluginDiscoverer[] discoverers = this.discoverersManager.GetDiscoverersFromSource(source).ToArray();
+            IPluginDiscoverer[] discoverers = this.discovererSourcesManager.GetDiscoverersFromSource(source).ToArray();
             var tasks = Task.WhenAll(discoverers.Select(d => d.DiscoverAllVersionsOfPlugin(pluginIdentity, cancellationToken)));
 
             try
@@ -381,11 +377,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Manager
             }
         }
 
-        private async Task<IPluginFetcher> GetPluginFetcher(AvailablePluginInfo availablePlugin)
+        private async Task<IPluginFetcher> GetPluginFetcher(AvailablePluginInfo availablePluginInfo)
         {
-            foreach (IPluginFetcher fetcher in this.pluginFetcherRepository.PluginResources)
+            foreach (IPluginFetcher fetcher in this.fetcherRepository.Resources)
             {
-                if (fetcher.TryGetGuid() == availablePlugin.FetcherResourceId && await fetcher.IsSupportedAsync(availablePlugin))
+                if (fetcher.TryGetGuid() == availablePluginInfo.FetcherResourceId && await fetcher.IsSupportedAsync(availablePluginInfo))
                 {
                     return fetcher;
                 }


### PR DESCRIPTION
- Implement the loader for loading and notifying consumers of additional discoverers and fetchers.
- Refactor the code so that it aligns with existing runtime "plugins loading" pattern. We would want to do some refactoring in the future so that plugin manager resources and plugins loading can use same code paths. 
