### PR TITLE
Plugin options system improvements

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
@@ -8,7 +8,9 @@ using System.Threading.Tasks;
 using Microsoft.Performance.SDK.Options;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.SDK.Runtime.Options;
+using Microsoft.Performance.SDK.Runtime.Options.Serialization;
 using Microsoft.Performance.SDK.Runtime.Options.Serialization.DTO;
+using Microsoft.Performance.SDK.Runtime.Options.Serialization.Loading;
 using Microsoft.Performance.SDK.Tests.Options;
 using Microsoft.Performance.Testing;
 using Microsoft.Performance.Testing.SDK;
@@ -109,6 +111,18 @@ public class PluginOptionsSystemTests
         var newDto = await sut.Loader.TryLoadAsync();
 
         Assert.AreEqual(expectedValue, newDto.BooleanOptions.First(o => o.Guid == optionGuid).Value);
+    }
+
+    [TestMethod]
+    public async Task TrySaveCurrentRegistry_LoaderFails_FailsToSave()
+    {
+        var sut = new PluginOptionsSystem(
+            new NullPluginOptionsLoader(),
+            new InMemoryPluginOptionsDtoRepository(),
+            new PluginOptionsRegistry(Logger.Null));
+
+        sut.RegisterOptionsFrom(new StubProcessingSource(TestPluginOption.FieldOption("foo")));
+        Assert.IsFalse(await sut.TrySaveCurrentRegistry());
     }
 
     private PluginOptionsSystem CreateSut(params IProcessingSource[] processingSources)

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsLoaderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsLoaderTests.cs
@@ -87,10 +87,22 @@ public class StreamPluginOptionsLoaderTests
         Assert.IsTrue(stream.CanWrite);
     }
 
-    private sealed class TestStreamPluginOptionsLoader
-        : StreamPluginOptionsLoader
+    [TestMethod]
+    public async Task EmptyStream_ReturnsEmptyDto()
     {
-        private readonly Stream stream;
+        using MemoryStream stream = new MemoryStream();
+        var sut = new TestStreamPluginOptionsLoader(stream, false);
+
+        var loadedDto = await sut.TryLoadAsync();
+
+        Assert.IsNotNull(loadedDto);
+        Assert.IsTrue(loadedDto.IsEmpty());
+    }
+
+    private sealed class TestStreamPluginOptionsLoader
+        : StreamPluginOptionsLoader<MemoryStream>
+    {
+        private readonly MemoryStream stream;
 
         public TestStreamPluginOptionsLoader(MemoryStream stream, bool closeStreamOnRead)
             : base(closeStreamOnRead, Logger.Null)
@@ -98,9 +110,14 @@ public class StreamPluginOptionsLoaderTests
             this.stream = stream;
         }
 
-        protected override Stream GetStream()
+        protected override MemoryStream GetStream()
         {
             return this.stream;
+        }
+
+        protected override bool HasContent(MemoryStream stream)
+        {
+            return stream.Length > 0;
         }
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsSystem.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsSystem.cs
@@ -154,6 +154,8 @@ public sealed class PluginOptionsSystem
     ///     the <see cref="Saver"/>. Previously saved options, as loaded by the <see cref="Loader"/> during this method call,
     ///     will still be included in the saved options. If an option in the <see cref="Registry"/> was previously saved,
     ///     its value will be updated after the save.
+    ///     If <see cref="Loader"/> fails to load options, the save will fail and this method will have
+    ///     no effect.
     /// </summary>
     /// <returns>
     ///     <c>true</c> if the <see cref="Registry"/> was saved; <c>false</c> otherwise.
