### PR TITLE
Add ResourceTimeRange.

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/Projection/ClipTimeToVisibleDomainProjection.cs
+++ b/src/Microsoft.Performance.SDK/Processing/Projection/ClipTimeToVisibleDomainProjection.cs
@@ -74,6 +74,36 @@ namespace Microsoft.Performance.SDK.Processing
             }
 
             /// <summary>
+            ///     Create a <see cref="ResourceTimeRange"/> projection that is clipped to a
+            ///     <see cref="VisibleDomainRegionContainer"/>.
+            ///     See also <seealso cref="IVisibleDomainSensitiveProjection"/>.
+            /// </summary>
+            /// <param name="resourceTimeRangeProjection">
+            ///     Original projection.
+            /// </param>
+            /// <returns>
+            ///     A visible domain sensitive projection.
+            /// </returns>
+            public static IProjection<int, ResourceTimeRange> Create(IProjection<int, ResourceTimeRange> resourceTimeRangeProjection)
+            {
+                Guard.NotNull(resourceTimeRangeProjection, nameof(resourceTimeRangeProjection));
+
+                var typeArgs = new[]
+                {
+                    resourceTimeRangeProjection.GetType(),
+                };
+
+                var constructorArgs = new object[]
+                {
+                    resourceTimeRangeProjection,
+                };
+
+                var type = typeof(ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator<>).MakeGenericType(typeArgs);
+                var instance = Activator.CreateInstance(type, constructorArgs);
+                return (IProjection<int, ResourceTimeRange>)instance;
+            }
+
+            /// <summary>
             ///     Creates a new percent projection that is defined by the current viewport.
             /// </summary>
             /// <param name="timeRangeColumn">
@@ -99,6 +129,34 @@ namespace Microsoft.Performance.SDK.Processing
                 var type = typeof(ClipTimeToVisibleTimeRangePercentColumnGenerator<>).MakeGenericType(typeArgs);
                 var instance = Activator.CreateInstance(type, constructorArgs);
                 return (IProjection<int, TimeRange>)instance;
