### PR TITLE
Fix FileSystemObsoletePluginsRemover for in-use plugins

### DIFF
--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     {
                         return File.Open(f, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);
                     }
-                    catch (IOException)
+                    catch (Exception)
                     {
                         return null;
                     }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -145,7 +145,13 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     ex is UnauthorizedAccessException)
                 {
                     this.logger.Error(ex, $"Failed to delete {toDelete}.");
-                    return false;
+
+                    /*
+                     * We return true here because the directory has been moved to a temporary location
+                     * with all of its original contents removed. From the perspective of the plugins system,
+                     * the directory is gone and will not interfere with installing a new instance of the plugin.
+                     */
+                    return true;
                 }
             }, cancellationToken);
         }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -171,13 +171,21 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
             if (streams.Any(s => s is null))
             {
                 // At least one file is in use. Close all the streams and return false.
-                streams.ForEach(s => s?.Close());
+                streams.ForEach(s =>
+                {
+                    s?.Close();
+                    s?.Dispose();
+                });
                 return false;
             }
 
             // All files are available to be deleted. Delete all the files and close the streams.
             files.ForEach(f => File.Delete(f));
-            streams.ForEach(s => s.Close());
+            streams.ForEach(s =>
+            {
+                s.Close();
+                s.Dispose();
+            });
             return true;
         }
     }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -161,8 +161,9 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     {
                         return File.Open(f, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
+                        this.logger.Error(e, $"Failed to open {f} for deletion.");
                         return null;
                     }
                 })

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Installation/Storage/FileSystemObsoletePluginsRemover.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     return false;
                 }
 
-
                 /*
                  * The directory is not in use, and the plugins system won't return that it is available
                  * to be loaded because we currently hold the lock on the plugin registry. We will first
@@ -151,6 +150,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                      * with all of its original contents removed. From the perspective of the plugins system,
                      * the directory is gone and will not interfere with installing a new instance of the plugin.
                      */
+
                     return true;
                 }
             }, cancellationToken);
@@ -183,6 +183,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                     s?.Close();
                     s?.Dispose();
                 });
+
                 return false;
             }
 
@@ -193,6 +194,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Installation
                 s.Close();
                 s.Dispose();
             });
+
             return true;
         }
     }


### PR DESCRIPTION
Fixes two issues
1. If a plugin is in use, the move may sometimes still succeed but the delete fail. To prevent modifying a plugin that is loaded, we first verify every single file within the plugin's directory is not currently in use. If anyone currently holds a handle to any file, we abort. Otherwise, we know it's at the very least safe to move, because it's impossible for another instance of a plugins system to return the directory as a plugin to be loaded (since we hold the registry lock).
2. If a move succeeds but delete fails, future attempts to move the directory will fail because the folder exists. To fix this case, the folder moved to now contains a random string.