### PR TITLE
User/lukebo/plugin options changes

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsRegistry.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsRegistry.cs
@@ -65,25 +65,6 @@ public sealed class PluginOptionsRegistry
     }
 
     /// <summary>
-    ///     Registers the <see cref="PluginOption"/> instances provided by the given <see cref="IProvider"/>.
-    /// </summary>
-    /// <param name="provider">
-    ///     The <see cref="IProvider"/> that provides the <see cref="PluginOption"/> instances to register.
-    /// </param>
-    internal void RegisterFrom(IProvider provider)
-    {
-        lock (this.mutex)
-        {
-            this.logger.Info($"Registering plugin options from {provider.GetType().FullName}.");
-
-            foreach (var option in provider.GetOptions())
-            {
-                this.optionByGuid[option.Guid] = option;
-            }
-        }
-    }
-
-    /// <summary>
     ///     Updates the state of the <see cref="PluginOption"/> instances in this registry from the given <see cref="PluginOptionsDto"/>. This
     ///     will have the following effects:
     ///     <list type="bullet">
@@ -114,7 +95,7 @@ public sealed class PluginOptionsRegistry
     /// <param name="dto">
     ///     The <see cref="PluginOptionsDto"/> from which to update the state of the <see cref="PluginOption"/> instances in this registry.
     /// </param>
-    internal void UpdateFromDto(PluginOptionsDto dto)
+    public void UpdateFromDto(PluginOptionsDto dto)
     {
         lock (this.mutex)
         {
@@ -123,6 +104,25 @@ public sealed class PluginOptionsRegistry
             ApplyBooleanDtos(dto.BooleanOptions);
             ApplyFieldDtos(dto.FieldOptions);
             ApplyFieldArrayDtos(dto.FieldArrayOptions);
+        }
+    }
+
+    /// <summary>
+    ///     Registers the <see cref="PluginOption"/> instances provided by the given <see cref="IProvider"/>.
+    /// </summary>
+    /// <param name="provider">
+    ///     The <see cref="IProvider"/> that provides the <see cref="PluginOption"/> instances to register.
+    /// </param>
+    internal void RegisterFrom(IProvider provider)
+    {
+        lock (this.mutex)
+        {
+            this.logger.Info($"Registering plugin options from {provider.GetType().FullName}.");
+
+            foreach (var option in provider.GetOptions())
+            {
+                this.optionByGuid[option.Guid] = option;
+            }
         }
     }
 

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/DTO/PluginOptionsDto.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/DTO/PluginOptionsDto.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Performance.SDK.Runtime.Options.Serialization.DTO;
 
@@ -24,4 +26,33 @@ public sealed class PluginOptionsDto
     ///     Gets or initializes the <see cref="FieldArrayPluginOptionDto"/> instances.
     /// </summary>
     public IReadOnlyCollection<FieldArrayPluginOptionDto> FieldArrayOptions { get; init; } = new List<FieldArrayPluginOptionDto>();
+
+    /// <summary>
+    ///     Merges the values from the given <see cref="PluginOptionsDto"/> into this one, returning the new instance.
+    ///     DTOs in <paramref name="newDto"/> that have the same <see cref="PluginOptionDto.Guid"/> as a DTO in this
+    ///     instance will replace the old DTO. DTOs in this instance which are not present in in <paramref name="newDto"/>
+    ///     will be included in the returned instance.
+    /// </summary>
+    /// <param name="newDto">
+    ///     The DTO to merge into this one.
+    /// </param>
+    /// <returns>
+    ///     A new <see cref="PluginOptionsDto"/> instance with the merged values.
+    /// </returns>
+    public PluginOptionsDto UpdateTo(PluginOptionsDto newDto)
+    {
+        return new PluginOptionsDto
+        {
+            BooleanOptions = WithoutUpdatedValues(this.BooleanOptions, newDto.BooleanOptions).Concat(newDto.BooleanOptions).ToList(),
+            FieldOptions = WithoutUpdatedValues(this.FieldOptions, newDto.FieldOptions).Concat(newDto.FieldOptions).ToList(),
+            FieldArrayOptions = WithoutUpdatedValues(this.FieldArrayOptions, newDto.FieldArrayOptions).Concat(newDto.FieldArrayOptions).ToList(),
+        };
+    }
+
+    private IEnumerable<T> WithoutUpdatedValues<T>(IEnumerable<T> oldDtos, IEnumerable<T> newDtos)
+        where T : PluginOptionDto
+    {
+        HashSet<Guid> newGuids = new(newDtos.Select(dto => dto.Guid));
+        return oldDtos.Where(oldDto => !newGuids.Contains(oldDto.Guid));
+    }
 }

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/FilePluginOptionsLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/FilePluginOptionsLoader.cs
@@ -48,6 +48,6 @@ public sealed class FilePluginOptionsLoader
     /// <inheritdoc />
     protected override Stream GetStream()
     {
-        return File.Open(this.filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return File.Open(this.filePath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read);
     }
 }

