### PR TITLE
Engine.Dispose disposes of any created processors.

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/ProcessingSourceExecutor.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/ProcessingSourceExecutor.cs
@@ -200,14 +200,14 @@ namespace Microsoft.Performance.SDK.Runtime
             {
                 if (disposing)
                 {
-                    if ((this.Processor is not null) && (this.Processor is IDisposable disposable))
+                    if (this.Processor is not null)
                     {
                         this.Context?.ProcessingSource?.Instance?.DisposeProcessor(this.Processor);
 
                         // The default behavior for ProcessingSource.DisposeProcessor() is to do nothing
                         // and disposing a second time shouldn't have negative consequences.
                         //
-                        disposable.Dispose();
+                        this.Processor.TryDispose();
                     }
                 }
 

--- a/src/Microsoft.Performance.SDK.Runtime/ProcessingSourceExecutor.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/ProcessingSourceExecutor.cs
@@ -14,10 +14,15 @@ namespace Microsoft.Performance.SDK.Runtime
     ///     Executes the <see cref="ICustomDataProcessor"/> of a <see cref="IProcessingSource"/>.
     /// </summary>
     public sealed class ProcessingSourceExecutor
+        : IDisposable
     {
+        private readonly ILogger logger;
+
+        private ICustomDataProcessor processor;
+        private ExecutionContext context;
         private List<TableDescriptor> enabledTables;
         private Dictionary<TableDescriptor, Exception> failedToEnableTables;
-        private readonly ILogger logger;
+        private bool disposedValue;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ProcessingSourceExecutor"/>
@@ -48,12 +53,34 @@ namespace Microsoft.Performance.SDK.Runtime
         /// <summary>
         ///     The custom data processor created by this object.
         /// </summary>
-        public ICustomDataProcessor Processor { get; private set; }
+        public ICustomDataProcessor Processor
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return this.processor;
+            }
+            private set
+            {
+                this.processor = value;
+            }
+        }
 
         /// <summary>
         ///     Provides access to the <see cref="ExecutionContext"/> used to initialize this object.
         /// </summary>
-        public ExecutionContext Context { get; private set; }
+        public ExecutionContext Context
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return this.context;
+            }
+            private set
+            {
+                this.context = value;
+            }
+        }
 
         /// <summary>
         ///     Creates the custom data processor and enables the specified tables.
@@ -63,6 +90,8 @@ namespace Microsoft.Performance.SDK.Runtime
         /// </param>
         public void InitializeCustomDataProcessor(ExecutionContext context)
         {
+            ThrowIfDisposed();
+
             Guard.NotNull(context, nameof(context));
 
             this.Processor = context.ProcessingSource.CreateProcessor(
@@ -114,6 +143,8 @@ namespace Microsoft.Performance.SDK.Runtime
         public async Task<ExecutionResult> ExecuteAsync(
             CancellationToken cancellationToken)
         {
+            ThrowIfDisposed();
+
             if (this.Processor == null)
             {
                 throw new InvalidOperationException($"{nameof(this.InitializeCustomDataProcessor)} wasn't successfully called before calling this method.");
@@ -154,6 +185,46 @@ namespace Microsoft.Performance.SDK.Runtime
                 this.Processor,
                 this.failedToEnableTables,
                 metadataName);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!this.disposedValue)
+            {
+                if (disposing)
+                {
+                    if ((this.Processor is not null) && (this.Processor is IDisposable disposable))
+                    {
+                        this.Context?.ProcessingSource?.Instance?.DisposeProcessor(this.Processor);
+
+                        // The default behavior for ProcessingSource.DisposeProcessor() is to do nothing
+                        // and disposing a second time shouldn't have negative consequences.
+                        //
+                        disposable.Dispose();
+                    }
+                }
+
+                this.enabledTables = null;
+                this.failedToEnableTables = null;
+                this.Processor = null;
+                this.Context = null;
+                this.disposedValue = true;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (this.disposedValue)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
         }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -682,6 +682,19 @@ namespace Microsoft.Performance.Toolkit.Engine
 
             if (disposing)
             {
+                if (this.executors != null)
+                {
+                    foreach (ProcessingSourceExecutor executor in this.executors)
+                    {
+                        if (executor.Processor is null)
+                        {
+                            continue;
+                        }
+
+                        executor.Context.ProcessingSource.Instance.DisposeProcessor(executor.Processor);
+                    }
+                }
+
                 //
                 // we diposes the original set only if we own the data sources.
                 // this only occurs when the user uses one of the convenience
@@ -699,6 +712,7 @@ namespace Microsoft.Performance.Toolkit.Engine
             this.workingDataSourceSet = null;
             this.internalDataSourceSet = null;
             this.tablesToProcessors = null;
+            this.executors = null;
             this.isDisposed = true;
         }
 

--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -686,12 +686,7 @@ namespace Microsoft.Performance.Toolkit.Engine
                 {
                     foreach (ProcessingSourceExecutor executor in this.executors)
                     {
-                        if (executor.Processor is null)
-                        {
-                            continue;
-                        }
-
-                        executor.Context.ProcessingSource.Instance.DisposeProcessor(executor.Processor);
+                        executor.Dispose();
                     }
                 }
 


### PR DESCRIPTION
These processors would eventually be disposed when the PluginSet is disposed. However, it is better to dispose of these in the Engine where they were created as they cannot be used beyond this point.

If a PluginSet is used to create many engines over time, such as in a service, then these data processors would have lived long beyond their expected lifetime, leaking memory.