### PR TITLE
Update version to -preview2

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4-preview",
+  "version": "1.4-preview2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
The changes to the plugin options API makes the previous preview incompatible with the current version. To denote this incompatibility, this PR changes the pre-release suffix to "preview2."