### PR TITLE
Remove assemblyVersion.precision from version.json

### DIFF
--- a/src/PluginsSystem/version.json
+++ b/src/PluginsSystem/version.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "0.1-preview",
-  "assemblyVersion": {
-    "precision": "revision"
-  },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$"
   ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
   "pathFilters": [
     ".",
     "!Microsoft.Performance.Toolkit.Plugins.Runtime.Tests",

--- a/src/version.json
+++ b/src/version.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.1",
-  "assemblyVersion": {
-    "precision": "revision"
-  },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$"
   ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
   "pathFilters": [
     ".",
     ":!SDK.sln",


### PR DESCRIPTION
This change will mean any 2 NuGet packages with the same major and minor (e.g. NuGet packages 1.1.1 and 1.1.2) produce binaries with the same DLL versions of 1.1.0.0. This means either DLL will be able to be loaded when a higher-order package requires NuGet package 1.1.*.