### PR TITLE
Remove references to static Logger.Create.

### DIFF
--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemPluginRegistryTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemPluginRegistryTests.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using AutoFixture;
 using Microsoft.Performance.SDK.Processing;
+using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Testing;
+using Microsoft.Performance.Toolkit.Plugins.Core;
+using Microsoft.Performance.Toolkit.Plugins.Core.Metadata;
 using Microsoft.Performance.Toolkit.Plugins.Core.Serialization;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Text.Json;
-using AutoFixture;
 using Fixture = AutoFixture.Fixture;
-using Microsoft.Performance.Toolkit.Plugins.Core;
-using Microsoft.Performance.Toolkit.Plugins.Core.Metadata;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
                 .Throws<ArgumentNullException>();
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.GetAllAsync(CancellationToken.None));
         }
@@ -76,7 +77,8 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var fakeSerializer = new Mock<ISerializer<List<InstalledPluginInfo>>>();
             var sut = new FileBackedPluginRegistry(
                 this.registryRoot,
-                fakeSerializer.Object);
+                fakeSerializer.Object,
+                Logger.Create);
 
             IReadOnlyCollection<InstalledPluginInfo> result = await sut.GetAllAsync(CancellationToken.None);
 
@@ -93,7 +95,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                 fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new List<InstalledPluginInfo>());
 
-                var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+                var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
                 await Assert.ThrowsExceptionAsync<RepositoryDataAccessException>(() => sut.GetAllAsync(CancellationToken.None));
             }
@@ -138,7 +140,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>(expectedResult));
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             IReadOnlyCollection<InstalledPluginInfo> actualResult = await sut.GetAllAsync(CancellationToken.None);
 
@@ -161,7 +163,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>() { fakeInstalledPluginInfo });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             InstalledPluginInfo actualResult = await sut.TryGetByIdAsync(fakeInstalledPluginInfo.Metadata.Identity.Id, CancellationToken.None);
 
@@ -179,7 +181,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>());
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             InstalledPluginInfo actualResult = await sut.TryGetByIdAsync(fakeInstalledPluginInfo.Metadata.Identity.Id, CancellationToken.None);
 
@@ -197,7 +199,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>() { fakeInstalledPluginInfo, fakeInstalledPluginInfo });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.TryGetByIdAsync(fakeInstalledPluginInfo.Metadata.Identity.Id, CancellationToken.None));
         }
@@ -217,7 +219,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>() { fakeInstalledPluginInfo });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             bool actualResult = await sut.ExistsAsync(fakeInstalledPluginInfo, CancellationToken.None);
 
@@ -235,7 +237,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>());
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             bool actualResult = await sut.ExistsAsync(fakeInstalledPluginInfo, CancellationToken.None);
 
@@ -253,7 +255,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>() { fakeInstalledPluginInfo, fakeInstalledPluginInfo });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.ExistsAsync(fakeInstalledPluginInfo, CancellationToken.None));
         }
@@ -269,7 +271,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var fakeSerializer = new Mock<ISerializer<List<InstalledPluginInfo>>>();
             InstalledPluginInfo fakeInstalledPluginInfo = new Fixture().Create<InstalledPluginInfo>();
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await sut.AddAsync(fakeInstalledPluginInfo, CancellationToken.None);
 
@@ -297,7 +299,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin1,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await sut.AddAsync(plugin2, CancellationToken.None);
 
@@ -325,7 +327,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin2
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.AddAsync(plugin1, CancellationToken.None));
         }
@@ -341,7 +343,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var fakeSerializer = new Mock<ISerializer<List<InstalledPluginInfo>>>();
             InstalledPluginInfo fakeInstalledPluginInfo = new Fixture().Create<InstalledPluginInfo>();
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => sut.DeleteAsync(fakeInstalledPluginInfo, CancellationToken.None));
@@ -365,7 +367,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin2,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await sut.DeleteAsync(plugin1, CancellationToken.None);
 
@@ -392,7 +394,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin1,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
         }
@@ -415,7 +417,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin1,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
         }
