### PR TITLE
Add template plugin manifest

### DIFF
--- a/devel-template/templates/PluginTemplate/pluginManifest.json
+++ b/devel-template/templates/PluginTemplate/pluginManifest.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/microsoft-performance-toolkit-sdk/main/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Manifest/PluginManifestSchema.json",
-  // Please fill out the following fields with your plugin information
   "identity": {
     "id": "__PLUGIN_ID__",
     "version": "__PLUGIN_VERSION__"

--- a/devel-template/templates/PluginTemplate/pluginManifest.json
+++ b/devel-template/templates/PluginTemplate/pluginManifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/microsoft-performance-toolkit-sdk/main/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Manifest/PluginManifestSchema.json",
+  // Please fill out the following fields with your plugin information
+  "identity": {
+    "id": "__PLUGIN_ID__",
+    "version": "__PLUGIN_VERSION__"
+  },
+  "displayName": "__PLUGIN_DISPLAY_NAME__",
+  "description": "__PLUGIN_DESCRIPTION__",
+  "owners": [
+    {
+      "name": "__PLUGIN_OWNER_NAME__",
+      "address": "__PLUGIN_OWNER_ADDRESS__",
+      "emailAddresses": [ "__PLUGIN_OWNER_EMAIL__A__", "__PLUGIN_OWNER_EMAIL__B__" ],
+      "phoneNumbers": [ "__PLUGIN_OWNER_PHONE__A__", "__PLUGIN_OWNER_PHONE__B__" ]
+    }
+  ],
+  "projectUrl": "__PLUGIN_PROJECT_URL__",
+  "manifestVersion": 1.0
+}

--- a/documentation/Plugins-System-Preview-Only/PluginTool-CLI.md
+++ b/documentation/Plugins-System-Preview-Only/PluginTool-CLI.md
@@ -34,7 +34,7 @@ The manifest file contains the following properties:
 
 #### `identity`
 
-`id` - A unique identifier for the plugin. e.g. `com.mycompany.myplugin`.
+`id` - An identifier for the plugin. Plugin IDs must be unique within the context of a plugin feed. It's recommended to use dots to create a namespace-like structure that reflects the organization and projects the plugin belongs to. e.g. `MyCompany.MyPlugin` or `MyCompany.MyProject.MyPlugin`.
 
 `version` - The version of the plugin in the format of sematic versioning. e.g. `1.0.0` or `1.0.0-beta.1`.
 

--- a/documentation/Plugins-System-Preview-Only/PluginTool-CLI.md
+++ b/documentation/Plugins-System-Preview-Only/PluginTool-CLI.md
@@ -26,3 +26,37 @@ The `plugintool` cli can be used to generate plugin metadata files (`metadata.js
   Specifies the path to the manifest file. If not provided, the tool will look for a `pluginManifest.json` file in the source directory.
 - `-w|--overwrite`  
   Specifies whether to overwrite existing metadata files if they exist. It's only valid if the `-o|--output` option is specified.
+
+### Manifest File
+The manifest file is an editable JSON file that allows users to specify the metadata for a plugin. To generate metadata files or package a plugin, a manifest file must be provided. The tool will look for a `pluginManifest.json` file in the source directory by default. The manifest file can also be specified using the `-m|--manifest` option. A template of the manifest file can be found [here](https://raw.githubusercontent.com/microsoft/microsoft-performance-toolkit-sdk/main/devel-template/templates/PluginTemplate/pluginManifest.json).
+
+The manifest file contains the following properties:
+
+#### `identity`
+
+`id` - A unique identifier for the plugin. e.g. `com.mycompany.myplugin`.
+
+`version` - The version of the plugin in the format of sematic versioning. e.g. `1.0.0` or `1.0.0-beta.1`.
+
+#### `displayName`
+A human-readable name for the plugin. e.g. `My Plugin`.
+
+#### `description`
+A human-readable description for the plugin. e.g. `This is a plugin for my application.`
+
+#### `owners`
+A list of owners for the plugin.
+
+`name` - The name of the owner. e.g. `John Doe`.
+
+`address` - The address of the owner. e.g. `My Company, 123 Main St, New York, NY 10001`.
+
+`emailAddresses` - A list of email addresses for the owner. e.g. `[ "myemail1@hotmail.com", "myemail2@outlook.com" ]`
+
+`phoneNumbers` - A list of phone numbers for the owner. e.g. `[ "123-456-7890", "098-765-4321" ]`
+
+#### `projectUrl`
+The URL of the project repository. e.g. `https://github.com/mycompany/myplugin`.
+
+#### `manifestVersion`
+The version of the manifest file defined in the schema this manifest file conforms to. e.g. `1.0`.

--- a/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Manifest/PluginManifestSchema.json
+++ b/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Manifest/PluginManifestSchema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "JSON Schema a plugin manifest",
+  "title": "Plugin Manifest Schema",
   "type": "object",
   "required": [
     "identity",
@@ -24,8 +24,8 @@
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.\\d+\\.\\d+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
-          "description": "The version number of the plugin."
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "description": "Semantic version of the plugin."
         }
       }
     },


### PR DESCRIPTION
Added documentation for `pluginManifest.json` which is required for packaging plugins. Added a template manifest file under devel-template for now in order for the doc to reference it.  The devel-template will be updated as part of the new plugin template work. This also fixed the schema name, and update the version pattern to use semantic versioning.