### PR TITLE
Offset servicing v1.1 version height

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.1",
+  "versionHeightOffset": 8,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
+8 to the height so the patch version won't conflict with the existing versions.