### PR TITLE
Plugins: Prevent deadlocking in RefreshDiscoverersIfNeededAsync

### DIFF
--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Discovery/PluginsDiscoveryOrchestrator.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Discovery/PluginsDiscoveryOrchestrator.cs
@@ -393,7 +393,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Discovery
             }
             finally
             {
-                this.requiresDiscoverersRefresh = false;
                 this.semaphore.Release();
             }
         }


### PR DESCRIPTION
`RefreshDiscoverersIfNeededAsync` (formerly mistyped as `RefereshDiscoverersIfNeededAsync`) exits early after taking the semaphore lock if it was not necessary to refresh discoverers. However, when this short-circuit path is taken, the semaphore was not being released, causing future calls to deadlock.

This PR fixes this method to _always_ release the lock when exiting the method.