### PR TITLE
Allow multiple FileDataSourceAttribute to be used

### DIFF
--- a/documentation/Using-the-SDK/Creating-your-plugin.md
+++ b/documentation/Using-the-SDK/Creating-your-plugin.md
@@ -47,7 +47,7 @@ Please refer to the links above to download and install the necessary requiremen
 1) Launch Visual Studio
 2) Click "Create new project"  
  ![VS2019_Create_New_Project.PNG](./.attachments/VS2019_CreateProject_Markup.png)
-3) Select .NET Standard on the left, and choose "Class Library (.NET Standard)." Make sure that you are using .NET Standard 2.0, or a .NET version that supports .NET Standard 2.0 (such as .NET Core 3.1, .NET 6, etc.).
+3) Select .NET Standard on the left, and choose "Class Library (.NET Standard)." Make sure that you are using .NET Standard 2.0, or a .NET version that supports .NET Standard 2.0 (such as .NET 8). The .NET version cannot be higher than WPA's .NET version (.NET 8).
  ![VS2019_New_DotNetStandard_20_Project.PNG](./.attachments/VS2019_CreateProject_ClassLibrary_Markup.png)
 4) Name your project
 5) Click "Create"

--- a/samples/SimpleDataSource/README.md
+++ b/samples/SimpleDataSource/README.md
@@ -15,5 +15,5 @@ See `SampleTextFile.txt` for an example of a file with this format.
 2. [.NET Standard 2.0](https://dotnet.microsoft.com/download/visual-studio-sdks)
 
 # Instructions
-Please refer to [Using the SDK/Creating a Simple SDK Plugin](../../documentaiton/Using-the-SDK/Creating-a-simple-sdk-plugin.md) for details 
+Please refer to [Using the SDK/Creating a Simple SDK Plugin](../../documentation/Using-the-SDK/Creating-a-simple-sdk-plugin.md) for details 
 on how to implement this source code.

--- a/samples/SimpleDataSource/SampleAddIn.csproj
+++ b/samples/SimpleDataSource/SampleAddIn.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.14-rc1" />
+    <PackageReference Include="Microsoft.Performance.SDK" Version="1.4.7-preview2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceReferenceTests.cs
@@ -8,11 +8,9 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Performance.SDK.Options;
 using Microsoft.Performance.SDK.Options.Definitions;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.SDK.Processing.DataSourceGrouping;
-using Microsoft.Performance.SDK.Runtime.Options;
 using Microsoft.Performance.Testing;
 using Microsoft.Performance.Testing.SDK;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -634,7 +632,8 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         }
 
         [ProcessingSource("{2D5E3373-88DA-4640-BD19-99FA8C437EB1}", "What", "Test")]
-        [FileDataSource("ext")]
+        [FileDataSource("ext1")]
+        [FileDataSource("ext2")]
         [ExtensionlessFileDataSource("No description")]
         [DirectoryDataSource("No description")]
         public class MultiDataSourceCds

--- a/src/Microsoft.Performance.SDK/Processing/FileDataSourceAttribute.cs
+++ b/src/Microsoft.Performance.SDK/Processing/FileDataSourceAttribute.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Performance.SDK.Processing
     ///     files of a specific type. This is used to instruct callers to route files
     ///     with a given extension to the decorated <see cref="IProcessingSource"/> for processing.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class FileDataSourceAttribute
         : DataSourceAttribute,
           IEquatable<FileDataSourceAttribute>

--- a/src/SDK.sln
+++ b/src/SDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31410.414
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11217.181
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Performance.SDK", "Microsoft.Performance.SDK\Microsoft.Performance.SDK.csproj", "{D6C6BE8C-6D62-44A9-AA99-E6B1CDC835F6}"
 EndProject


### PR DESCRIPTION
Simply removing this will allow plugins to support multiple different file extensions. WPA already has the support for it as WPA always processes `FileDataSourceAttribute` in an `IEnumerable`. Even in this repo we have tests for multiple extensions (`TryGetFileExtensions_FileDataSources_ReturnsExtensions`)