+            }
+
+            /// <summary>
+            ///     Creates a new percent projection that is defined by the current viewport.
+            /// </summary>
+            /// <param name="resourceTimeRangeColumn">
+            ///     Original projection.
+            /// </param>
+            /// <returns>
+            ///     A viewport sensitive projection.
+            /// </returns>
+            public static IProjection<int, ResourceTimeRange> CreatePercent(IProjection<int, ResourceTimeRange> resourceTimeRangeColumn)
+            {
+                Guard.NotNull(resourceTimeRangeColumn, nameof(resourceTimeRangeColumn));
+
+                var typeArgs = new[]
+                {
+                    resourceTimeRangeColumn.GetType(),
+                };
+
+                var constructorArgs = new object[]
+                {
+                    resourceTimeRangeColumn,
+                };
+
+                var type = typeof(ClipTimeToVisibleResourceTimeRangePercentColumnGenerator<>).MakeGenericType(typeArgs);
+                var instance = Activator.CreateInstance(type, constructorArgs);
+                return (IProjection<int, ResourceTimeRange>)instance;
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
@@ -228,6 +286,72 @@ namespace Microsoft.Performance.SDK.Processing
                 public bool DependsOnVisibleDomain => true;
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+            private struct ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator<TGenerator>
+                : IProjection<int, ResourceTimeRange>,
+                  IVisibleDomainSensitiveProjection
+                  where TGenerator : IProjection<int, ResourceTimeRange>
+            {
+                internal TGenerator Generator { get; }
+
+                internal VisibleDomainRegionContainer VisibleDomainContainer { get; }
+
+                public ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator(TGenerator resourceTimeRangeGenerator)
+                {
+                    this.Generator = resourceTimeRangeGenerator;
+                    this.VisibleDomainContainer = new VisibleDomainRegionContainer();
+                }
+
+                // IProjection<int, Timestamp>
+                public ResourceTimeRange this[int value]
+                {
+                    get
+                    {
+                        TimeRange visibleDomain = this.VisibleDomainContainer.VisibleDomain;
+
+                        ResourceTimeRange resourceTimeRange = this.Generator[value];
+
+                        resourceTimeRange.StartTime = ClipTimestampToVisibleDomain(resourceTimeRange.StartTime, visibleDomain);
+                        resourceTimeRange.EndTime = ClipTimestampToVisibleDomain(resourceTimeRange.EndTime, visibleDomain);
+
+                        return resourceTimeRange;
+                    }
+                }
+
+                public Type SourceType
+                {
+                    get
+                    {
+                        return typeof(int);
+                    }
+                }
+
+                public Type ResultType
+                {
+                    get
+                    {
+                        return typeof(ResourceTimeRange);
+                    }
+                }
+
+                public object Clone()
+                {
+                    var result = new ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator<TGenerator>(
+                        VisibleDomainSensitiveProjection.CloneIfVisibleDomainSensitive(this.Generator));
+                    return result;
+                }
+
+
+                public bool NotifyVisibleDomainChanged(IVisibleDomainRegion visibleDomain)
+                {
+                    this.VisibleDomainContainer.VisibleDomainRegion = visibleDomain;
+                    VisibleDomainSensitiveProjection.NotifyVisibleDomainChanged(this.Generator, visibleDomain);
+                    return true;
+                }
+
+                public bool DependsOnVisibleDomain => true;
+            }
+
             private struct ClipTimeToVisibleTimeRangePercentColumnGenerator<TGenerator>
                 : IProjection<int, TimeRange>,
                   IVisibleDomainSensitiveProjection,
@@ -300,6 +424,98 @@ namespace Microsoft.Performance.SDK.Processing
                         if (arg is TimeRange)
                         {
                             numerator = ((TimeRange)arg).Duration;
+                        }
+                        else if (arg is TimestampDelta)
+                        {
+                            numerator = (TimestampDelta)arg;
+                        }
+                        else
+                        {
+                            throw new FormatException();
+                        }
+
+                        TimestampDelta visibleDomainDuration = getVisibleDomainDuration();
+                        double percent = (visibleDomainDuration != TimestampDelta.Zero) ?
+                            (100.0 * ((double)numerator.ToNanoseconds) / (visibleDomainDuration.ToNanoseconds)) :
+                            100.0;
+
+                        return percent.ToString(format, formatProvider);
+                    }
+                }
+            }
+
+            private struct ClipTimeToVisibleResourceTimeRangePercentColumnGenerator<TGenerator>
+                : IProjection<int, ResourceTimeRange>,
+                  IVisibleDomainSensitiveProjection,
+                  IFormatProvider
+                  where TGenerator : IProjection<int, ResourceTimeRange>
+            {
+                private readonly ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator<TGenerator> resourceTimeRangeColumnGenerator;
+
+                // IFormatProvider returns an object - cannot return 'this' struct. 
+                // So implement ICustomFormatter in a private class and return that object.
+                //
+                private readonly ClipTimeToVisibleResourceTimeRangePercentFormatProvider customFormatter;
+
+                public ClipTimeToVisibleResourceTimeRangePercentColumnGenerator(TGenerator timeRangeGenerator)
+                {
+                    var internalGenerator = new ClipTimeToVisibleResourceTimeRangeDomainColumnGenerator<TGenerator>(timeRangeGenerator);
+                    this.resourceTimeRangeColumnGenerator = internalGenerator;
+
+                    this.customFormatter =
+                        new ClipTimeToVisibleResourceTimeRangePercentFormatProvider(() => internalGenerator.VisibleDomainContainer.VisibleDomain.Duration);
+                }
+
+                public ResourceTimeRange this[int value] => this.resourceTimeRangeColumnGenerator[value];
+
+                public Type SourceType => typeof(int);
+
+                public Type ResultType => typeof(ResourceTimeRange);
+
+                public bool DependsOnVisibleDomain => true;
+
+                public object GetFormat(Type formatType)
+                {
+                    return (formatType == typeof(ResourceTimeRange) ||
+                            formatType == typeof(TimestampDelta)) ? this.customFormatter : null;
+                }
+
+                public object Clone()
+                {
+                    var result = new ClipTimeToVisibleResourceTimeRangePercentColumnGenerator<TGenerator>(
+                        VisibleDomainSensitiveProjection.CloneIfVisibleDomainSensitive(this.resourceTimeRangeColumnGenerator.Generator));
+                    return result;
+                }
+
+                public bool NotifyVisibleDomainChanged(IVisibleDomainRegion visibleDomain)
+                {
+                    this.resourceTimeRangeColumnGenerator.NotifyVisibleDomainChanged(visibleDomain);
+                    return true;
+                }
+
+                private class ClipTimeToVisibleResourceTimeRangePercentFormatProvider
+                    : ICustomFormatter
+                {
+                    private readonly Func<TimestampDelta> getVisibleDomainDuration;
+
+                    public ClipTimeToVisibleResourceTimeRangePercentFormatProvider(Func<TimestampDelta> getVisibleDomainDuration)
+                    {
+                        Guard.NotNull(getVisibleDomainDuration, nameof(getVisibleDomainDuration));
+
+                        this.getVisibleDomainDuration = getVisibleDomainDuration;
+                    }
+
+                    public string Format(string format, object arg, IFormatProvider formatProvider)
+                    {
+                        if (arg == null)
+                        {
+                            return string.Empty;
+                        }
+
+                        TimestampDelta numerator;
+                        if (arg is ResourceTimeRange)
+                        {
+                            numerator = ((ResourceTimeRange)arg).Duration;
                         }
                         else if (arg is TimestampDelta)
                         {

--- a/src/Microsoft.Performance.SDK/ResourceTimeRange.cs
+++ b/src/Microsoft.Performance.SDK/ResourceTimeRange.cs
@@ -1,0 +1,428 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Performance.SDK
+{
+    /// <summary>
+    ///     Represents a range between two <see cref="Timestamp"/>s on a resource with an <see cref="int"/> id.
+    /// </summary>
+    [TypeConverter(typeof(ResourceTimeRangeConverter))]
+    [StructLayout(LayoutKind.Sequential)]
+    [DebuggerDisplay("{ResourceId}: {StartTime.ToNanoseconds}ns - {EndTime.ToNanoseconds}ns")]
+    public struct ResourceTimeRange
+        : IEquatable<ResourceTimeRange>,
+          IFormatForClipboard,
+          IConvertible
+    {
+        private int resourceId;
+        private TimeRange timeRange;
+
+        /// <summary>
+        ///     Gets or sets the resource id.
+        /// </summary>
+        public int ResourceId
+        {
+            get
+            {
+                return this.resourceId;
+            }
+
+            set
+            {
+                this.resourceId = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the time range.
+        /// </summary>
+        public TimeRange TimeRange
+        {
+            get
+            {
+                return this.timeRange;
+            }
+
+            set
+            {
+                this.timeRange = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the start of the range.
+        /// </summary>
+        public Timestamp StartTime
+        {
+            get
+            {
+                return this.timeRange.StartTime;
+            }
+
+            set
+            {
+                this.timeRange.StartTime = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the end of the range.
+        /// </summary>
+        public Timestamp EndTime
+        {
+            get
+            {
+                return this.timeRange.EndTime;
+            }
+
+            set
+            {
+                this.timeRange.EndTime = value;
+            }
+        }
+
+        /// <summary>
+        ///     Determines whether the given instances are considered to be equal.
+        /// </summary>
+        /// <param name="first">
+        ///     The first instance.
+        /// </param>
+        /// <param name="second">
+        ///     The second instance.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if the instances are considered to be equal;
+        ///     <c>false</c> otherwise.
+        /// </returns>
+        public static bool operator ==(ResourceTimeRange first, ResourceTimeRange second)
+        {
+            return first.Equals(second);
+        }
+
+        /// <summary>
+        ///     Determines whether the given instances are not considered to be equal.
+        /// </summary>
+        /// <param name="first">
+        ///     The first instance.
+        /// </param>
+        /// <param name="second">
+        ///     The second instance.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if the instances are not considered to be equal;
+        ///     <c>false</c> otherwise.
+        /// </returns>
+        public static bool operator !=(ResourceTimeRange first, ResourceTimeRange second)
+        {
+            return !first.Equals(second);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return (obj != null) && (obj is ResourceTimeRange resourceTimeRange) && Equals(resourceTimeRange);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCodeUtils.CombineHashCodeValues(this.resourceId.GetHashCode(), this.timeRange.GetHashCode());
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ResourceTimeRange other)
+        {
+            return (this.resourceId == other.resourceId) && (this.timeRange == other.timeRange);
+        }
+
+        /// <summary>
+        ///     Gets the duration represented by this <see cref="ResourceTimeRange"/>
+        ///     as a <see cref="TimestampDelta"/>.
+        /// </summary>
+        public TimestampDelta Duration
+        {
+            get
+            {
+                return this.timeRange.Duration;
+            }
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ResourceTimeRange"/>
+        ///     struct.
+        /// </summary>
+        /// <param name="resourceId">
+        ///     The resource id of the resource time range.
+        /// </param>
+        /// <param name="timeRange">
+        ///     The time range of the resource time range.
+        /// </param>
+        public ResourceTimeRange(int resourceId, TimeRange timeRange)
+        {
+            this.resourceId = resourceId;
+            this.timeRange = timeRange;
+        }
+
+        /// <summary>
+        ///     Determines whether this instance contains the given <see cref="Timestamp"/>.
+        /// </summary>
+        /// <param name="time">
+        ///     The time to check.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="time"/> is contained within this range;
+        ///     <c>false</c> otherwise.
+        /// </returns>
+        public bool Contains(Timestamp time)
+        {
+            return this.timeRange.Contains(time);
+        }
+
+        /// <summary>
+        ///     Gets a <see cref="ResourceTimeRange"/> representing no resource time.
+        /// </summary>
+        public static ResourceTimeRange Zero
+        {
+            get
+            {
+                return new ResourceTimeRange(0, TimeRange.Zero);
+            }
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return ToString(new StringBuilder()).ToString();
+        }
+
+        private StringBuilder ToString(StringBuilder sb)
+        {
+            return sb.Append('[').Append(this.resourceId.ToString()).Append(", ").Append(this.timeRange.ToString()).Append(']');
+        }
+
+        /// <summary>
+        ///     Parses the given string into a <see cref="ResourceTimeRange"/>.
+        /// </summary>
+        /// <param name="s">
+        ///     The string to parse.
+        /// </param>
+        /// <returns>
+        ///     The parsed <see cref="ResourceTimeRange" />
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">
+        ///     <paramref name="s"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="System.FormatException">
+        ///     <paramref name="s"/> is not parseable into a <see cref="ResourceTimeRange"/>.
+        /// </exception>
+        public static ResourceTimeRange Parse(string s)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException("s");
+            }
+
+            ResourceTimeRange result;
+            if (!TryParse(s, out result))
+            {
+                throw new FormatException();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Attempts to parse the given string into a <see cref="ResourceTimeRange"/>.
+        /// </summary>
+        /// <param name="s">
+        ///     The string to parse.
+        /// </param>
+        /// <param name="result">
+        ///     The parsed <see cref="ResourceTimeRange"/>; if successful.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if parsing was successful; <c>false</c>
+        ///     otherwise.
+        /// </returns>
+        public static bool TryParse(string s, out ResourceTimeRange result)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException("s");
+            }
+
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                throw new ArgumentOutOfRangeException("s");
+            }
+
+            // "[0,0]" is the shortest string that would work.
+            if (s.Length < 5)
+            {
+                result = ResourceTimeRange.Zero;
+                return false;
+            }
+
+            int leftBracketIndex = s.IndexOf('[');
+            if (leftBracketIndex == -1)
+            {
+                leftBracketIndex = s.IndexOf('(');
+            }
+
+            int commaIndex = s.IndexOf(',');
+            int rightBracketIndex = s.LastIndexOf(']');
+            if (rightBracketIndex == -1)
+            {
+                rightBracketIndex = s.LastIndexOf(')');
+            }
+
+            if (leftBracketIndex != 0 || commaIndex == -1 || rightBracketIndex != (s.Length - 1))
+            {
+                result = ResourceTimeRange.Zero;
+                return false;
+            }
+
+            string beginStr = s.Substring(leftBracketIndex + 1, commaIndex - leftBracketIndex - 1);
+            string endStr = s.Substring(commaIndex + 1, rightBracketIndex - commaIndex - 1);
+
+            int resourceId;
+            TimeRange timeRange;
+
+            if (!int.TryParse(beginStr, out resourceId) || !TimeRange.TryParse(endStr, out timeRange))
+            {
+                result = ResourceTimeRange.Zero;
+                return false;
+            }
+
+            result = new ResourceTimeRange(resourceId, timeRange);
+            return true;
+        }
+
+        /// <inheritdoc />
+        string IFormatForClipboard.ToClipboardString(string format, bool includeUnits)
+        {
+            return TimestampFormatter.ToClipboardString(this.Duration.ToNanoseconds, format, null, includeUnits);
+        }
+
+        /// <inheritdoc />
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(TimestampDelta))
+            {
+                return this.Duration;
+            }
+            else if (conversionType == typeof(ResourceTimeRange)) // needed since Convert.ToType goes down this code-path
+            {
+                return this;
+            }
+            else
+            {
+                throw new InvalidCastException();
+            }
+        }
+
+        /// <inheritdoc />
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        /// <inheritdoc />
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            return Convert.ToBoolean(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            return Convert.ToByte(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            return Convert.ToChar(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return Convert.ToDateTime(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            return this.Duration.ToNanoseconds;
+        }
+
+        /// <inheritdoc />
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            return Convert.ToDouble(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            return Convert.ToSByte(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            return Convert.ToSingle(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return this.ToString();
+        }
+
+        /// <inheritdoc />
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            return Convert.ToUInt16(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            return Convert.ToUInt32(this.Duration.ToNanoseconds);
+        }
+
+        /// <inheritdoc />
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            return Convert.ToUInt64(this.Duration.ToNanoseconds);
+        }
+    }
+}

--- a/src/Microsoft.Performance.SDK/ResourceTimeRangeConverter.cs
+++ b/src/Microsoft.Performance.SDK/ResourceTimeRangeConverter.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Microsoft.Performance.SDK
+{
+    /// <summary>
+    ///     Converts instances to <see cref="TimeRange"/> instances.
+    /// </summary>
+    public sealed class ResourceTimeRangeConverter
+        : TypeConverter,
+          ICustomTypeConverter
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ResourceTimeRangeConverter"/>
+        ///     class.
+        /// </summary>
+        public ResourceTimeRangeConverter()
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc />
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc />
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            string asString = value as string;
+            if (asString != null)
+            {
+                ResourceTimeRange resourceTimeRange;
+
+                if (ResourceTimeRange.TryParse(asString.Trim(), out resourceTimeRange))
+                {
+                    return resourceTimeRange;
+                }
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc />
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture, 
+            object value, 
+            Type destinationType)
+        {
+            if (destinationType == null)
+            {
+                throw new ArgumentNullException("destinationType");
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        /// <inheritdoc />
+        public Type GetOutputType()
+        {
+            return typeof(ResourceTimeRange);
+        }
+    }
+}

--- a/src/Microsoft.Performance.SDK/TimeFormatProviders.cs
+++ b/src/Microsoft.Performance.SDK/TimeFormatProviders.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Performance.SDK
 {
     /// <summary>
     /// Abstract helper for Time based objects
-    /// <see cref="Timestamp"/>, <see cref="TimestampDelta"/>, <see cref="TimeRange"/>.
+    /// <see cref="Timestamp"/>, <see cref="TimestampDelta"/>, <see cref="TimeRange"/>, <see cref="ResourceTimeRange"/>.
     /// <inheritdoc cref="IFormatProvider"/>
     /// </summary>
     [DefaultFormat(TimestampFormatter.FormatSecondsGrouped)]
@@ -37,6 +37,11 @@ namespace Microsoft.Performance.SDK
             {
                 var timeRange = (TimeRange)arg;
                 return TimestampFormatter.ToString(timeRange.Duration.ToNanoseconds, format, formatProvider);
+            }
+            else if (arg is ResourceTimeRange)
+            {
+                var resourceTimeRange = (ResourceTimeRange)arg;
+                return TimestampFormatter.ToString(resourceTimeRange.Duration.ToNanoseconds, format, formatProvider);
             }
             else if (arg is TimestampDelta)
             {
@@ -75,4 +80,10 @@ namespace Microsoft.Performance.SDK
     /// <inheritdoc cref="IFormatProvider"/>
     /// </summary>
     public sealed class TimeRangeFormatProvider : TimeFormatProvider { }
+
+    /// <summary>
+    /// Format Provider for <see cref="ResourceTimeRange"/>.
+    /// <inheritdoc cref="IFormatProvider"/>
+    /// </summary>
+    public sealed class ResourceTimeRangeFormatProvider : TimeFormatProvider { }
 }


### PR DESCRIPTION

# `ResourceTimeRange`

`ResourceTimeRange` is a new duration-like data type that is designed to compute accurately total resource usage when aggregated as `Sum`.

In particular, `Sum` aggregation of `ResourceTimeRange` values avoids both:

* overestimation of total usage in the presence of nested activities on the same resource.
* underestimation of total usage in the presence of activities running concurrently on different resources.

## Differences from current Duration-like Data Types

Two other duration-like data types already exist in the Microsoft Performance Toolkit SDK, `TimeStampDelta` and `TimeRange`.  They either overestimate or underestimate the total usage `ResourceTimeRange` computes, as follows:

* `TimeStampDelta` values sum as the plain sum of durations, irrespective of potential nesting of the respective activities on the same resource.  As such, they _overestimate_ resource usage in the presence of nested activities on the same resource.  However, `TimeStampDelta` correctly accounts for parallel resource usage in the presence of activities running concurrently on different resources.
* `TimeRange` values sum as the total duration of the union of their time intervals, irrespective of potentially parallelism of the respective activities running on different resources.  As such, they _underestimate_ resource usage in the presence of activities running concurrently on different resources.  However, `TimeRange` correctly eliminates resource usage duplication in the presence of nested activities on the same resource.

`ResourceTimeRange` combines the strengths of `TimeStampDelta` and `TimeRange` while eliminating their weaknesses for the use case of computing the total resource usage.

## New Data Type Details

Technically, `ResourceTimeRange` contains both an `int` resource id and a `TimeRange`.  The resource id interpretation can vary from column to column, so that different columns in the same or different tables could perform total resource usage computation on CPUs, disks, processes, threads, etc., depending on the corresponding resource affinity/interaction interpretation of the respective entities in the rows of the table.

Like `TimeRange`, `ResourceTimeRange` is compared and presented as a `TimeStampDelta`, offering an alternative `Sum` aggregation to `TimeStampDelta`'s plain summing of durations.

`ResourceTimeRange` values sum as the sum of across resources of the total duration of the union of their time intervals on the same resource.  As such, they behave like `TimeRange` values on the same resource and like `TimeStampDelta` values across different resources.

`ResourceTimeRange` values also aggregate as `Min`, `Max`, `Count`, `Unique Count`, similar to `TimeRange` values.