### PR TITLE
Add support for static generic methods as bodies for struct functions

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/CodeGenerationContext.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CodeGenerationContext.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Performance.SDK.Processing
             var resultType = methodToCall.ReturnType;
 
             var type = moduleBuilder.DefineType(
-                methodToCall.DeclaringType.FullName + "$." + methodToCall.Name,
+                $"{methodToCall.DeclaringType.FullName}$.{methodToCall.Name}$.{methodToCall.MethodHandle.Value.ToInt64():x16}",
                 TypeAttributes.Public,
                 typeof(ValueType),
                 new Type[] 

--- a/src/Microsoft.Performance.SDK/Processing/CodeGenerationContext.cs
+++ b/src/Microsoft.Performance.SDK/Processing/CodeGenerationContext.cs
@@ -110,6 +110,20 @@ namespace Microsoft.Performance.SDK.Processing
             var resultType = methodToCall.ReturnType;
 
             var type = moduleBuilder.DefineType(
+                //
+                // Notes:
+                //
+                // 1. `MethodInfo.MethodHandle.Value` is used in the name of the generated type as a unique identifier
+                //    to avoid type name collisions.
+                //
+                //    `MethofInfo.DelaringType.FullName` and `MethofInfo.DelaringType.Name` are used there only for
+                //    easy attribution purposes and could, in principle, be removed.  The exact `methodToCall` is
+                //    available in the code of the `get_Item` method of the generated dynamic type.
+                //
+                // 2. The `MethodInfo.MethodHandle.Value` cannot be reused while this generated type is still loaded
+                //    because `methodToCall` is referenced directly in the IL code of the `get_Item` method of the
+                //    generated dynamic type.
+                //
                 $"{methodToCall.DeclaringType.FullName}$.{methodToCall.Name}$.{methodToCall.MethodHandle.Value.ToInt64():x16}",
                 TypeAttributes.Public,
                 typeof(ValueType),


### PR DESCRIPTION
# Problem

The name of the implicitly created struct function type for a static method is fully determined by full name of the static method declaring type and the method name itself.  This leads to runtime exceptions when multiple instantiations of the same generic method or multiple overloads with the same name are used as bodies for multiple concurrent struct functions -- because of a type name collision within the same code generation context module.

# Solution

We can eliminate this type name collision by adding a unique discriminator between generic instantiations and/or overloads.  Such a unique discriminator is the value of the associated `RuntimeMethodHandle`.

This enables the free use of static generic methods and static method overloads as bodies for struct functions, leading to better code sharing and simpler code free of extraneous ad-hoc discriminators.