### PR TITLE
Enable custom processor environments in the Engine.

### DIFF
--- a/src/Microsoft.Performance.Toolkit.Engine/EngineCreateInfo.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/EngineCreateInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Performance.Toolkit.Engine
 
         private readonly Dictionary<Type, object> authProviders = new Dictionary<Type, object>();
 
-        private ProcessEnvironmentFactory processEnvironmentFactory;
+        private ProcessorEnvironmentFactory processEnvironmentFactory;
 
         /// <summary>
         ///     Initializes the statc members of the <see cref="EngineCreateInfo"/>
@@ -150,7 +150,7 @@ namespace Microsoft.Performance.Toolkit.Engine
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="factory"/> is <c>null</c>.
         /// </exception>
-        public EngineCreateInfo WithProcessorEnvironmentFactory(ProcessEnvironmentFactory factory)
+        public EngineCreateInfo WithProcessorEnvironmentFactory(ProcessorEnvironmentFactory factory)
         {
             Guard.NotNull(factory, nameof(factory));
 
@@ -198,7 +198,7 @@ namespace Microsoft.Performance.Toolkit.Engine
         /// </summary>
         public bool IsInteractive { get; set; }
 
-        internal ProcessEnvironmentFactory ProcessEnvironmentFactory
+        internal ProcessorEnvironmentFactory ProcessEnvironmentFactory
         {
             get
             {

--- a/src/Microsoft.Performance.Toolkit.Engine/EngineCreateInfo.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/EngineCreateInfo.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Auth;
 using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Runtime;
 
 namespace Microsoft.Performance.Toolkit.Engine
 {
@@ -16,9 +17,11 @@ namespace Microsoft.Performance.Toolkit.Engine
     /// </summary>
     public sealed class EngineCreateInfo
     {
-        private static string DefaultRuntimeName;
+        private static readonly string DefaultRuntimeName;
 
         private readonly Dictionary<Type, object> authProviders = new Dictionary<Type, object>();
+
+        private ProcessEnvironmentFactory processEnvironmentFactory;
 
         /// <summary>
         ///     Initializes the statc members of the <see cref="EngineCreateInfo"/>
@@ -135,6 +138,27 @@ namespace Microsoft.Performance.Toolkit.Engine
         }
 
         /// <summary>
+        ///     Registers a <see cref="ProcessEnvironmentFactory"/> to use for generating a custom processor 
+        ///     environment.
+        /// </summary>
+        /// <param name="factory">
+        ///     Factory for generating a <see cref="ProcessorEnvironment"/>.
+        /// </param>
+        /// <returns>
+        ///     The instance of <see cref="EngineCreateInfo"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="factory"/> is <c>null</c>.
+        /// </exception>
+        public EngineCreateInfo WithProcessorEnvironmentFactory(ProcessEnvironmentFactory factory)
+        {
+            Guard.NotNull(factory, nameof(factory));
+
+            this.ProcessEnvironmentFactory = factory;
+            return this;
+        }
+
+        /// <summary>
         ///     Gets or sets the name of the runtime on which the application is built.
         /// </summary>
         /// <remarks>
@@ -173,6 +197,22 @@ namespace Microsoft.Performance.Toolkit.Engine
         ///     will fail. By default, this property is <c>false</c>.
         /// </summary>
         public bool IsInteractive { get; set; }
+
+        internal ProcessEnvironmentFactory ProcessEnvironmentFactory
+        {
+            get
+            {
+                // Wrap any custom factory in the default factory. If there is no custom factory, or if it returns null,
+                // then a default runtime will be created.
+                return new RuntimeProcessorEnvironmentFactory(
+                    (type) => this.LoggerFactory?.Invoke(type) ?? Logger.Create(type),
+                    this.processEnvironmentFactory);
+            }
+            private set
+            {
+                this.processEnvironmentFactory = value;
+            }
+        }
 
         internal ReadOnlyDictionary<Type, object> AuthProviders => new ReadOnlyDictionary<Type, object>(this.authProviders);
     }

--- a/src/Microsoft.Performance.Toolkit.Engine/ProcessEnvironmentFactory.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/ProcessEnvironmentFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
+
+
+namespace Microsoft.Performance.Toolkit.Engine
+{
+    /// <summary>
+    ///     This is used to generate processor environments.
+    /// </summary>
+    public abstract class ProcessEnvironmentFactory
+    {
+        /// <summary>
+        ///     Creates a <see cref="ProcessorEnvironment"/> for a processor.
+        /// </summary>
+        /// <param name="processingSourceIdentifier">
+        ///     Identifies the source processor used to generate the data processor.
+        /// </param>
+        /// <param name="dataSourceGroup">
+        ///     A collection of <see cref="IDataSource"/>s that a <see cref="ICustomDataProcessor"/> can process together
+        ///     in a specified <see cref="IProcessingMode"/>.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="ProcessorEnvironment"/> or <c>null</c>. When <c>null</c> is returned, a default processor 
+        ///     environment will be used.
+        /// </returns>
+        public abstract ProcessorEnvironment CreateProcessorEnvironment(
+            Guid processingSourceIdentifier,
+            IDataSourceGroup dataSourceGroup);
+    }
+}

--- a/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironment.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironment.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Performance.SDK.Processing;
+
+namespace Microsoft.Performance.Toolkit.Engine
+{
+    public abstract class ProcessorEnvironment
+        : IProcessorEnvironment
+    {
+        /// <inheritdoc/>
+        public abstract ILogger CreateLogger(Type processorType);
+
+        /// <inheritdoc />
+        /// <remarks>
+        ///     This implementation does not support the concept of dynamic table builder and always returns 
+        ///     <c>null</c>.
+        /// </remarks>
+        public virtual IDynamicTableBuilder RequestDynamicTableBuilder(TableDescriptor descriptor)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironment.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironment.cs
@@ -6,6 +6,7 @@ using Microsoft.Performance.SDK.Processing;
 
 namespace Microsoft.Performance.Toolkit.Engine
 {
+    /// <inheritdoc cref="IProcessorEnvironment"/>
     public abstract class ProcessorEnvironment
         : IProcessorEnvironment
     {

--- a/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironmentFactory.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironmentFactory.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
 
-
 namespace Microsoft.Performance.Toolkit.Engine
 {
     /// <summary>

--- a/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironmentFactory.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/ProcessorEnvironmentFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Performance.Toolkit.Engine
     /// <summary>
     ///     This is used to generate processor environments.
     /// </summary>
-    public abstract class ProcessEnvironmentFactory
+    public abstract class ProcessorEnvironmentFactory
     {
         /// <summary>
         ///     Creates a <see cref="ProcessorEnvironment"/> for a processor.

--- a/src/Microsoft.Performance.Toolkit.Engine/RuntimeProcessorEnvironmentFactory.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/RuntimeProcessorEnvironmentFactory.cs
@@ -10,12 +10,12 @@ using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
 namespace Microsoft.Performance.Toolkit.Engine
 {
     internal sealed class RuntimeProcessorEnvironmentFactory
-        : ProcessEnvironmentFactory
+        : ProcessorEnvironmentFactory
     {
         private readonly Func<Type, ILogger> loggerFactory;
-        private readonly ProcessEnvironmentFactory wrappedFactory;
+        private readonly ProcessorEnvironmentFactory wrappedFactory;
 
-        public RuntimeProcessorEnvironmentFactory(Func<Type, ILogger> loggerFactory, ProcessEnvironmentFactory wrappedFactory)
+        public RuntimeProcessorEnvironmentFactory(Func<Type, ILogger> loggerFactory, ProcessorEnvironmentFactory wrappedFactory)
         {
             Debug.Assert(loggerFactory != null);
             this.loggerFactory = loggerFactory;

--- a/src/Microsoft.Performance.Toolkit.Engine/RuntimeProcessorEnvironmentFactory.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/RuntimeProcessorEnvironmentFactory.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
+
+namespace Microsoft.Performance.Toolkit.Engine
+{
+    internal sealed class RuntimeProcessorEnvironmentFactory
+        : ProcessEnvironmentFactory
+    {
+        private readonly Func<Type, ILogger> loggerFactory;
+        private readonly ProcessEnvironmentFactory wrappedFactory;
+
+        public RuntimeProcessorEnvironmentFactory(Func<Type, ILogger> loggerFactory, ProcessEnvironmentFactory wrappedFactory)
+        {
+            Debug.Assert(loggerFactory != null);
+            this.loggerFactory = loggerFactory;
+            this.wrappedFactory = wrappedFactory;
+        }
+
+        public override ProcessorEnvironment CreateProcessorEnvironment(
+            Guid processingSourceIdentifier,
+            IDataSourceGroup dataSourceGroup)
+        {
+            return this.wrappedFactory?.CreateProcessorEnvironment(processingSourceIdentifier, dataSourceGroup)
+                ?? new RuntimeProcessorEnvironment(this.loggerFactory);
+        }
+
+        private sealed class RuntimeProcessorEnvironment
+            : ProcessorEnvironment
+        {
+            private readonly Func<Type, ILogger> loggerFactory;
+            private readonly object loggerLock = new object();
+
+            private ILogger logger;
+            private Type processorType;
+
+            public RuntimeProcessorEnvironment(
+                Func<Type, ILogger> loggerFactory)
+            {
+                Debug.Assert(loggerFactory != null);
+
+                this.loggerFactory = loggerFactory;
+            }
+
+            public override ILogger CreateLogger(Type processorType)
+            {
+                Guard.NotNull(processorType, nameof(processorType));
+
+                lock (this.loggerLock)
+                {
+                    if (logger != null)
+                    {
+                        if (this.processorType != processorType)
+                        {
+                            throw new ArgumentException(
+                                $"{nameof(CreateLogger)} cannot be called with multiple types in a single instance.",
+                                nameof(processorType));
+                        }
+
+                        return this.logger;
+                    }
+
+                    this.processorType = processorType;
+                    this.logger = this.loggerFactory(processorType);
+                    return this.logger;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change allows a factory to be passed into EngineCreateInfo that will be used to create custom processor environments.

A new default factory, RuntimeProcessorEnvironmentFactory, was created and the existing RuntimeProcessorEnvironment was moved from Engine to this class. This default environment is now used if no custom factory is assigned, or if the custom factory returns null.