### PR TITLE
fix string comparison structs crash when compared with default values

### DIFF
--- a/src/Microsoft.Performance.SDK.Tests/AssemblyInfo.cs
+++ b/src/Microsoft.Performance.SDK.Tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.Testing;
+
+[assembly: UnitTest]

--- a/src/Microsoft.Performance.SDK.Tests/StringWithCaseInsensitiveComparisonTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/StringWithCaseInsensitiveComparisonTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Performance.SDK.Tests;
+
+[TestClass]
+public class StringWithCaseInsensitiveComparisonTests
+{
+    [TestMethod]
+    [DataRow("Alphabet", "alphabet", 0, DisplayName = "Equal ignoring casing")]
+    [DataRow("Bravo", "apple", 1, DisplayName = "Comparison ignoring casing")]
+    public void CompareTo_ProvidesCaseInsensitiveOrdering(string first, string second, int expectedSign)
+    {
+        var left = new StringWithCaseInsensitiveComparison(first);
+        var right = new StringWithCaseInsensitiveComparison(second);
+
+        Assert.AreEqual(expectedSign, left.CompareTo(right));
+        Assert.AreEqual(-expectedSign, right.CompareTo(left));
+    }
+
+    [TestMethod]
+    public void DefaultValue_CompareToBehavesConsistently()
+    {
+        var defaultValue = default(StringWithCaseInsensitiveComparison);
+        var other = new StringWithCaseInsensitiveComparison("apple");
+
+        Assert.AreEqual(0, defaultValue.CompareTo(default(StringWithCaseInsensitiveComparison)));
+        Assert.IsTrue(defaultValue < other);
+        Assert.IsTrue(other > defaultValue);
+    }
+}

--- a/src/Microsoft.Performance.SDK.Tests/StringWithLogicalComparisonTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/StringWithLogicalComparisonTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Performance.SDK.Tests;
+
+[TestClass]
+public class StringWithLogicalComparisonTests
+{
+    [TestMethod]
+    [DataRow("item20", "item1", 1, DisplayName = "Numeric segments compared by value")]
+    [DataRow("apple", "0x10", 1, DisplayName = "Hex less than with non-hex")]
+    [DataRow("0x1f", "0x0a", 1, DisplayName = "Hex comparison")]
+    [DataRow("0xB0", "0xaB", 1, DisplayName = "Hex comparison ignoring cases")]
+    [DataRow("0xa0", "0xA0", 1, DisplayName = "Hex compare cases when numerically equal")]
+    [DataRow("00000000-0000-0000-ABCD-000000000001", "00000000-0000-0000-0000-ABCDEF000001", 1, DisplayName = "GUID comparison")]
+    [DataRow("Apple", "F0000000-0000-0000-0000-000000000000", 1, DisplayName = "GUID less than non-GUID")]
+    [DataRow("-1", "-2", 1, DisplayName = "Negative number comparison")]
+    [DataRow("0", "-2", 1, DisplayName = "Negative number compared with non-negative")]
+    [DataRow("-0xa", "-0xf", 1, DisplayName = "Negative hex comparison")]
+    [DataRow("-0xa", "0xa", 1, DisplayName = "Negative hex compared with non-negative hex")]
+    public void CompareTo_FollowsLogicalOrdering(string first, string second, int expectedSign)
+    {
+        var left = new StringWithLogicalComparison(first);
+        var right = new StringWithLogicalComparison(second);
+
+        Assert.AreEqual(expectedSign, left.CompareTo(right));
+        Assert.AreEqual(-expectedSign, right.CompareTo(left));
+    }
+
+    [TestMethod]
+    public void DefaultValue_CompareToBehavesConsistently()
+    {
+        var defaultValue = default(StringWithLogicalComparison);
+        var other = new StringWithLogicalComparison("apple");
+
+        Assert.AreEqual(0, defaultValue.CompareTo(default(StringWithLogicalComparison)));
+        Assert.IsTrue(defaultValue < other);
+        Assert.IsTrue(other > defaultValue);
+    }
+}

--- a/src/Microsoft.Performance.SDK/CompareNumericWithExceptionsMethods.cs
+++ b/src/Microsoft.Performance.SDK/CompareNumericWithExceptionsMethods.cs
@@ -219,6 +219,19 @@ namespace Microsoft.Performance.SDK
         private static unsafe int _wcstcmpWithNumericExceptions<TCharTraits>(char* string1, char* string2)
             where TCharTraits : ICharTraits, new()
         {
+            if (string1 == string2)
+            {
+                return firstEqualsSecond;
+            }
+            else if (string1 == null)
+            {
+                return firstLessThanSecond;
+            }
+            else if (string2 == null)
+            {
+                return secondLessThanFirst;
+            }
+
             var charTraits = new TCharTraits();
 
             bool fTreatAsNegative = false;

--- a/src/Microsoft.Performance.SDK/StringWithCaseInsensitiveComparison.cs
+++ b/src/Microsoft.Performance.SDK/StringWithCaseInsensitiveComparison.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 
@@ -16,7 +18,7 @@ namespace Microsoft.Performance.SDK
           IComparable,
           IFormattable
     {
-        private readonly string source;
+        private readonly string? source;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="StringWithCaseInsensitiveComparison"/>
@@ -86,13 +88,13 @@ namespace Microsoft.Performance.SDK
         /// <inheritdoc />
         public override string ToString()
         {
-            return this.source;
+            return this.source ?? string.Empty;
         }
 
         /// <inheritdoc />
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            return this.source;
+            return ToString();
         }
     }
 }

--- a/src/Microsoft.Performance.SDK/StringWithLogicalComparison.cs
+++ b/src/Microsoft.Performance.SDK/StringWithLogicalComparison.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Performance.SDK
@@ -14,7 +16,7 @@ namespace Microsoft.Performance.SDK
           IComparable,
           IFormattable
     {
-        private readonly string source;
+        private readonly string? source;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="StringWithLogicalComparison"/>
@@ -83,13 +85,13 @@ namespace Microsoft.Performance.SDK
         /// <inheritdoc />
         public override string ToString()
         {
-            return this.source;
+            return this.source ?? string.Empty;
         }
 
         /// <inheritdoc />
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            return this.source;
+            return ToString();
         }
     }
 }


### PR DESCRIPTION
The string comparison structs are meant to be used as column data types. When their default values are used, the internal string will be null, which triggers a null reference exception in their comparison logic or ToString.

This PR fixes this issue, adds null annotations and unit tests