### PR TITLE
Use SingleOrDefault in GetPrebuiltConfigurationFromEmbeddedResource

### DIFF
--- a/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Performance.SDK.Processing
                 Debug.Assert(tableAssembly != null, "Unable to retrieve assembly for a table type.");
 
                 var resourceName = tableAssembly.GetManifestResourceNames()
-                    .Single(name => name.EndsWith(tableAttribute.EmbeddedResourcePath));
+                    .SingleOrDefault(name => name.EndsWith(tableAttribute.EmbeddedResourcePath));
 
                 if (string.IsNullOrWhiteSpace(resourceName))
                 {

--- a/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Performance.SDK.Processing
             {
                 logger?.Warn(
                     $"Failed to processed table configurations for table {tableType} in file " +
-                    $"{tableAttribute.ExternalResourceFilePath}: {e.Message}.");
+                    $"{tableAttribute.ExternalResourceFilePath}: {e}");
             }
 
             return null;
@@ -251,8 +251,7 @@ namespace Microsoft.Performance.SDK.Processing
             catch (Exception e)
             {
                 logger?.Warn(
-                    $"Unable to retrieve embedded resource for prebuilt configurations in table {tableType}\n" +
-                    $"{e.Message}.");
+                    $"Unable to retrieve embedded resource for prebuilt configurations in table {tableType}\n" + e);
             }
 
             return null;

--- a/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableConfigurations.cs
@@ -193,8 +193,9 @@ namespace Microsoft.Performance.SDK.Processing
             catch (Exception e)
             {
                 logger?.Warn(
+                    e,
                     $"Failed to processed table configurations for table {tableType} in file " +
-                    $"{tableAttribute.ExternalResourceFilePath}: {e}");
+                    $"{tableAttribute.ExternalResourceFilePath}.");
             }
 
             return null;
@@ -251,7 +252,7 @@ namespace Microsoft.Performance.SDK.Processing
             catch (Exception e)
             {
                 logger?.Warn(
-                    $"Unable to retrieve embedded resource for prebuilt configurations in table {tableType}\n" + e);
+                    e, $"Unable to retrieve embedded resource for prebuilt configurations in table {tableType}.");
             }
 
             return null;


### PR DESCRIPTION
This starts to throw with the newly added AI tables because `GetManifestResourceNames` is empty. Not sure if this is a sign of a bigger issue. If this is expected, this change will stop it from throwing exceptions unnecessarily