### PR TITLE
Prevent installing plugin over previous installation folder

### DIFF
--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/ErrorCodes.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/ErrorCodes.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
             "PLUGINS_VALIDATION_UnsupportedSdkVersion",
             "The plugin is not compatible with the current running version of the SDK.");
 
+        public static ErrorCodes PLUGINS_VALIDATION_PreviousInstallationFolderExists = new ErrorCodes(
+            60002,
+            "PLUGINS_VALIDATION_PreviousInstallationFolderExists",
+            "The plugin has already been previously installed and has not been removed.");
+
         //
         // We do duplicate checking on the numeric and string codes
         // as part of construction of this collection. If there are

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -107,10 +107,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     return true;
                 }
 
-                // First try to rename the directory to a temporary name.
+                // First try to move the directory to the temp folder.
                 // If this succeeds, it means no other process was using any file
                 // in the directory, and we can safely delete it.
-                var toDelete = dir + ".delete";
+                var toDelete = Path.Combine(Path.GetTempPath(), new DirectoryInfo(dir).Name + ".delete");
+
                 try
                 {
                     Directory.Move(dir, toDelete);

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -60,20 +60,20 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                 IEnumerable<string> dirsToRemove = this.pluginsStorageDirectory.GetAllRootDirectories()
                     .Where(d => !dirsInUse.Contains(d, StringComparer.OrdinalIgnoreCase));
 
-                IEnumerable<(string dirToRemove, Task task)> dirTaskTuples = dirsToRemove
-                    .Select(dirToRemove => (dirToRemove: dirToRemove, task: DeleteDirectory(dirToRemove, cancellationToken)));
+                List<(string dirToRemove, Task<bool> task)> dirTaskTuples = dirsToRemove
+                    .Select(dirToRemove => (dirToRemove: dirToRemove, task: TryDeleteDirectory(dirToRemove, cancellationToken)))
+                    .ToList();
 
-                IEnumerable<Task> tasks = dirsToRemove.Select(d => DeleteDirectory(d, cancellationToken));
                 try
                 {
-                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                    await Task.WhenAll(dirTaskTuples.Select(t => t.task)).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
                     this.logger.Info($"The request to clean up plugins from the storage is cancelled.");
 
                     dirTaskTuples
-                        .Where(p => p.task.Status == TaskStatus.RanToCompletion)
+                        .Where(p => p.task.Status == TaskStatus.RanToCompletion && p.task.Result)
                         .ToList()
                         .ForEach(t => this.logger.Info($"{t.dirToRemove} has been successfully deleted"));
 
@@ -85,7 +85,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
 
                 foreach (var tuple in dirTaskTuples)
                 {
-                    if (tuple.task.IsFaulted)
+                    if (tuple.task.IsFaulted || tuple.task.IsCanceled || !tuple.task.Result)
                     {
                         this.logger.Error(tuple.task.Exception, $"Failed to clean up directory {tuple.dirToRemove}");
                     }
@@ -97,13 +97,44 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
             }
         }
 
-        private Task DeleteDirectory(string dir, CancellationToken cancellationToken)
+        private Task<bool> TryDeleteDirectory(string dir, CancellationToken cancellationToken)
         {
             return Task.Run(() =>
             {
-                if (Directory.Exists(dir))
+                if (!Directory.Exists(dir))
                 {
-                    Directory.Delete(dir, true);
+                    // The directory does not exist, so it is already deleted.
+                    return true;
+                }
+
+                // First try to rename the directory to a temporary name.
+                // If this succeeds, it means no other process was using any file
+                // in the directory, and we can safely delete it.
+                var toDelete = dir + ".delete";
+                try
+                {
+                    Directory.Move(dir, toDelete);
+                }
+                catch (IOException e)
+                {
+                    this.logger.Error(e, $"Failed to delete {dir} because it is in use.");
+                    return false;
+                }
+
+                try
+                {
+                    Directory.Delete(toDelete, true);
+                    return true;
+                }
+                catch (Exception ex) when (
+                    ex is IOException ||
+                    ex is UnauthorizedAccessException)
+                {
+                    this.logger.Error(ex, $"Failed to delete {dir}.");
+
+                    // Restore the original directory name
+                    Directory.Move(toDelete, dir);
+                    return false;
                 }
             }, cancellationToken);
         }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -131,10 +131,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     ex is IOException ||
                     ex is UnauthorizedAccessException)
                 {
-                    this.logger.Error(ex, $"Failed to delete {dir}.");
-
-                    // Restore the original directory name
-                    Directory.Move(toDelete, dir);
+                    this.logger.Error(ex, $"Failed to delete {toDelete}.");
                     return false;
                 }
             }, cancellationToken);

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/PluginsSystem.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/PluginsSystem.cs
@@ -159,6 +159,9 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
                 checsumCalculator,
                 loggerFactory);
 