@@ -166,6 +168,12 @@ public sealed class PluginOptionsSystem
     {
         var newDto = optionsRegistryToDtoConverter.ConvertToDto(this.Registry);
         var oldDto = await this.Loader.TryLoadAsync();
+
+        if (oldDto == null)
+        {
+            return false;
+        }
+
         return await this.Saver.TrySaveAsync(oldDto.UpdateTo(newDto));
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/DTO/PluginOptionsDto.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/DTO/PluginOptionsDto.cs
@@ -27,6 +27,13 @@ public sealed class PluginOptionsDto
     /// </summary>
     public IReadOnlyCollection<FieldArrayPluginOptionDto> FieldArrayOptions { get; init; } = new List<FieldArrayPluginOptionDto>();
 
+    public bool IsEmpty()
+    {
+        return !this.BooleanOptions.Any() &&
+               !this.FieldOptions.Any() &&
+               !this.FieldArrayOptions.Any();
+    }
+
     /// <summary>
     ///     Merges the values from the given <see cref="PluginOptionsDto"/> into this one, returning the new instance.
     ///     DTOs in <paramref name="newDto"/> that have the same <see cref="PluginOptionDto.Guid"/> as a DTO in this

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/FilePluginOptionsLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/FilePluginOptionsLoader.cs
@@ -12,10 +12,8 @@ namespace Microsoft.Performance.SDK.Runtime.Options.Serialization.Loading;
 ///     A <see cref="IPluginOptionsLoader"/> that can load a <see cref="PluginOptionsDto"/> instance from a file.
 /// </summary>
 public sealed class FilePluginOptionsLoader
-    : StreamPluginOptionsLoader
+    : StreamPluginOptionsLoader<FileStream>
 {
-    private readonly string filePath;
-
     /// <summary>
     ///     Initializes a new instance of the <see cref="FilePluginOptionsLoader"/> class.
     /// </summary>
@@ -37,17 +35,27 @@ public sealed class FilePluginOptionsLoader
         Guard.NotNullOrWhiteSpace(filePath, nameof(filePath));
         Guard.NotNull(logger, nameof(logger));
 
-        this.filePath = filePath;
+        this.FilePath = filePath;
     }
+
+    /// <summary>
+    ///     Gets the path to the file from which to load options.
+    /// </summary>
+    public string FilePath { get; }
 
     private protected override string GetDeserializeErrorMessage(Exception exception)
     {
-        return $"Failed to load plugin options from '{this.filePath}': {exception.Message}.";
+        return $"Failed to load plugin options from '{this.FilePath}': {exception.Message}.";
     }
 
     /// <inheritdoc />
-    protected override Stream GetStream()
+    protected override FileStream GetStream()
     {
-        return File.Open(this.filePath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read);
+        return File.Open(this.FilePath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read);
+    }
+
+    protected override bool HasContent(FileStream stream)
+    {
+        return stream.Length > 0;
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/StreamPluginOptionsLoader.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Loading/StreamPluginOptionsLoader.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Performance.SDK.Runtime.Options.Serialization.Loading;
 /// <summary>
 ///     Base class for <see cref="IPluginOptionsLoader"/> classes which load from a stream.
 /// </summary>
-public abstract class StreamPluginOptionsLoader
+public abstract class StreamPluginOptionsLoader<T>
     : IPluginOptionsLoader
+    where T : Stream
 {
     private readonly bool closeStreamOnRead;
     private readonly ILogger logger;
@@ -45,6 +46,11 @@ public abstract class StreamPluginOptionsLoader
         var stream = GetStream();
         try
         {
+            if (!HasContent(stream))
+            {
+                return new PluginOptionsDto();
+            }
+
             return await JsonSerializer.DeserializeAsync<PluginOptionsDto>(stream, jsonSerializerOptions);
         }
         catch (Exception e)
@@ -72,5 +78,7 @@ public abstract class StreamPluginOptionsLoader
     /// <returns>
     ///     The <see cref="Stream"/> from which to load the <see cref="PluginOptionsDto"/>.
     /// </returns>
-    protected abstract Stream GetStream();
+    protected abstract T GetStream();
+
+    protected abstract bool HasContent(T stream);
 }

--- a/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Saving/FilePluginOptionsSaver.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/Serialization/Saving/FilePluginOptionsSaver.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Performance.SDK.Runtime.Options.Serialization.Saving;
 public sealed class FilePluginOptionsSaver
     : StreamPluginOptionsSaver
 {
-    private readonly string filePath;
-
     /// <summary>
     ///     Initializes a new instance of the <see cref="FilePluginOptionsSaver"/> class.
     /// </summary>
@@ -37,17 +35,22 @@ public sealed class FilePluginOptionsSaver
         Guard.NotNullOrWhiteSpace(filePath, nameof(filePath));
         Guard.NotNull(logger, nameof(logger));
 
-        this.filePath = filePath;
+        this.FilePath = filePath;
     }
+
+    /// <summary>
+    ///     Gets the path to the file to which options will be saved.
+    /// </summary>
+    public string FilePath { get; }
 
     private protected override string GetSerializeErrorMessage(Exception exception)
     {
-        return $"Failed to save plugin options to '{this.filePath}': {exception.Message}.";
+        return $"Failed to save plugin options to '{this.FilePath}': {exception.Message}.";
     }
 
     /// <inheritdoc />
     protected override Stream GetStream()
     {
-        return File.Open(this.filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+        return File.Open(this.FilePath, FileMode.Create, FileAccess.Write, FileShare.None);
     }
 }


### PR DESCRIPTION
* Prevents a NRE when calling `PluginOptionsSystem.TrySaveCurrentRegistry` if the loader fails to load options. Adds a test for this scenario.
* Updates `StreamPluginOptionsLoader` to return an empty DTO if the stream being loaded from has no data. Adds a test for this scenario.
* Makes the filepaths on the file loader/saver public.