--- a/src/Microsoft.Performance.SDK.Tests/Options/TestPluginOption.cs
+++ b/src/Microsoft.Performance.SDK.Tests/Options/TestPluginOption.cs
@@ -18,14 +18,17 @@ public static class TestPluginOption
     /// <param name="defaultValue">
     ///     The default value for the option.
     /// </param>
+    /// <param name="guid">
+    ///     The GUID for the option. If <c>null</c>, a new GUID will be generated.
+    /// </param>
     /// <returns>
     ///     A new <see cref="BooleanOption"/> with random values.
     /// </returns>
-    public static BooleanOption BooleanOption(bool defaultValue)
+    public static BooleanOption BooleanOption(bool defaultValue, Guid? guid = null)
     {
         return new BooleanOption()
         {
-            Guid = Guid.NewGuid(),
+            Guid = guid ?? Guid.NewGuid(),
             Category = Utilities.RandomString(5),
             Name = Utilities.RandomString(5),
             Description = Utilities.RandomString(5),
@@ -39,14 +42,17 @@ public static class TestPluginOption
     /// <param name="defaultValue">
     ///     The default value for the option.
     /// </param>
+    /// <param name="guid">
+    ///     The GUID for the option. If <c>null</c>, a new GUID will be generated.
+    /// </param>
     /// <returns>
     ///     A new <see cref="FieldOption"/> with random values.
     /// </returns>
-    public static FieldOption FieldOption(string defaultValue)
+    public static FieldOption FieldOption(string defaultValue, Guid? guid = null)
     {
         return new FieldOption()
         {
-            Guid = Guid.NewGuid(),
+            Guid = guid ?? Guid.NewGuid(),
             Category = Utilities.RandomString(5),
             Name = Utilities.RandomString(5),
             Description = Utilities.RandomString(5),
@@ -60,14 +66,17 @@ public static class TestPluginOption
     /// <param name="defaultValue">
     ///     The default value for the option.
     /// </param>
+    /// <param name="guid">
+    ///     The GUID for the option. If <c>null</c>, a new GUID will be generated.
+    /// </param>
     /// <returns>
     ///     A new <see cref="FieldArrayOption"/> with random values.
     /// </returns>
-    public static FieldArrayOption FieldArrayOption(string[] defaultValue)
+    public static FieldArrayOption FieldArrayOption(string[] defaultValue, Guid? guid = null)
     {
         return new FieldArrayOption()
         {
-            Guid = Guid.NewGuid(),
+            Guid = guid ?? Guid.NewGuid(),
             Category = Utilities.RandomString(5),
             Name = Utilities.RandomString(5),
             Description = Utilities.RandomString(5),


### PR DESCRIPTION
* Makes `PluginOptionsRegistry.UpdateFromDto` a public method so that runtime users can manually update options without forcing re-loading from the loader.
* Ensures that saving the current registry does not erase previously saved values.
    * Adds tests for this case
* `FilePluginOptionsLoader` now opens the file stream with `OpenOrCreate`