@@ -433,7 +435,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             InstalledPluginInfo fakeInstalledPluginInfo = new Fixture().Create<InstalledPluginInfo>();
             var fakeUpdatedPluginInfo = CreatePluginWithDifferentIdVersion(fakeInstalledPluginInfo);
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => sut.UpdateAsync(fakeInstalledPluginInfo, fakeUpdatedPluginInfo, CancellationToken.None));
@@ -448,7 +450,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             InstalledPluginInfo fakeInstalledPluginInfo = new Fixture().Create<InstalledPluginInfo>();
             var toUpdate = CreatePluginWithDifferentInstallDate(fakeInstalledPluginInfo);
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => sut.UpdateAsync(fakeInstalledPluginInfo, toUpdate, CancellationToken.None));
@@ -467,7 +469,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             fakeSerializer.Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()).Result)
                 .Returns(new List<InstalledPluginInfo>());
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
         }
@@ -488,7 +490,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     toUpdate,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
         }
@@ -509,7 +511,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                     plugin1,
                 });
 
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             await sut.UpdateAsync(plugin1, plugin2, CancellationToken.None);
 
@@ -528,7 +530,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         public async Task AquireLock_Succeeds()
         {
             var fakeSerializer = new Mock<ISerializer<List<InstalledPluginInfo>>>();
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             using (IDisposable _ = await sut.AquireLockAsync(CancellationToken.None, null))
             {
@@ -543,7 +545,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         public async Task AquireLock_Fails()
         {
             var fakeSerializer = new Mock<ISerializer<List<InstalledPluginInfo>>>();
-            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
+            var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object, Logger.Create);
 
             Task<IDisposable> attempt;
             using (IDisposable _ = await sut.AquireLockAsync(CancellationToken.None, null))

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/PluginSourcesRepositoryTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/PluginSourcesRepositoryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Specialized;
+using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Testing;
 using Microsoft.Performance.Toolkit.Plugins.Core.Discovery;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,7 +18,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Single_New_Added()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var source = new PluginSource(FakeUris.Uri1);
 
             bool success = repo.Add(source);
@@ -55,7 +56,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Single_CollectionChangedInvoked()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var source = new PluginSource(FakeUris.Uri1);
             bool raised = false;
 
@@ -91,7 +92,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Single_NullItem_ThrowsArgumentNullException()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
 
             PluginSource? pluginSource = null;
             Assert.ThrowsException<ArgumentNullException>(() => repo.Add(pluginSource));
@@ -104,7 +105,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Multiple_New_Added()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var sources = new PluginSource[]
             {
                 new PluginSource(FakeUris.Uri1),
@@ -137,7 +138,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Multiple_CollectionChangedInvoked()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var sources = new PluginSource[]
             {
                 new PluginSource(FakeUris.Uri1),
@@ -176,7 +177,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Add_Mutiple_ThrowsArgumentNullException()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
 
             PluginSource[]? pluginSources = null;
             Assert.ThrowsException<ArgumentNullException>(() => repo.Add(pluginSources));
@@ -267,7 +268,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Remove_Single_ThrowsArgumentNullException()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
 
             PluginSource? pluginSource = null;
             Assert.ThrowsException<ArgumentNullException>(() => repo.Remove(pluginSource));
@@ -361,7 +362,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void Remove_Multiple_ThrowsArgumentNullException()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
 
             PluginSource[]? pluginSources = null;
             Assert.ThrowsException<ArgumentNullException>(() => repo.Remove(pluginSources));
@@ -376,7 +377,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void CollectionChanged_NewItem_Correct()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var source = new PluginSource(FakeUris.Uri1);
 
             repo.CollectionChanged += (s, e) =>
@@ -392,7 +393,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
         [UnitTest]
         public void CollectionChanged_NewItems_Correct()
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             var sources = new[]
             {
                 new PluginSource(FakeUris.Uri1),
@@ -450,7 +451,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
         private PluginSourceRepository CreateSut(IEnumerable<PluginSource>? existingPluginSources)
         {
-            var repo = new PluginSourceRepository();
+            var repo = new PluginSourceRepository(Logger.Create);
             if (existingPluginSources != null && existingPluginSources.Any())
             {
                 repo.Add(existingPluginSources);

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Discovery/PluginsDiscoveryOrchestrator.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Discovery/PluginsDiscoveryOrchestrator.cs
@@ -460,7 +460,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Discovery
 
                 Debug.Assert(discoverer != null);
 
-                discoverer.SetLogger(Logger.Create(discoverer.GetType()));
+                discoverer.SetLogger(this.loggerFactory.Invoke(discoverer.GetType()));
                 results.Add(discoverer);
             }
 

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginsSystemResourceRepository.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Extensibility/PluginsSystemResourceRepository.cs
@@ -7,7 +7,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Processing;
-using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Toolkit.Plugins.Core.Extensibility;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Common;
 
@@ -20,29 +19,8 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
         where T : IPluginsSystemResource
     {
         private readonly HashSet<PluginsSystemResourceReference> resources;
-        private readonly ILogger logger;
         private readonly Func<Type, ILogger> loggerFactory;
         private readonly object mutex = new object();
-
-        /// <summary>
-        ///     Initializes a <see cref="PluginsSystemResourceRepository{T}"/> with an empty collection of resources.
-        /// </summary>
-        public PluginsSystemResourceRepository()
-            : this(Logger.Create)
-        {
-        }
-
-        /// <summary>
-        ///     Initializes a <see cref="PluginsSystemResourceRepository{T}"/> with an existing collection of <paramref name="resources"/>.
-        /// </summary>
-        /// <param name="resources">
-        ///     A collection of <see cref="IPluginsSystemResource"s of type <see cref="T"/>.
-        /// </param>
-        public PluginsSystemResourceRepository(
-            IEnumerable<T> resources)
-            : this(resources, Logger.Create)
-        {
-        }
 
         /// <summary>
         ///     Initializes a <see cref="PluginsSystemResourceRepository{T}"/> with an empty collection of resources and a logger factory.
@@ -72,7 +50,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Extensibility
             Guard.NotNull(resources, nameof(resources));
 
             this.loggerFactory = loggerFactory;
-            this.logger = loggerFactory(typeof(PluginsSystemResourceRepository<T>));
             SetResourcesLoggers(resources.ToArray());
             this.resources = new HashSet<PluginsSystemResourceReference>(resources.Select(r => new PluginsSystemResourceReference(r)));
         }

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/PluginSourceRepository.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/PluginSourceRepository.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Processing;
-using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Toolkit.Plugins.Core.Discovery;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Common;
 
@@ -35,14 +34,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory(typeof(PluginSourceRepository));
             this.currentSources = new HashSet<PluginSource>();
-        }
-
-        /// <summary>
-        ///    Creates an instance of the <see cref="PluginSourceRepository"/>.
-        /// </summary>
-        internal PluginSourceRepository()
-            : this(Logger.Create)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/FileBackedPluginRegistry.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Registry/FileBackedPluginRegistry.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Medallion.Threading.FileSystem;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Processing;
-using Microsoft.Performance.SDK.Runtime;
 using Microsoft.Performance.Toolkit.Plugins.Core.Serialization;
 using Microsoft.Performance.Toolkit.Plugins.Runtime.Exceptions;
 
@@ -33,23 +32,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
         private readonly ISerializer<List<InstalledPluginInfo>> registryFileSerializer;
 
         private readonly ILogger logger;
-        private readonly Func<Type, ILogger> loggerFactory;
-
-        /// <summary>
-        ///     Creates an instance of <see cref="FileBackedPluginRegistry"/> with a registry root and a serializer.
-        /// </summary>
-        /// <param name="registryRoot">
-        ///     The root directory of the registry.
-        /// </param>
-        /// <param name="serializer">
-        ///     Used to serialize and deserialize the registry file.
-        /// </param>
-        public FileBackedPluginRegistry(
-            string registryRoot,
-            ISerializer<List<InstalledPluginInfo>> serializer)
-            : this(registryRoot, serializer, Logger.Create)
-        {
-        }
 
         /// <summary>
         ///     Creates an instance of <see cref="FileBackedPluginRegistry"/> with a registry root and a logger.
@@ -82,7 +64,6 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime
             this.registryRoot = Path.GetFullPath(registryRoot);
             this.registryFilePath = Path.Combine(registryRoot, registryFileName);
             this.registryFileSerializer = serializer;
-            this.loggerFactory = loggerFactory;
             this.logger = loggerFactory(typeof(FileBackedPluginRegistry));
 
             string lockFilePath = Path.Combine(registryRoot, lockFileName);

--- a/src/SDK.sln
+++ b/src/SDK.sln
@@ -43,6 +43,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Performance.Toolk
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PluginConfigurationEditor", "Tools\PluginConfigurationEditor\PluginConfigurationEditor.csproj", "{B010E944-C96D-4152-8CA6-38E5D53070E1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFiles", "SolutionFiles", "{69A945DD-619C-45D6-BC3F-24AAF24F482F}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		nuget.config = nuget.config
+		version.json = version.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
PluginsDiscoveryOrchestrator was using Logger.Create despite having stored a logger factory.

Several other classes had constructors that default to Logger.Create as a logger factory. Rather than keeping these around, the tests that used these now pass in Logger.Create.
