### PR TITLE
ProcessedEventData: delay allocation until first event.

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/ProcessedEventData.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ProcessedEventData.cs
@@ -25,14 +25,6 @@ namespace Microsoft.Performance.SDK.Processing
         private List<List<T>> events;
 
         /// <summary>
-        /// Default constructor.
-        /// </summary>
-        public ProcessedEventData()
-        {
-            this.CreateNewList();
-        }
-
-        /// <summary>
         /// The number of data elements added.
         /// </summary>
         public uint Count { get; private set; }
@@ -117,13 +109,13 @@ namespace Microsoft.Performance.SDK.Processing
 
         private bool ListIsFull()
         {
-            return this.currentEventsBuilderList.Count == BuilderListSize;
+            return this.currentEventsBuilderList == null || this.currentEventsBuilderList.Count == BuilderListSize;
         }
 
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator()
         {
-            for(uint i = 0; i < this.Count; ++i)
+            for (uint i = 0; i < this.Count; ++i)
             {
                 yield return this[i];
             }


### PR DESCRIPTION
If a data cooker is using this class and never processes any events from the trace, then performing an initial allocation is a waste of memory.

This change delays that initial allocation until the first event is received.

I tested with an existing XPerf cooker (EtwSessionInfo) to be sure that it works as expected.

This change is important because the more data cookers use this class, the higher the initial allocation cost would become.