### PR TITLE
Move TryGetAuthProvider to new IApplicationEnvironmentV2 interface

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/ApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/ApplicationEnvironment.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Performance.SDK.Runtime
 {
     /// <inheritdoc cref="IApplicationEnvironment"/>
     public class ApplicationEnvironment
-        : IApplicationEnvironment
+        : IApplicationEnvironmentV2
     {
         private readonly IMessageBox messageBox;
 

--- a/src/Microsoft.Performance.SDK.Tests/TestClasses/TestApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TestClasses/TestApplicationEnvironment.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace Microsoft.Performance.SDK.Tests.TestClasses
 {
     public class TestApplicationEnvironment
-        : IApplicationEnvironment
+        : IApplicationEnvironmentV2
     {
         public string ApplicationName { get; set; }
 

--- a/src/Microsoft.Performance.SDK/Processing/ApplicationEnvironmentExtensions.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ApplicationEnvironmentExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Performance.SDK.Auth;
 
 namespace Microsoft.Performance.SDK.Processing
 {
@@ -142,6 +143,38 @@ namespace Microsoft.Performance.SDK.Processing
             params object[] args)
         {
             self.DisplayMessage(MessageType.Error, formatProvider, format, args);
+        }
+
+        /// <summary>
+        ///     Attempts to get an <see cref="IAuthProvider{TAuth, TResult}"/> that can provide authentication
+        ///     for <see cref="IAuthMethod{TResult}"/> of type <typeparamref name="TAuth"/>.
+        /// </summary>
+        /// <param name="provider">
+        ///     The found provider, or <c>null</c> if no registered provider can provide authentication for
+        ///     <typeparamref name="TAuth"/>.
+        /// </param>
+        /// <typeparam name="TAuth">
+        ///     The type of the <see cref="IAuthMethod{TResult}"/> for which to attempt to get a provider.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///     The type of the result of a successful authentication for <typeparamref name="TAuth"/>.
+        /// </typeparam>
+        /// <returns>
+        ///     <c>true</c> if a provider was found; <c>false</c> otherwise. If <c>false</c> is returned,
+        ///     <paramref name="provider"/> will be <c>null</c>.
+        /// </returns>
+        public static bool TryGetAuthProvider<TAuth, TResult>(
+            this IApplicationEnvironment applicationEnvironment,
+            out IAuthProvider<TAuth, TResult> provider)
+            where TAuth : IAuthMethod<TResult>
+        {
+            if (applicationEnvironment is IApplicationEnvironmentV2 v2)
+            {
+                return v2.TryGetAuthProvider(out provider);
+            }
+
+            provider = null;
+            return false;
         }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ApplicationEnvironmentExtensions.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ApplicationEnvironmentExtensions.cs
@@ -149,6 +149,9 @@ namespace Microsoft.Performance.SDK.Processing
         ///     Attempts to get an <see cref="IAuthProvider{TAuth, TResult}"/> that can provide authentication
         ///     for <see cref="IAuthMethod{TResult}"/> of type <typeparamref name="TAuth"/>.
         /// </summary>
+        /// <param name="self">
+        ///     The <see cref="IApplicationEnvironment"/> instance.
+        /// </param>
         /// <param name="provider">
         ///     The found provider, or <c>null</c> if no registered provider can provide authentication for
         ///     <typeparamref name="TAuth"/>.
@@ -164,11 +167,11 @@ namespace Microsoft.Performance.SDK.Processing
         ///     <paramref name="provider"/> will be <c>null</c>.
         /// </returns>
         public static bool TryGetAuthProvider<TAuth, TResult>(
-            this IApplicationEnvironment applicationEnvironment,
+            this IApplicationEnvironment self,
             out IAuthProvider<TAuth, TResult> provider)
             where TAuth : IAuthMethod<TResult>
         {
-            if (applicationEnvironment is IApplicationEnvironmentV2 v2)
+            if (self is IApplicationEnvironmentV2 v2)
             {
                 return v2.TryGetAuthProvider(out provider);
             }

--- a/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironment.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.Performance.SDK.Auth;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Extensibility.SourceParsing;
 
@@ -118,26 +117,5 @@ namespace Microsoft.Performance.SDK.Processing
             string caption,
             string format,
             params object[] args);
-
-        /// <summary>
-        ///     Attempts to get an <see cref="IAuthProvider{TAuth, TResult}"/> that can provide authentication
-        ///     for <see cref="IAuthMethod{TResult}"/> of type <typeparamref name="TAuth"/>.
-        /// </summary>
-        /// <param name="provider">
-        ///     The found provider, or <c>null</c> if no registered provider can provide authentication for
-        ///     <typeparamref name="TAuth"/>.
-        /// </param>
-        /// <typeparam name="TAuth">
-        ///     The type of the <see cref="IAuthMethod{TResult}"/> for which to attempt to get a provider.
-        /// </typeparam>
-        /// <typeparam name="TResult">
-        ///     The type of the result of a successful authentication for <typeparamref name="TAuth"/>.
-        /// </typeparam>
-        /// <returns>
-        ///     <c>true</c> if a provider was found; <c>false</c> otherwise. If <c>false</c> is returned,
-        ///     <paramref name="provider"/> will be <c>null</c>.
-        /// </returns>
-        bool TryGetAuthProvider<TAuth, TResult>(out IAuthProvider<TAuth, TResult> provider)
-            where TAuth : IAuthMethod<TResult>;
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironmentV2.cs
+++ b/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironmentV2.cs
@@ -3,6 +3,9 @@ using Microsoft.Performance.SDK.Auth;
 
 namespace Microsoft.Performance.SDK.Processing
 {
+    /// <summary>
+    ///     Extends <see cref="IApplicationEnvironment"/> to provide additional functionality.
+    /// </summary>
     [Obsolete("This interface will be removed in version 2.0 of the SDK. It is OK to use this interface in version 1.x of the SDK.")]
     public interface IApplicationEnvironmentV2
         : IApplicationEnvironment

--- a/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironmentV2.cs
+++ b/src/Microsoft.Performance.SDK/Processing/IApplicationEnvironmentV2.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Performance.SDK.Auth;
+
+namespace Microsoft.Performance.SDK.Processing
+{
+    [Obsolete("This interface will be removed in version 2.0 of the SDK. It is OK to use this interface in version 1.x of the SDK.")]
+    public interface IApplicationEnvironmentV2
+        : IApplicationEnvironment
+    {
+        /// <summary>
+        ///     Attempts to get an <see cref="IAuthProvider{TAuth, TResult}"/> that can provide authentication
+        ///     for <see cref="IAuthMethod{TResult}"/> of type <typeparamref name="TAuth"/>.
+        /// </summary>
+        /// <param name="provider">
+        ///     The found provider, or <c>null</c> if no registered provider can provide authentication for
+        ///     <typeparamref name="TAuth"/>.
+        /// </param>
+        /// <typeparam name="TAuth">
+        ///     The type of the <see cref="IAuthMethod{TResult}"/> for which to attempt to get a provider.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///     The type of the result of a successful authentication for <typeparamref name="TAuth"/>.
+        /// </typeparam>
+        /// <returns>
+        ///     <c>true</c> if a provider was found; <c>false</c> otherwise. If <c>false</c> is returned,
+        ///     <paramref name="provider"/> will be <c>null</c>.
+        /// </returns>
+        bool TryGetAuthProvider<TAuth, TResult>(out IAuthProvider<TAuth, TResult> provider)
+            where TAuth : IAuthMethod<TResult>;
+    }
+}

--- a/src/Microsoft.Performance.Testing.SDK/StubApplicationEnvironment.cs
+++ b/src/Microsoft.Performance.Testing.SDK/StubApplicationEnvironment.cs
@@ -10,7 +10,7 @@ using System;
 namespace Microsoft.Performance.Testing.SDK
 {
     public class StubApplicationEnvironment
-        : IApplicationEnvironment
+        : IApplicationEnvironmentV2
     {
         public string ApplicationName { get; set; }
 


### PR DESCRIPTION
This ensures backwards compatibility with plugins on 1.x