### PR TITLE
upgrade to .NET 10; upgrade packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '10.x'
     - name: Setup NBGV
-      uses: dotnet/nbgv@v0.4
+      uses: dotnet/nbgv@v0.5.1
       with:
-        toolVersion: 3.6.143
+        toolVersion: 3.9.50
     - name: Restore dependencies
       run: dotnet restore "${{ github.workspace }}/src/SDK.sln"
     - name: Build solution

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.6.143</Version>
+      <Version>3.9.50</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,6 +4,6 @@
 	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 	  <PackageReference Update="MSTest.TestAdapter" Version="2.2.7" />
 	  <PackageReference Update="MSTest.TestFramework" Version="2.2.7" />
-	  <PackageReference Update="System.Text.Json" Version="8.0.5" />
+	  <PackageReference Update="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>true</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> <!-- Needed for Microsoft.CodeAnalysis.CSharp -->
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <Content Remove="Plugins\MockProcessingSources\**\*.*" />

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp/Microsoft.Performance.SDK.Runtime.NetCoreApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.Performance.SDK.Runtime.NetCoreApp</AssemblyName>
     <RootNamespace>Microsoft.Performance.SDK.Runtime.NetCoreApp</RootNamespace>
     <Authors>Microsoft</Authors>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Microsoft.Performance.SDK.Runtime.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Microsoft.Performance.SDK.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Performance.SDK.Runtime/ConcurrentSet`1.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/ConcurrentSet`1.cs
@@ -44,6 +44,16 @@ namespace Microsoft.Performance.SDK.Runtime
             }
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ConcurrentSet{T}"/> class
+        ///     with the specified equality comparer.
+        /// </summary>
+        /// <param name="comparer">The equality comparer to use when comparing values in the set.</param>
+        public ConcurrentSet(IEqualityComparer<T> comparer)
+        {
+            this.items = new ConcurrentDictionary<T, object>(comparer);
+        }
+
         /// <inheritdoc cref="HashSet{T}.Add(T)"/>
         public bool Add(T item)
         {

--- a/src/Microsoft.Performance.SDK.Tests/Microsoft.Performance.SDK.Tests.csproj
+++ b/src/Microsoft.Performance.SDK.Tests/Microsoft.Performance.SDK.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Microsoft.Performance.SDK/Microsoft.Performance.SDK.csproj
+++ b/src/Microsoft.Performance.SDK/Microsoft.Performance.SDK.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" Version="5.11.5" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.14.3" /><!-- Support for netstandard has been dropped in version 7 -->
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests.Driver/Microsoft.Performance.Toolkit.Engine.Tests.Driver.csproj
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests.Driver/Microsoft.Performance.Toolkit.Engine.Tests.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/Microsoft.Performance.Toolkit.Engine.Tests.csproj
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/Microsoft.Performance.Toolkit.Engine.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.csproj
+++ b/src/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests.csproj
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Microsoft.Performance.Toolkit.Plugins.Runtime.csproj
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime/Microsoft.Performance.Toolkit.Plugins.Runtime.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DistributedLock.FileSystem" Version="1.0.1" />
+    <PackageReference Include="DistributedLock.FileSystem" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/Microsoft.Performance.Toolkit.Plugins.Cli.Tests.csproj
+++ b/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/Microsoft.Performance.Toolkit.Plugins.Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Microsoft.Performance.Toolkit.Plugins.Cli.csproj
+++ b/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Microsoft.Performance.Toolkit.Plugins.Cli.csproj
@@ -20,11 +20,11 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/PlugInConfigurationEditor/PlugInConfigurationEditor.csproj
+++ b/src/Tools/PlugInConfigurationEditor/PlugInConfigurationEditor.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just upgrading the framework to .NET 10.
Support for .NET 6 and .NET Core 3.1 is dropped while .NET 8 support is kept.
No changes to .NET Standard support

Certain Nuget packages have also been also upgraded to new versions