### PR TITLE
Use specified logger when available.

### DIFF
--- a/src/Microsoft.Performance.Toolkit.Engine/PluginSet.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/PluginSet.cs
@@ -340,7 +340,10 @@ namespace Microsoft.Performance.Toolkit.Engine
 
             try
             {
-                assemblyLoader ??= new AssemblyLoader();
+                assemblyLoader ??= logger is null
+                    ? new AssemblyLoader()
+                    : new AssemblyLoader(logger);
+
                 var validatorFactory = new Func<IEnumerable<string>, IPreloadValidator>(_ => new NullValidator());
 
                 AssemblyExtensionDiscovery assemblyDiscovery = logger is null


### PR DESCRIPTION
While doing some testing I found another location that wasn't getting the user-specified logger.