### PR TITLE
Un-consolidate ColumnConfiguration constructors

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/ColumnConfiguration.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnConfiguration.cs
@@ -17,6 +17,43 @@ namespace Microsoft.Performance.SDK.Processing
         /// <param name="metadata">
         ///     The metadata about the column.
         /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        ///     <paramref name="metadata"/> is <c>null</c>.
+        /// </exception>
+        public ColumnConfiguration(ColumnMetadata metadata)
+            : this(metadata, null, null)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ColumnConfiguration"/>
+        ///     class.
+        /// </summary>
+        /// <param name="metadata">
+        ///     The metadata about the column.
+        /// </param>
+        /// <param name="hints">
+        ///     Optional hints about displaying this column in the UI. This parameter
+        ///     may be <c>null</c>. If this parameter is <c>null</c>, then
+        ///     <see cref="UIHints.Default"/> will be used for this instance.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        ///     <paramref name="metadata"/> is <c>null</c>.
+        /// </exception>
+        public ColumnConfiguration(
+            ColumnMetadata metadata,
+            UIHints hints)
+            : this(metadata, hints, null)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ColumnConfiguration"/>
+        ///     class.
+        /// </summary>
+        /// <param name="metadata">
+        ///     The metadata about the column.
+        /// </param>
         /// <param name="hints">
         ///     Optional hints about displaying this column in the UI. This parameter
         ///     may be <c>null</c>. If this parameter is <c>null</c>, then
@@ -30,8 +67,8 @@ namespace Microsoft.Performance.SDK.Processing
         /// </exception>
         public ColumnConfiguration(
             ColumnMetadata metadata,
-            UIHints hints = null,
-            Guid? variantGuid = null)
+            UIHints hints,
+            Guid? variantGuid)
         {
             Guard.NotNull(metadata, nameof(metadata));
 

--- a/src/Microsoft.Performance.SDK/Processing/ColumnConfiguration.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnConfiguration.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Performance.SDK.Processing
         public ColumnConfiguration(ColumnMetadata metadata)
             : this(metadata, null, null)
         {
+            // These telescoping constructors are required to maintain backwards compatibility.
+            // Do not consolidate to a constructor with optional parameters since that breaks the API.
         }
 
         /// <summary>
@@ -45,6 +47,8 @@ namespace Microsoft.Performance.SDK.Processing
             UIHints hints)
             : this(metadata, hints, null)
         {
+            // These telescoping constructors are required to maintain backwards compatibility.
+            // Do not consolidate to a constructor with optional parameters since that breaks the API.
         }
 
         /// <summary>


### PR DESCRIPTION
Plugins that used the old constructors cannot call the new one with default parameters.