### PR TITLE
Do not automatically enable tables in the Engine.

### DIFF
--- a/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/Engine.cs
@@ -794,7 +794,7 @@ namespace Microsoft.Performance.Toolkit.Engine
                 pluginOptionsSystem.TryLoadAsync()
                     .ConfigureAwait(false)
                     .GetAwaiter()
-                    .GetResult();;
+                    .GetResult();
 
                 instance.applicationEnvironment = new EngineApplicationEnvironment(
                     applicationName: applicationName,
@@ -1117,7 +1117,7 @@ namespace Microsoft.Performance.Toolkit.Engine
                         x => ConsoleLogger.Create(x.GetType()), // todo: this shouldn't be using a console logger by default
                         processingSource,
                         dsg, // todo #214
-                        processingSource.Instance.MetadataTables,
+                        [],
                         this.CreateInfo.ProcessEnvironmentFactory.CreateProcessorEnvironment(processingSource.Guid, dsg),
                         processorOptions);
 


### PR DESCRIPTION
Even though the Engine was only enabling Meta tables, these tables and their dependencies consume resources. These tables may manually be enabled through EnableTable().

Note: we are considering this a bug fix, not a breaking change, as tables should not be enabled by default.