### PR TITLE
Support exposing timezones relevant to processed datasources

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/DataSourceInfo.cs
+++ b/src/Microsoft.Performance.SDK/Processing/DataSourceInfo.cs
@@ -136,5 +136,10 @@ namespace Microsoft.Performance.SDK.Processing
                 return this.FirstEventWallClockUtc.AddTicks(this.EndTimestampNanoseconds / 100);
             }
         }
+
+        /// <summary>
+        ///     Gets or initializes the time zones that are of significance to this data source.
+        /// </summary>
+        public IReadOnlyCollection<DataSourceTimeZone> TimeZones { get; init; } = Array.Empty<DataSourceTimeZone>();
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/DataSourceTimeZone.cs
+++ b/src/Microsoft.Performance.SDK/Processing/DataSourceTimeZone.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     Represents a time zone that is of significance to a data source.
+/// </summary>
+/// <param name="Label">
+///     A human-readable label that describes the significance of the time zone.
+/// </param>
+/// <param name="TimeZone">
+///     The time zone.
+/// </param>
+public sealed record DataSourceTimeZone(string Label, TimeZoneInfo TimeZone);


### PR DESCRIPTION
Currently, the `DataSourceInfo` a data processor exposes requires its `DateTime` be UTC. This constraint may cause a processor to disregard relevant information, such as which time zone the data source was created.

This PR adds a new `DataSourceTimeZone` record that describes time zones of significance to data sources. Instances of these records are now accessible from the `DataSourceInfo`, allowing plugins to expose this previously disregarded information to SDK drivers.