### PR TITLE
Engine.Create(IDataSource) disposes of DataSourceSet.

### DIFF
--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/DataSourceSetTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/DataSourceSetTests.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Performance.Toolkit.Engine.Tests
 {
     [TestClass]
-    public class DataSourceSetTests
+    public sealed class DataSourceSetTests
         : EngineFixture
     {
         private DataSourceSet Sut { get; set; }
@@ -165,7 +165,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         public void TryAddDataSourceOnly_NoCookersOrDataSourcesSupport_False()
         {
             var tempDir = this.Scratch.CreateSubdirectory(nameof(TryAddDataSourceOnly_NoCookersOrDataSourcesSupport_False));
-            
+
             CopyAssemblyContainingType(typeof(Source123DataSource), tempDir);
             using (var plugins = PluginSet.Load(tempDir.FullName))
             using (var sut = DataSourceSet.Create(plugins))

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/EngineFixture.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/EngineFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         public void Initialize()
         {
             var scratchPath = Path.Combine(
-                this.TestContext.TestResultsDirectory, 
+                this.TestContext.TestResultsDirectory,
                 $"Scratch-{this.GetType().Name}-{this.TestContext.TestName}");
             this.Scratch = new DirectoryInfo(scratchPath);
             try
@@ -77,6 +77,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
         public virtual void OnCleanup()
         {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+            GC.WaitForPendingFinalizers();
         }
 
         protected static void CopyAssemblyContainingType(Type type, DirectoryInfo destDir)

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/PluginSetTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/PluginSetTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void Ctor_ExtensionDirectory_IsCurrent()
         {
-            var sut = PluginSet.Load();
+            using var sut = PluginSet.Load();
 
             Assert.AreEqual(1, sut.ExtensionDirectories.Count());
             Assert.AreEqual(Environment.CurrentDirectory, sut.ExtensionDirectories.First());
@@ -30,7 +30,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void ExtensionDirectory_ExistingDirectory_Sets()
         {
-            var sut = PluginSet.Load(this.Scratch.FullName);
+            using var sut = PluginSet.Load(this.Scratch.FullName);
 
             Assert.AreEqual(1, sut.ExtensionDirectories.Count());
             Assert.AreEqual(this.Scratch.FullName, sut.ExtensionDirectories.First());
@@ -67,7 +67,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             {
                 Directory.CreateDirectory(relative);
 
-                var sut = PluginSet.Load(relative);
+                using var sut = PluginSet.Load(relative);
 
                 Assert.AreEqual(1, sut.ExtensionDirectories.Count());
                 Assert.AreEqual(relativeFull, sut.ExtensionDirectories.First());
@@ -86,7 +86,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             var dir2 = this.Scratch.CreateSubdirectory("Dir2");
 
 
-            var sut = PluginSet.Load(new[] { dir1.FullName, dir2.FullName });
+            using var sut = PluginSet.Load(new[] { dir1.FullName, dir2.FullName });
 
             Assert.AreEqual(2, sut.ExtensionDirectories.Count());
             Assert.IsTrue(sut.ExtensionDirectories.Contains(dir1.FullName));

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
        "Source123 for Runtime Tests")]
     [FileDataSource(Extension)]
     public sealed class Source123DataSource
-        : ProcessingSource
+        : ProcessingSource,
+          IDisposable
     {
         private IEnumerable<Option> supportedOptions = new List<Option>()
         {
@@ -28,10 +29,14 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
         public static Guid Guid = Guid.Parse(GuidAsString);
         public const string Extension = ".s123d";
 
+        private bool disposedValue;
+
         public Source123DataSource()
             : base(new Discovery())
         {
         }
+
+        public bool IsDisposed => this.disposedValue;
 
         protected override ICustomDataProcessor CreateProcessorCore(
             IEnumerable<IDataSource> dataSources,
@@ -58,7 +63,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
         public override IEnumerable<Option> CommandLineOptions => supportedOptions;
 
         public ProcessorOptions UserSpecifiedOptions { get; private set; }
-        
+
         private sealed class Discovery
             : IProcessingSourceTableProvider
         {
@@ -69,6 +74,30 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
                     Source123Table.TableDescriptor,
                 };
             }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~Source123DataSource()
+        {
+            throw new InvalidOperationException($"{nameof(Source123DataSource)} was not disposed of correctly.");
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/TestCookers/Source123/Source123DataSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.Testing.SDK;
@@ -31,9 +32,13 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests.TestCookers.Source123
 
         private bool disposedValue;
 
+        // saves the constructor stack. useful for debugging cases where Dispose wasn't called.
+        private readonly StackTrace constructionStack = null;
+
         public Source123DataSource()
             : base(new Discovery())
         {
+            this.constructionStack = new StackTrace(true);
         }
 
         public bool IsDisposed => this.disposedValue;

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineCreateInfoTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineCreateInfoTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
 using Microsoft.Performance.Testing;
 using Microsoft.Performance.Testing.SDK;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Performance.Toolkit.Engine.Tests
 {
@@ -18,7 +18,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void DefaultRuntime_Set()
         {
-            var sut = new EngineCreateInfo(DataSourceSet.Create().AsReadOnly());
+            using var dataSourceSet = DataSourceSet.Create();
+            var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly());
 
             string expectedName = typeof(EngineCreateInfo).Assembly.GetName().Name;
             Assert.AreEqual(expectedName, sut.RuntimeName);
@@ -28,7 +29,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void DefaultProcessorOptionsResolver_Set()
         {
-            var sut = new EngineCreateInfo(DataSourceSet.Create().AsReadOnly());
+            using var dataSourceSet = DataSourceSet.Create();
+            var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly());
             Assert.IsNotNull(sut.OptionsResolver, "Options Resolver is null when a default is expected");
 
             var dsg = new DataSourceGroup(new[] { new FileDataSource("sample") }, new DefaultProcessingMode());
@@ -57,7 +59,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             var dsg = new DataSourceGroup(new[] { new FileDataSource("sample") }, new DefaultProcessingMode());
 
-            var sut = new EngineCreateInfo(DataSourceSet.Create().AsReadOnly()).WithProcessorOptions(processorOptions);
+            using var dataSourceSet = DataSourceSet.Create();
+            var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly()).WithProcessorOptions(processorOptions);
 
             Assert.IsNotNull(sut.OptionsResolver, "Options Resolver is null when a default is expected");
 
@@ -92,7 +95,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             var dsg = new DataSourceGroup(new[] { new FileDataSource("sample") }, new DefaultProcessingMode());
 
-            var sut = new EngineCreateInfo(DataSourceSet.Create().AsReadOnly()).WithProcessorOptions(processorOptionsMap);
+            using var dataSourceSet = DataSourceSet.Create();
+            var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly()).WithProcessorOptions(processorOptionsMap);
 
             Assert.IsNotNull(sut.OptionsResolver, "Options Resolver is null when a default is expected");
 
@@ -103,7 +107,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 new Tuple<Guid, IDataSourceGroup>(Guid.NewGuid(), Any.DataSourceGroup()),
                 new Tuple<Guid, IDataSourceGroup>(Guid.NewGuid(), Any.DataSourceGroup()),
             };
-            
+
             var guidDataSourcePairs = new[]
             {
                 new Tuple<Guid, IDataSourceGroup>(processingGuid, dsg),
@@ -120,7 +124,8 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [UnitTest]
         public void NullOptionsResolver_Failure()
         {
-            var sut = new EngineCreateInfo(DataSourceSet.Create().AsReadOnly());
+            using var dataSourceSet = DataSourceSet.Create();
+            var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly());
             IProcessingOptionsResolver resolver = null;
             Assert.ThrowsException<ArgumentNullException>(() => sut.WithProcessorOptions(resolver));
         }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -113,6 +113,75 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
         [TestMethod]
         [IntegrationTest]
+        public void Create_DataSource_DisposesDataSet()
+        {
+            // Engine.Create(IDataSourceSet) owns the data source set and should dispose of it
+
+            Source123DataSource processingSource = null;
+
+            using (Engine sut = Engine.Create(new FileDataSource("test" + Source123DataSource.Extension)))
+            {
+                processingSource = sut.Plugins.ProcessingSourceReferences
+                    .Where(x => x.Name == nameof(Source123DataSource))
+                    .First()
+                    .Instance as Source123DataSource;
+
+                Assert.IsNotNull(processingSource, $"{nameof(processingSource)} is null.");
+            }
+
+            Assert.IsTrue(processingSource.IsDisposed, $"{processingSource} is not disposed.");
+        }
+
+        [TestMethod]
+        [IntegrationTest]
+        public void Create_DataSourceAndType_DisposesDataSet()
+        {
+            // Engine.Create(IDataSourceSet, Type) owns the data source set and should dispose of it
+
+            Source123DataSource processingSource = null;
+
+            using (Engine sut = Engine.Create(new FileDataSource("test" + Source123DataSource.Extension), typeof(Source123DataSource)))
+            {
+                processingSource = sut.Plugins.ProcessingSourceReferences
+                    .Where(x => x.Name == nameof(Source123DataSource))
+                    .First()
+                    .Instance as Source123DataSource;
+
+                Assert.IsNotNull(processingSource, $"{nameof(processingSource)} is null.");
+            }
+
+            Assert.IsTrue(processingSource.IsDisposed, $"{processingSource} is not disposed.");
+        }
+
+        [TestMethod]
+        [IntegrationTest]
+        public void Create_DataSourcesAndType_DisposesDataSet()
+        {
+            // Engine.Create(IEnumerable<IDataSourceSet>, Type) owns the data source set and should dispose of it
+
+            Source123DataSource processingSource = null;
+
+            IDataSource[] sources = new[]
+            {
+                new FileDataSource("test1" + Source123DataSource.Extension),
+                new FileDataSource("test2" + Source123DataSource.Extension),
+            };
+
+            using (Engine sut = Engine.Create(sources, typeof(Source123DataSource)))
+            {
+                processingSource = sut.Plugins.ProcessingSourceReferences
+                    .Where(x => x.Name == nameof(Source123DataSource))
+                    .First()
+                    .Instance as Source123DataSource;
+
+                Assert.IsNotNull(processingSource, $"{nameof(processingSource)} is null.");
+            }
+
+            Assert.IsTrue(processingSource.IsDisposed, $"{processingSource} is not disposed.");
+        }
+
+        [TestMethod]
+        [IntegrationTest]
         public void Create_WithValidOptions()
         {
             var expectedProcessorOptions = new ProcessorOptions(

--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Performance.Toolkit.Engine
                 dataSourceSet.AddDataSource(dataSource);
 
                 var info = new EngineCreateInfo(dataSourceSet.AsReadOnly());
-                return Create(info);
+                return CreateCore(info, dataSourceSet);
             }
             catch
             {


### PR DESCRIPTION
What's "funny" about this bug is that the comment in Engine.Dispose() directly references this case.

```
//
// we diposes the original set only if we own the data sources.
// this only occurs when the user uses one of the convenience
// methods that creates a DataSource internally, **e.g. Create(IDataSource).**
//

this.internalDataSourceSet.SafeDispose();
```

I added tests for each of the helper Create methods that should be disposing of the DataSourceSet.