+            List<IPluginValidator> installValidators = new List<IPluginValidator>(validatorsToUse);
+            installValidators.Add(new PreviousInstallationFolderValidator(loggerFactory(typeof(PreviousInstallationFolderValidator)), storageDirectory));
+
             var validator = new InstalledPluginDirectoryChecksumValidator(storageDirectory, checsumCalculator, loggerFactory(typeof(InstalledPluginDirectoryChecksumValidator)));
 
             var installer = new FileBackedPluginsInstaller(
@@ -166,7 +169,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
                 validator,
                 installedPluginStorage,
                 packageReader,
-                compositePluginValidator,
+                new CompositePluginValidator(installValidators),
                 options.InvalidPluginsGate,
                 loggerFactory);
 

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Validation/PreviousInstallationFolderValidator.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Validation/PreviousInstallationFolderValidator.cs
@@ -5,16 +5,13 @@ using System;
 using System.IO;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Processing;
-using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Toolkit.Plugins.Core.Metadata;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Installation;
-using NuGet.Versioning;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Validation
 {
     /// <summary>
-    ///     Validates a plugin's <see cref="PluginMetadata.SdkVersion"/> is compatible with
-    ///     the currently running's SDK version.
+    ///     Validates a plugin's installation directory is not already in use by a previous installation.
     /// </summary>
     public class PreviousInstallationFolderValidator
         : IPluginValidator

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Validation/PreviousInstallationFolderValidator.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Validation/PreviousInstallationFolderValidator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Runtime;
+using Microsoft.Performance.Toolkit.Plugins.Core.Metadata;
+using Microsoft.Performance.Toolkit.Plugins.Runtime.Installation;
+using NuGet.Versioning;
+
+namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Validation
+{
+    /// <summary>
+    ///     Validates a plugin's <see cref="PluginMetadata.SdkVersion"/> is compatible with
+    ///     the currently running's SDK version.
+    /// </summary>
+    public class PreviousInstallationFolderValidator
+        : IPluginValidator
+    {
+        private readonly ILogger logger;
+        private readonly IPluginsStorageDirectory pluginsStorageDirectory;
+
+        public PreviousInstallationFolderValidator(
+            ILogger logger,
+            IPluginsStorageDirectory pluginsStorageDirectory)
+        {
+            this.logger = logger;
+            this.pluginsStorageDirectory = pluginsStorageDirectory;
+        }
+
+        public ErrorInfo[] GetValidationErrors(PluginMetadata pluginMetadata)
+        {
+            var dir = this.pluginsStorageDirectory.GetRootDirectory(pluginMetadata.Identity);
+
+            if (Directory.Exists(dir))
+            {
+                string errorMessage =
+                    $"The plugin {pluginMetadata.Identity} has already been previously installed to {dir} and has not been removed. Please remove the folder and try again.";
+
+                this.logger.Error(errorMessage);
+
+                return new []{ new ErrorInfo(ErrorCodes.PLUGINS_VALIDATION_PreviousInstallationFolderExists, errorMessage) };
+            }
+
+            return Array.Empty<ErrorInfo>();
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `IPluginValidator` that checks to make sure the plugin installation folder does not yet exist. This new validator is passed only to the plugins installer.

Also fixes logic in the obsolete plugin remover to
1. Only attempt to delete each directory once (before, it was calling `DeleteDirectory` multiple times due to a multiple enumeration of an `IEnumerable` containing the task)
2. Prevent directories from being only partially removed if another process is using one or more of its files