### PR TITLE
Plugins: allow resetting registry if it becomes corrupted

### DIFF
--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/FileBackedPluginsInstaller.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/FileBackedPluginsInstaller.cs
@@ -291,6 +291,15 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
             }
         }
 
+        /// <inheritdoc/>
+        public async Task ResetInstalledPlugins(CancellationToken cancellationToken)
+        {
+            using (await this.pluginRegistry.AquireLockAsync(cancellationToken, null))
+            {
+                await this.pluginRegistry.Reset(cancellationToken);
+            }
+        }
+
         private async Task<InstalledPlugin> CreateInstalledPluginAsync(
             InstalledPluginInfo installedPluginInfo,
             CancellationToken cancellationToken)

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/IPluginsInstaller.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/IPluginsInstaller.cs
@@ -115,6 +115,9 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
         /// <exception cref="OperationCanceledException">
         ///     Throws when the operation was cancelled.
         /// </exception>
+        /// <exception cref="RepositoryDataAccessException">
+        ///     Throws when the installed plugins registry cannot be reset.
+        /// </exception>
         Task ResetInstalledPlugins(CancellationToken cancellationToken);
     }
 }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/IPluginsInstaller.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/IPluginsInstaller.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Performance.Toolkit.Plugins.Runtime.Exceptions;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
 {
@@ -24,6 +25,13 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
         /// </returns>
         /// <exception cref="OperationCanceledException">
         ///     Throws when the operation was cancelled.
+        /// </exception>
+        /// <exception cref="RepositoryCorruptedException">
+        ///     Throws when the installed plugins registry is corrupted, requiring <see cref="ResetInstalledPlugins"/>
+        ///     to be invoked.
+        /// </exception>
+        /// <exception cref="RepositoryDataAccessException">
+        ///     Throws when the installed plugins registry cannot be read or written to.
         /// </exception>
         Task<InstalledPluginsResults> GetAllInstalledPluginsAsync(
             CancellationToken cancellationToken);
@@ -47,11 +55,17 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
         ///     The <see cref="InstalledPluginInfo"/> of the installed plugin if the installation was successful. Otherwise, null.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        ///     Throws when <paramref name="pluginPackage"/> or <paramref name="installationRoot"/> or
-        ///     <paramref name="sourceUri"/> is null.
+        ///     Throws when <paramref name="pluginStream"/> or <paramref name="sourceUri"/> is null.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     Throws when the operation was cancelled.
+        /// </exception>
+        /// <exception cref="RepositoryCorruptedException">
+        ///     Throws when the installed plugins registry is corrupted, requiring <see cref="ResetInstalledPlugins"/>
+        ///     to be invoked.
+        /// </exception>
+        /// <exception cref="RepositoryDataAccessException">
+        ///     Throws when the installed plugins registry cannot be read or written to.
         /// </exception>
         Task<InstalledPlugin> InstallPluginAsync(
             Stream pluginStream,
@@ -77,8 +91,30 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
         /// <exception cref="OperationCanceledException">
         ///     Throws when the operation was cancelled.
         /// </exception>
+        /// <exception cref="RepositoryCorruptedException">
+        ///     Throws when the installed plugins registry is corrupted, requiring <see cref="ResetInstalledPlugins"/>
+        ///     to be invoked.
+        /// </exception>
+        /// <exception cref="RepositoryDataAccessException">
+        ///     Throws when the installed plugins registry cannot be read or written to.
+        /// </exception>
         Task<bool> UninstallPluginAsync(
             InstalledPlugin installedPlugin,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Resets the state of installed plugins, which uninstall every formerly installed plugin.
+        ///     This is necessary if the plugin installation registry becomes corrupted.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     Signals that the caller wishes to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     An await-able <see cref="Task"/>.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">
+        ///     Throws when the operation was cancelled.
+        /// </exception>
+        Task ResetInstalledPlugins(CancellationToken cancellationToken);
     }
 }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/FileBackedPluginRegistry.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/FileBackedPluginRegistry.cs
@@ -238,7 +238,17 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
         /// <inheritdoc/>
         public Task Reset(CancellationToken cancellationToken)
         {
-            return Task.Run(() => File.Delete(this.registryFilePath), cancellationToken);
+            return Task.Run(() =>
+            {
+                try
+                {
+                    File.Delete(this.registryFilePath);
+                }
+                catch (IOException e)
+                {
+                    throw new RepositoryDataAccessException("Failed to delete plugin registry.", e);
+                }
+            }, cancellationToken);
         }
 
         private async Task<List<InstalledPluginInfo>> ReadInstalledPlugins(

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/IPluginRegistry.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/IPluginRegistry.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Common;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime
@@ -13,5 +15,15 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
         : IKeyedRepository<InstalledPluginInfo, string>,
           ISynchronizedObject
     {
+        /// <summary>
+        ///     Resets the plugin registry to an empty state.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///     Signals that the caller wishes to cancel the operation.
+        /// </param>
+        /// <returns>
+        ///     An awaitable task that completes when the registry has been reset.
+        /// </returns>
+        Task Reset(CancellationToken cancellationToken);
     }
 }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/IPluginRegistry.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/IPluginRegistry.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Common;
+using Microsoft.Performance.Toolkit.Plugins.Runtime.Exceptions;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime
 {
@@ -24,6 +26,12 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
         /// <returns>
         ///     An awaitable task that completes when the registry has been reset.
         /// </returns>
+        /// <exception cref="OperationCanceledException">
+        ///     Throws when the operation was cancelled.
+        /// </exception>
+        /// <exception cref="RepositoryDataAccessException">
+        ///     Throws when the installed plugins registry cannot be reset.
+        /// </exception>
         Task Reset(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
When deserializing the plugins registry, the caller should have a way to recover from a corrupt file. This PR adds a `ResetInstalledPlugins` method to the `IPluginsInstaller` which will effectively delete the registry file.

Additionally, this PR
1. Documents that `IPluginsInstaller` can throw `RepositoryCorruptedException` and `RepositoryDataAccessException`
2. Updates the repository to throw `RepositoryCorruptedException` when a `JsonException` is encountered (previously, this threw `RepositoryDataAccessException`, which did not make sense to me)
3. Also throws `RepositoryCorruptedException` when an `ArgumentNullException` is encountered during deserialization

The last change is necessary because System.Text.Json will not throw a JsonException if a deserialized class is missing members (although, this functionality is coming in .NET 8). Instead, the deserialized classes are using `Guard.NotNull` clauses that throw `ArgumentNullException` when a deserialized constructor parameter is null (i.e. not present in the JSON).