### PR TITLE
User/jmaxson/filtered plugin loading

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
@@ -127,34 +127,6 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
 
         [TestMethod]
         [UnitTest]
-        public void ProcessAssemblies_NullDirectoryPath2()
-        {
-            Assert.ThrowsException<ArgumentNullException>(
-                () => this.Discovery.ProcessAssemblies(
-                    (string)null,
-                    false,
-                    null,
-                    null,
-                    false,
-                    out _));
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void ProcessAssemblies_EmptyDirectoryPath()
-        {
-            Assert.ThrowsException<ArgumentException>(
-                () => this.Discovery.ProcessAssemblies(
-                    string.Empty,
-                    false,
-                    null,
-                    null,
-                    false,
-                    out _));
-        }
-
-        [TestMethod]
-        [UnitTest]
         public void ProcessAssemblies_NoObservers()
         {
             this.FindFiles.enumerateFiles = (directory, searchPattern, searchOptions) =>
@@ -167,80 +139,6 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
             var testAssemblyDirectory = Path.GetDirectoryName(testAssembly.GetCodeBaseAsLocalPath());
 
             this.Discovery.ProcessAssemblies(testAssemblyDirectory, out _);
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void ProcessAssemblies_SpecificSearchPattern()
-        {
-            var searchPatterns = new[] { "*.elephant", "*.bananas" };
-            var patternsSearched = new List<string>(searchPatterns.Length);
-
-            this.FindFiles.enumerateFiles = (directory, searchPattern, searchOptions) =>
-            {
-                Assert.IsTrue(
-                    searchPattern == searchPatterns[0] || searchPattern == searchPatterns[1]);
-                patternsSearched.Add(searchPattern);
-                return new List<string>();
-            };
-
-            this.Observers.Add(new TestExtensionObserver());
-
-            RegisterObservers();
-
-            this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, false, searchPatterns, null, false, out _);
-
-            Assert.AreEqual(searchPatterns.Length, patternsSearched.Count);
-            foreach (var pattern in searchPatterns)
-            {
-                Assert.IsTrue(patternsSearched.Contains(pattern));
-            }
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void ProcessAssemblies_SpecifyExclusions()
-        {
-            var exclusions = new[] { "Blawp.dll", };
-
-            this.FindFiles.enumerateFiles =
-                (directory, searchPattern, searchOptions) => new List<string>() { exclusions[0].ToLower(), };
-
-            this.Observers.Add(new TestExtensionObserver());
-
-            RegisterObservers();
-            this.Loader.LoadAssemblyFunc =
-                s =>
-                {
-                    Assert.Fail("LoadAssembly should not be called, the file should be excluded.");
-                    return null;
-                };
-
-            this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, false, null, exclusions, false, out _);
-        }
-
-        [TestMethod]
-        [UnitTest]
-        public void ProcessAssemblies_SpecifyCaseSensitiveExclusions()
-        {
-            var exclusions = new[] { "Blawp.dll", };
-
-            this.FindFiles.enumerateFiles =
-                (directory, searchPattern, searchOptions) => new List<string>() { exclusions[0].ToLower(), };
-
-            this.Observers.Add(new TestExtensionObserver());
-            RegisterObservers();
-
-            bool assemblyLoaded = false;
-            this.Loader.LoadAssemblyFunc = s =>
-            {
-                assemblyLoaded = true;
-                return this.GetType().Assembly;
-            };
-
-            this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, false, null, exclusions, true, out _);
-
-            Assert.IsTrue(assemblyLoaded);
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
@@ -15,16 +15,28 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
     internal class TestFindFiles
         : AssemblyExtensionDiscovery.IFindFiles
     {
-        public Func<string, string, SearchOption, IEnumerable<string>> enumerateFiles;
+        public Func<string, string, IEnumerable<string>> enumerateFiles;
 
-        public IEnumerable<string> EnumerateFiles(string directoryPath, string searchPattern, SearchOption searchOption)
+        public IEnumerable<string> EnumerateFiles(string directoryPath, string searchPattern)
         {
             if (enumerateFiles == null)
             {
                 return new List<string>();
             }
 
-            return this.enumerateFiles.Invoke(directoryPath, searchPattern, searchOption);
+            return this.enumerateFiles.Invoke(directoryPath, searchPattern);
+        }
+
+        public Func<string, IEnumerable<string>> enumerateFolders;
+
+        public IEnumerable<string> EnumerateFolders(string directoryPath)
+        {
+            if (enumerateFolders == null)
+            {
+                return new List<string>();
+            }
+
+            return this.enumerateFolders.Invoke(directoryPath);
         }
     }
 
@@ -129,9 +141,15 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
         [UnitTest]
         public void ProcessAssemblies_NoObservers()
         {
-            this.FindFiles.enumerateFiles = (directory, searchPattern, searchOptions) =>
+            this.FindFiles.enumerateFiles = (directory, searchPattern) =>
             {
                 Assert.Fail("EnumerateFiles shouldn't be called if there are no observers.");
+                return new List<string>();
+            };
+
+            this.FindFiles.enumerateFolders = (directory) =>
+            {
+                Assert.Fail("EnumerateFolders shouldn't be called if there are no observers.");
                 return new List<string>();
             };
 
@@ -143,11 +161,158 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
 
         [TestMethod]
         [UnitTest]
+        public void ProcessAssemblies_SpecifyExclusions()
+        {
+            var exclusions = new[] { "Blawp.dll", };
+
+            string configPath = Path.Combine(this.TestAssemblyDirectory, AssemblyExtensionDiscovery.ExclusionsFilename);
+
+            try
+            {
+                {
+                    using StreamWriter writer = File.CreateText(configPath);
+                    writer.WriteLine(exclusions[0]);
+                    writer.Flush();
+                }
+
+                this.FindFiles.enumerateFiles =
+                    (directory, searchPattern) => new List<string>() { exclusions[0], };
+
+                this.Observers.Add(new TestExtensionObserver());
+
+                RegisterObservers();
+                this.Loader.LoadAssemblyFunc =
+                    s =>
+                    {
+                        Assert.Fail("LoadAssembly should not be called, the file should be excluded.");
+                        return null;
+                    };
+
+                this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, out _);
+            }
+            finally
+            {
+                File.Delete(configPath);
+            }
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void ProcessAssemblies_SpecifyExclusions_DifferingCase()
+        {
+            var exclusions = new[] { "Blawp.dll", };
+
+            string configPath = Path.Combine(this.TestAssemblyDirectory, AssemblyExtensionDiscovery.ExclusionsFilename);
+
+            try
+            {
+                {
+                    using StreamWriter writer = File.CreateText(configPath);
+                    writer.WriteLine(exclusions[0]);
+                    writer.Flush();
+                }
+
+                // exclusions are case sensitive. using ToLower here should make it so that we still receive a callback
+                this.FindFiles.enumerateFiles =
+                    (directory, searchPattern) =>
+                    {
+                        if (searchPattern.EndsWith(".dll"))
+                        {
+                            return new List<string>() { exclusions[0].ToLower(), };
+                        }
+
+                        return new List<string>();
+                    };
+
+                var observer = new TestExtensionObserver();
+                this.Observers.Add(observer);
+
+                var assembly = new FakeAssembly
+                {
+                    TypesToReturn = new[]
+                    {
+                    typeof(int),
+                    typeof(bool),
+                    typeof(string),
+                    },
+                };
+
+                int callbackCount = 0;
+                RegisterObservers();
+                this.Loader.LoadAssemblyFunc =
+                    s =>
+                    {
+                        callbackCount++;
+                        return assembly;
+                    };
+
+                this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, out _);
+
+                Assert.AreEqual(1, callbackCount);
+                Assert.AreEqual(0, observer.ProcessTypes.Count);
+            }
+            finally
+            {
+                File.Delete(configPath);
+            }
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void ProcessAssemblies_SpecifyExclusions_Folder()
+        {
+            var exclusions = new[] { "SubFolder", };
+
+            string configPath = Path.Combine(this.TestAssemblyDirectory, AssemblyExtensionDiscovery.ExclusionsFilename);
+            string subFolderPath = Path.Combine(this.TestAssemblyDirectory, exclusions[0]);
+
+            try
+            {
+                {
+                    using StreamWriter writer = File.CreateText(configPath);
+                    writer.WriteLine(exclusions[0]);
+                    writer.Flush();
+                }
+
+                this.FindFiles.enumerateFiles =
+                    (directory, searchPattern) =>
+                    {
+                        Assert.AreNotEqual(directory, subFolderPath);
+                        return new List<string>();
+                    };
+
+                this.FindFiles.enumerateFolders =
+                    (directory) =>
+                    {
+                        Assert.AreNotEqual(directory, subFolderPath);
+                        return new List<string> { subFolderPath };
+                    };
+
+                this.Observers.Add(new TestExtensionObserver());
+
+                RegisterObservers();
+                this.Loader.LoadAssemblyFunc =
+                    s =>
+                    {
+                        Assert.Fail("LoadAssembly should not be called, the folder should be excluded.");
+                        return null;
+                    };
+
+                this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, out _);
+            }
+            finally
+            {
+                File.Delete(configPath);
+            }
+        }
+
+        [TestMethod]
+        [UnitTest]
         public void ProcessAssemblies_ValidAssemblyThatDoesNotReferenceSdk_TypesNotEnumerated()
         {
             var files = new[] { "Blawp.dll", };
             this.FindFiles.enumerateFiles =
-                (directory, searchPattern, searchOptions) =>
+                (directory, searchPattern) =>
                     searchPattern.EndsWith(".dll")
                         ? new List<string>() { files[0].ToLower(), }
                         : new List<string>();
@@ -179,7 +344,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
         {
             var files = new[] { "Blawp.dll", };
             this.FindFiles.enumerateFiles =
-                (directory, searchPattern, searchOptions) =>
+                (directory, searchPattern) =>
                     searchPattern.EndsWith(".dll")
                         ? new List<string>() { files[0].ToLower(), }
                         : new List<string>();
@@ -205,6 +370,72 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
             this.Loader.LoadAssemblyFunc = s => assembly;
 
             this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, out _);
+
+            CollectionAssert.AreEquivalent(assembly.TypesToReturn, observer.ProcessTypes);
+        }
+
+        [TestMethod]
+        [UnitTest]
+        public void ProcessAssemblies_ValidAssemblyThatReferencesSdk_TypesEnumerated_SubFolder()
+        {
+            const string subFolderName = "SubFolder";
+
+            string subFolderPath = Path.Combine(this.TestAssemblyDirectory, subFolderName);
+            var files = new[] { "Blawp.dll", };
+
+            this.FindFiles.enumerateFiles =
+                (directory, searchPattern) =>
+                {
+                    if (directory == subFolderPath)
+                    {
+                        return searchPattern.EndsWith(".dll")
+                            ? new List<string>() { files[0].ToLower(), }
+                            : new List<string>();
+                    }
+
+                    return new List<string>();
+                };
+
+            this.FindFiles.enumerateFolders =
+                (directory) =>
+                {
+                    if (directory == this.TestAssemblyDirectory)
+                    {
+                        return new List<string> { subFolderPath };
+                    }
+
+                    return new List<string>();
+                };
+
+            var observer = new TestExtensionObserver();
+            this.Observers.Add(observer);
+            RegisterObservers();
+
+            var assembly = new FakeAssembly
+            {
+                ReferencedAssemblies = new[]
+                {
+                    SdkAssembly.Assembly.GetName(),
+                },
+                TypesToReturn = new[]
+                {
+                    typeof(int),
+                    typeof(bool),
+                    typeof(string),
+                },
+            };
+
+            this.Loader.LoadAssemblyFunc = s => assembly;
+
+            try
+            {
+                Directory.CreateDirectory(subFolderPath);
+                this.Discovery.ProcessAssemblies(this.TestAssemblyDirectory, out _);
+            }
+            finally
+            {
+                Directory.Delete(subFolderPath, true);
+            }
 
             CollectionAssert.AreEquivalent(assembly.TypesToReturn, observer.ProcessTypes);
         }

--- a/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Performance.SDK.Processing;
 
@@ -139,86 +138,6 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
         /// </returns>
         public bool ProcessAssemblies(IEnumerable<string> directoryPaths, out ErrorInfo error)
         {
-            return this.ProcessAssemblies(directoryPaths, true, null, null, false, out error);
-        }
-
-        /// <summary>
-        ///     This method scans the given directory for modules to search for extensibility types. All types found will
-        ///     be passed along to any observers.
-        /// </summary>
-        /// <param name="directoryPath">
-        ///     Directory to process.
-        /// </param>
-        /// <param name="includeSubdirectories">
-        ///     Indicates whether subdirectories will be searched.
-        /// </param>
-        /// <param name="searchPatterns">
-        ///     The search patterns to use. If null or empty, defaults to "*.dll" and "*.exe".
-        /// </param>
-        /// <param name="exclusionFileNames">
-        ///     A set of files names to exclude from the search. May be null.
-        /// </param>
-        /// <param name="exclusionsAreCaseSensitive">
-        ///     Indicates whether files names should be treated as case sensitive.
-        /// </param>
-        /// <param name="error">
-        ///     If this method returns <c>false</c>, then this parameter receives
-        ///     information about the error(s) that occurred.
-        /// </param>
-        /// <returns>
-        ///     Whether or not all assemblies in the given directory were processed successfully.
-        /// </returns>
-        public bool ProcessAssemblies(
-            string directoryPath,
-            bool includeSubdirectories,
-            IEnumerable<string> searchPatterns,
-            IEnumerable<string> exclusionFileNames,
-            bool exclusionsAreCaseSensitive,
-            out ErrorInfo error)
-        {
-            return this.ProcessAssemblies(
-                new[] { directoryPath, },
-                includeSubdirectories,
-                searchPatterns,
-                exclusionFileNames,
-                exclusionsAreCaseSensitive,
-                out error);
-        }
-
-        /// <summary>
-        ///     This method scans the given directory for modules to search for extensibility types. All types found will
-        ///     be passed along to any observers.
-        /// </summary>        
-        /// <param name="directoryPaths">
-        ///     Directories to process.
-        /// </param>
-        /// <param name="includeSubdirectories">
-        ///     Indicates whether subdirectories will be searched.
-        /// </param>
-        /// <param name="searchPatterns">
-        ///     The search patterns to use. If null or empty, defaults to "*.dll" and "*.exe".
-        /// </param>
-        /// <param name="exclusionFileNames">
-        ///     A set of files names to exclude from the search. May be null.
-        /// </param>
-        /// <param name="exclusionsAreCaseSensitive">
-        ///     Indicates whether files names should be treated as case sensitive.
-        /// </param>
-        /// <param name="error">
-        ///     If this method returns <c>false</c>, then this parameter receives
-        ///     information about the error(s) that occurred.
-        /// </param>
-        /// <returns>
-        ///     Whether or not all assemblies in the given directories were processed successfully.
-        /// </returns>
-        public bool ProcessAssemblies(
-            IEnumerable<string> directoryPaths,
-            bool includeSubdirectories,
-            IEnumerable<string> searchPatterns,
-            IEnumerable<string> exclusionFileNames,
-            bool exclusionsAreCaseSensitive,
-            out ErrorInfo error)
-        {
             Guard.NotNull(directoryPaths, nameof(directoryPaths));
             directoryPaths.ForEach(x => Guard.NotNullOrWhiteSpace(x, nameof(directoryPaths)));
 
@@ -226,16 +145,9 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
 
             var watch = Stopwatch.StartNew();
 
-            if (searchPatterns == null || !searchPatterns.Any())
-            {
-                searchPatterns = new[] { "*.dll", "*.exe" };
-            }
-
-            var exclusionSet = exclusionFileNames != null
-                ? new HashSet<string>(exclusionFileNames, exclusionsAreCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase)
-                : new HashSet<string>();
-
-            var searchOption = includeSubdirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+            var searchPatterns = new[] { "*.dll", "*.exe" };
+            var exclusionSet = new HashSet<string>(StringComparer.CurrentCulture);
+            var searchOption = SearchOption.AllDirectories;
 
             var loaded = new List<Assembly>();
 
@@ -341,10 +253,10 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
                 Debug.Assert(!allLoaded);
                 error = new DiscoveryError(
                             directoryPaths,
-                            includeSubdirectories,
+                            true,
                             searchPatterns,
-                            exclusionFileNames,
-                            exclusionsAreCaseSensitive)
+                            null,
+                            true)
                 {
                     Target = string.Empty,
                     Details = directoryErrors.ToArray(),

--- a/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
@@ -196,9 +196,11 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
 
                     foreach (string subDirectory in subDirectories)
                     {
-                        if (exclusions.Contains(Path.GetDirectoryName(subDirectory)))
+                        string directoryName = new DirectoryInfo(subDirectory).Name;
+
+                        if (exclusions.Contains(directoryName))
                         {
-                            this.logger?.Verbose("Process assemblies: excluding directory '{0}'.", subDirectory);
+                            this.logger?.Verbose("Process assemblies: excluding directory '{0}'.", directoryName);
                             continue;
                         }
 

--- a/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
@@ -414,11 +414,9 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
             Debug.Assert(!string.IsNullOrWhiteSpace(targetDirectory), $"{nameof(targetDirectory)} is null.");
             Debug.Assert(Directory.Exists(targetDirectory), $"{nameof(targetDirectory)} is invalid.");
 
-            string configurationFile = Directory
-                .GetFiles(targetDirectory, AssemblyExtensionDiscovery.ExclusionsFilename)
-                .FirstOrDefault();
+            string configurationFile = Path.Combine(targetDirectory, AssemblyExtensionDiscovery.ExclusionsFilename);
 
-            if (configurationFile != null)
+            if (File.Exists(configurationFile))
             {
                 try
                 {

--- a/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Discovery/AssemblyExtensionDiscovery.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Performance.SDK.Runtime.Discovery
     public class AssemblyExtensionDiscovery
         : IExtensionTypeProvider
     {
-        public static readonly string ExclusionsFilename = "PluginLoadExclusions";
+        internal static readonly string ExclusionsFilename = "PluginLoadExclusions";
         private static readonly string[] SearchPatterns = new[] { "*.dll", "*.exe" };
 
         private readonly IAssemblyLoader assemblyLoader;


### PR DESCRIPTION
Provides a way for a plugin to specify that files/folder should be skipped when loading the plugin's folder. When the file 'PluginLoadExclusions" is found in a folder, each line of that file is interpreted as a file or folder to exclude from the discovery process.

Runtime code related to extension discovery that wasn't being used was removed.

Tests have been updated to test exclusion of a file and a folder.
A test has been added to test successfully loading from a folder.
Logging has been added when exclusions are enabled.