### PR TITLE
Introduce ITableBuilder.AddTableCommand3

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -326,5 +328,121 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
             command3.OnExecute(new TableCommandContext(null, null, test3));
             Assert.AreEqual(captured3, test3);
         }
+
+		[TestMethod]
+		[UnitTest]
+		public void AddTableCommand3InvalidArgumentsThrow()
+		{
+			TableCommandCallback2 noop = (_, __) => Task.FromResult<TableCommandResult>(VoidTableCommandResult.Instance);
+
+			Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand3(null, _ => true, noop));
+			Assert.ThrowsException<ArgumentException>(() => this.Sut.AddTableCommand3(string.Empty, _ => true, noop));
+			Assert.ThrowsException<ArgumentException>(() => this.Sut.AddTableCommand3("   ", _ => true, noop));
+			Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand3("test", null, noop));
+			Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand3("test", _ => true, null));
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public void AddTableCommand3DuplicateNameThrows()
+		{
+			TableCommandCallback2 noop = (_, __) => Task.FromResult<TableCommandResult>(VoidTableCommandResult.Instance);
+
+			this.Sut.AddTableCommand3("test", _ => true, noop);
+
+			Assert.ThrowsException<InvalidOperationException>(
+				() => this.Sut.AddTableCommand3("TEST", _ => true, noop));
+			Assert.ThrowsException<InvalidOperationException>(
+				() => this.Sut.AddTableCommand3(" test ", _ => true, noop));
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public void AddTableCommand3ReturnsBuilderAndTrimsName()
+		{
+			TableCommandCallback2 noop = (_, __) => Task.FromResult<TableCommandResult>(VoidTableCommandResult.Instance);
+
+			var ret = this.Sut.AddTableCommand3("  test  ", _ => true, noop);
+
+			Assert.AreEqual(this.Sut, ret);
+			Assert.AreEqual(1, this.Sut.Commands3.Count);
+			Assert.AreEqual("test", this.Sut.Commands3.Single().CommandName);
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public async Task AddTableCommand3RoundTripsVoidResult()
+		{
+			TableCommandCallback2 callback = (_, __) => Task.FromResult<TableCommandResult>(VoidTableCommandResult.Instance);
+
+			this.Sut.AddTableCommand3("void", _ => true, callback);
+			var command = this.Sut.Commands3.Single();
+
+			var context = new TableCommandContext2(
+				null,
+				null,
+				new[] { new SelectedTableRow(5, new[] { 0, 1, 2 }) });
+
+			var result = await command.OnExecute(context, CancellationToken.None);
+
+			Assert.AreSame(VoidTableCommandResult.Instance, result);
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public async Task AddTableCommand3RoundTripsOpenUrisResult()
+		{
+			var uris = new[] { new Uri("https://example.com"), new Uri("file:///c:/tmp") };
+			TableCommandContext2 captured = null;
+			TableCommandCallback2 callback = (ctx, __) =>
+			{
+				captured = ctx;
+				return Task.FromResult<TableCommandResult>(new OpenUrisTableCommandResult(uris));
+			};
+
+			this.Sut.AddTableCommand3("openUris", _ => true, callback);
+			var command = this.Sut.Commands3.Single();
+
+			var selected = new[]
+			{
+				new SelectedTableRow(0, Array.Empty<int>()),
+				new SelectedTableRow(7, new[] { 3 }),
+			};
+			var context = new TableCommandContext2(Guid.NewGuid(), null, selected);
+
+			var result = await command.OnExecute(context, CancellationToken.None);
+
+			Assert.AreSame(context, captured);
+			var openUris = result as OpenUrisTableCommandResult;
+			Assert.IsNotNull(openUris);
+			CollectionAssert.AreEqual(uris, openUris.Uris.ToArray());
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public void SelectedTableRowNullSubRowIndicesNormalizedToEmpty()
+		{
+			var row = new SelectedTableRow(3, null);
+
+			Assert.IsNotNull(row.SubRowIndices);
+			Assert.AreEqual(0, row.SubRowIndices.Count);
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public void SelectedTableRowSingleArgConstructorUsesEmptySubRows()
+		{
+			var row = new SelectedTableRow(42);
+
+			Assert.AreEqual(42, row.RowIndex);
+			Assert.AreEqual(0, row.SubRowIndices.Count);
+		}
+
+		[TestMethod]
+		[UnitTest]
+		public void OpenUrisTableCommandResultNullUrisThrows()
+		{
+			Assert.ThrowsException<ArgumentNullException>(() => new OpenUrisTableCommandResult(null));
+		}
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime/TableBuilder.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/TableBuilder.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Performance.SDK.Runtime
         private readonly ReadOnlyCollection<IDataColumn> columnsRO;
         private readonly List<TableConfiguration> builtInTableConfigurations;
         private readonly List<TableCommand2> commands2;
+        private readonly List<TableCommand3> commands3;
         private readonly ColumnVariantsRegistrar variantsRegistrar;
 
         // Maps a row to a collection of row detail entry
@@ -49,6 +50,9 @@ namespace Microsoft.Performance.SDK.Runtime
 
             this.commands2 = new List<TableCommand2>();
             this.Commands = this.commands2;
+
+            this.commands3 = new List<TableCommand3>();
+            this.Commands3 = this.commands3;
 
             this.variantsRegistrar = new ColumnVariantsRegistrar();
 
@@ -69,6 +73,12 @@ namespace Microsoft.Performance.SDK.Runtime
         public int RowCount { get; private set; }
 
         public IReadOnlyList<TableCommand2> Commands { get; }
+
+        /// <summary>
+        ///     Gets the collection of asynchronous, result-returning commands registered
+        ///     via <see cref="AddTableCommand3"/>.
+        /// </summary>
+        public IReadOnlyList<TableCommand3> Commands3 { get; }
 
         /// <summary>
         ///     Gets the <see cref="IColumnVariantsRegistrar"/> that can be used to find
@@ -118,6 +128,27 @@ namespace Microsoft.Performance.SDK.Runtime
             }
 
             this.commands2.Add(new TableCommand2(canonicalName, canExecute, onExecute));
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public ITableBuilder AddTableCommand3(
+            string commandName,
+            Predicate<TableCommandContext2> canExecute,
+            TableCommandCallback2 onExecute)
+        {
+            Guard.NotNullOrWhiteSpace(commandName, nameof(commandName));
+            Guard.NotNull(canExecute, nameof(canExecute));
+            Guard.NotNull(onExecute, nameof(onExecute));
+
+            var canonicalName = commandName.Trim();
+            if (this.commands3.Any(x => StringComparer.CurrentCultureIgnoreCase.Equals(x.CommandName, canonicalName)))
+            {
+                throw new InvalidOperationException($"Duplicate command names are not allowed. Duplicate: {canonicalName}");
+            }
+
+            this.commands3.Add(new TableCommand3(canonicalName, canExecute, onExecute));
 
             return this;
         }

--- a/src/Microsoft.Performance.SDK.Runtime/TableCommand3.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/TableCommand3.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Performance.SDK.Processing;
+
+namespace Microsoft.Performance.SDK.Runtime;
+
+/// <summary>
+///     Represents an asynchronous, result-returning command that can be executed
+///     against a table. See
+///     <see cref="ITableBuilder.AddTableCommand3(string, Predicate{TableCommandContext2}, TableCommandCallback2)"/>.
+/// </summary>
+/// <param name="CommandName">
+///     The name of the command to be shown to the user.
+/// </param>
+/// <param name="CanExecute">
+///     A <see cref="Predicate{T}"/> that determines if the command can be executed.
+/// </param>
+/// <param name="OnExecute">
+///     The asynchronous function to execute when the command is invoked.
+/// </param>
+public sealed record TableCommand3(
+    string CommandName,
+    Predicate<TableCommandContext2> CanExecute,
+    TableCommandCallback2 OnExecute);

--- a/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/CustomDataProcessorTests.cs
@@ -178,6 +178,11 @@ namespace Microsoft.Performance.SDK.Tests
                 throw new NotImplementedException();
             }
 
+            public ITableBuilder AddTableCommand3(string commandName, Predicate<TableCommandContext2> canExecute, TableCommandCallback2 onExecute)
+            {
+                throw new NotImplementedException();
+            }
+
             public ITableBuilder AddTableConfiguration(TableConfiguration configuration)
             {
                 throw new NotImplementedException();

--- a/src/Microsoft.Performance.SDK/Microsoft.Performance.SDK.xml
+++ b/src/Microsoft.Performance.SDK/Microsoft.Performance.SDK.xml
@@ -1,0 +1,16489 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Performance.SDK</name>
+    </assembly>
+    <members>
+        <member name="T:Microsoft.Performance.SDK.Address">
+            <summary>
+                Represents a memory address.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.#ctor(System.UInt64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Address"/>
+                class with the given memory address.
+            </summary>
+            <param name="address">
+                The memory address.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Address.Value">
+            <summary>
+            Returns the raw address value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Address.ToBytes">
+            <summary>
+                Gets the byte representation of this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Address.Zero">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Address"/> that represents
+                memory address zero (0.)
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Address.MinValue">
+            <summary>
+                Gets the value of the lowest memory address
+                representable by this class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Address.MaxValue">
+            <summary>
+                Gets the value of the highest memory address
+                representable by this class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.CompareTo(Microsoft.Performance.SDK.Address)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.Equals(Microsoft.Performance.SDK.Address)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_LessThan(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Address"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_GreaterThan(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Address"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_LessThanOrEqual(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Address"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_GreaterThanOrEqual(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Address"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_Equality(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Address"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_Inequality(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Address)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Address"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Address"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_Addition(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Add bytes to a given address to create a new address.
+            </summary>
+            <param name="left">
+                Existing address.
+            </param>
+            <param name="bytes">
+                Byte count to add.
+            </param>
+            <returns>
+                Adjusted address.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.op_Subtraction(Microsoft.Performance.SDK.Address,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Subtract bytes from a given address to create a new address.
+            </summary>
+            <param name="left">
+                Existing address.
+            </param>
+            <param name="bytes">
+                Byte count to add.
+            </param>
+            <returns>
+                Adjusted address.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Address.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.AddressConverter">
+            <summary>
+                Converts instances of objects into <see cref="T:Microsoft.Performance.SDK.Address"/> instances,
+                if possible.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.AddressConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.AddressConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.AddressConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth">
+            <summary>
+                An <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> that acquires bearer tokens for accessing Azure services.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.#ctor(System.Guid,System.String[],System.Boolean,System.String,System.String,System.Nullable{System.Guid},System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth"/> class.
+            </summary>
+            <param name="appId">
+                The <see cref="T:System.Guid"/> of the Microsoft Entra ID (formerly Azure Active Directory) of the
+                application to authenticate to.
+            </param>
+            <param name="scopes">
+                The required scopes that the returned bearer token must have.
+            </param>
+            <param name="allowCache">
+                A value indicating whether or not to allow the acquired token to come from a cache. This value may
+                be <c>false</c> if a token for these scopes was previously acquired, but the token does not have access
+                to the required resources. In this case, a different token (e.g. a token for a different user) may be
+                required.
+            </param>
+            <param name="appName">
+                A human-readable display name for the application the user is logging into.
+            </param>
+            <param name="authReason">
+                An optional human-readable description to describe why the authentication is needed. For example,
+                "retrieve data from Azure DevOps".
+            </param>
+            <param name="tenant">
+                The optional tenant the authenticated principal must be logged into. May be <c>null</c>.
+            </param>
+            <param name="preferredAccountDomain">
+                The optional domain name of accounts which should be preferred for this authentication request.
+                May be <c>null</c>.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.AppId">
+            <summary>
+                Gets the <see cref="T:System.Guid"/> of the Microsoft Entra ID (formerly Azure Active Directory) of the
+                application to authenticate to.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.Scopes">
+            <summary>
+                Gets the required scopes that the returned bearer token must have.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.AllowCache">
+            <summary>
+                Gets a value indicating whether or not to allow the acquired token to come from a cache. This value may
+                be <c>false</c> if a token for these scopes was previously acquired, but the token does not have access
+                to the required resources. In this case, a different token (e.g. a token for a different user) may be
+                required.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.AppName">
+            <summary>
+                Gets a human-readable display name for the application the user is logging into.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.AuthReason">
+            <summary>
+                Gets an optional human-readable description to describe why the authentication is needed. For example,
+                "retrieve data from Azure DevOps".
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.Tenant">
+            <summary>
+                Gets the optional tenant the authenticated principal must be logged into. May be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Auth.AzureBearerTokenAuth.PreferredAccountDomain">
+            <summary>
+                Gets the optional domain name of accounts which should be preferred for this authentication request.
+                May be <c>null</c>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1">
+            <summary>
+                Represents an authentication method that can be used to authenticate to a service.
+            </summary>
+            <typeparam name="TResult">
+                The type of the result of a successful authentication.
+            </typeparam>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2">
+            <summary>
+                Provides authentication for a given <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/>.
+            </summary>
+            <typeparam name="TAuth">
+                The type of the <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> this provider can authenticate.
+            </typeparam>
+            <typeparam name="TResult">
+                The type of the result of a successful authentication.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Auth.IAuthProvider`2.TryGetAuth(`0)">
+            <summary>
+                Attempts to authenticate the given <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/>.
+            </summary>
+            <param name="authRequest">
+                The <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> to authenticate.
+            </param>
+            <returns>
+                An awaitable task that, upon completion, will contain the result of the authentication request.
+                The result of the authentication will either be an instance of <typeparamref name="TResult"/> if
+                the authentication was successful, or <c>null</c> if the authentication failed.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Bytes">
+            <summary>
+                Represents a quantity as a number of bytes.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.#ctor(System.UInt64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Bytes"/>
+                class, representing the given number of bytes.
+            </summary>
+            <param name="bytes">
+                The number of bytes being represented.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.TotalBytes">
+            <summary>
+                Gets the total number of bytes represented by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.TotalKilobytes">
+            <summary>
+                Gets the total number of bytes represented by this instance,
+                expressed as a value in kilobytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.TotalMegabytes">
+            <summary>
+                Gets the total number of bytes represented by this instance,
+                expressed as a value in megabytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.TotalGigabytes">
+            <summary>
+                Gets the total number of bytes represented by this instance,
+                expressed as a value in gigabytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.Zero">
+            <summary>
+                Gets the instance representing a quantity of zero (0)
+                bytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.MinValue">
+            <summary>
+                Gets the smallest quantity of bytes representable by
+                this class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Bytes.MaxValue">
+            <summary>
+                Gets the largest quantity of bytes representable by
+                this class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.CompareTo(Microsoft.Performance.SDK.Bytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.Equals(Microsoft.Performance.SDK.Bytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_LessThan(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Bytes"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_GreaterThan(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Bytes"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_LessThanOrEqual(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Bytes"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_GreaterThanOrEqual(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Bytes"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_Equality(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Bytes"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_Inequality(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Bytes"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Bytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.ToString(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_Subtraction(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Subtracts two quantities of <see cref="T:Microsoft.Performance.SDK.Bytes"/> from
+                each other.
+            </summary>
+            <param name="first">
+                The minuend.
+            </param>
+            <param name="second">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="second"/> from
+                <paramref name="first"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.op_Addition(Microsoft.Performance.SDK.Bytes,Microsoft.Performance.SDK.Bytes)">
+            <summary>
+                Adds two quantities of <see cref="T:Microsoft.Performance.SDK.Bytes"/> to
+                each other.
+            </summary>
+            <param name="first">
+                The first addend.
+            </param>
+            <param name="second">
+                The second addend.
+            </param>
+            <returns>
+                The result of the addition of <paramref name="first"/> with
+                <paramref name="second"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToType(System.Type,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#GetTypeCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToBoolean(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToChar(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToDateTime(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToDecimal(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToDouble(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToSByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToSingle(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToString(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToUInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToUInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IConvertible#ToUInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Bytes.GetGraphValue">
+            <summary>
+                Gets a graphable representation of this instance's
+                value.
+            </summary>
+            <returns>
+                The value of this instance as a <see cref="T:System.Double"/>,
+                suitable for graphing.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.BytesConverter">
+            <summary>
+                Converts instances of objects to <see cref="T:Microsoft.Performance.SDK.Bytes"/>, if
+                possible.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverter.TryParse(System.String,System.UInt64@,Microsoft.Performance.SDK.BytesUnits@,System.Int32@)">
+            <summary>
+                Attempts to parse the given <see cref="T:System.String"/> into a
+                quantity of bytes.
+            </summary>
+            <param name="str">
+                The <see cref="T:System.String"/> to parse.
+            </param>
+            <param name="bytes">
+                The quantity of bytes parsed.
+            </param>
+            <param name="units">
+                The units of the bytes parsed.
+            </param>
+            <param name="precision">
+                The precision of the parsing.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="str"/> was able to be parsed;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverter.ConvertToBytesUnit(System.UInt64,Microsoft.Performance.SDK.BytesUnits)">
+            <summary>
+                Converts the given raw quantity of bytes to a quantity of
+                bytes using the given unit.
+            </summary>
+            <param name="bytesValue">
+                The raw number of bytes.
+            </param>
+            <param name="units">
+                The units with which to represent the quantity specified by
+                <paramref name="bytesValue"/>.
+            </param>
+            <returns>
+                A quantity, in the given <paramref name="units"/>, representing the
+                given quantity of bytes.
+            </returns>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="units"/> is not a valid member of the <see cref="T:Microsoft.Performance.SDK.BytesUnits"/>
+                enumeration.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.BytesConverterUtils">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for dealing
+                with quantities of bytes and their representations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverterUtils.SplitNumberAndUnits(System.String,Microsoft.Performance.SDK.BytesUnits,System.String@,Microsoft.Performance.SDK.BytesUnits@)">
+            <summary>
+                Attempts to split the given string argument into the number
+                piece and the units piece.
+            </summary>
+            <param name="str">
+                The <see cref="T:System.String"/> to split.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if no units are found in <paramref name="str"/>.
+            </param>
+            <param name="remainingText">
+                The part of <paramref name="str"/> that could not be parsed.
+            </param>
+            <param name="units">
+                The units that were parsed / used.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="str"/> is <c>null</c>
+                - or -
+                <paramref name="str"/> is whitespace.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverterUtils.ConvertToBytes(System.Decimal,Microsoft.Performance.SDK.BytesUnits)">
+            <summary>
+                Converts the given raw quantity of bytes to a quantity of
+                bytes using the given unit.
+            </summary>
+            <param name="value">
+                The raw number of bytes.
+            </param>
+            <param name="units">
+                The units with which to represent the quantity specified by
+                <paramref name="value"/>.
+            </param>
+            <returns>
+                A quantity, in the given <paramref name="units"/>, representing the
+                given quantity of bytes.
+            </returns>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="units"/> is not a valid member of the <see cref="T:Microsoft.Performance.SDK.BytesUnits"/>
+                enumeration.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesConverterUtils.ConvertToBytesUnits(System.Decimal,Microsoft.Performance.SDK.BytesUnits@)">
+            <summary>
+                Converts the given byte value to a quantity using the largest possible unit
+                that still leaves a quantity with a magnitude of at least one in said unit.
+            </summary>
+            <param name="value">
+                The value to convert.
+            </param>
+            <param name="bytesUnits">
+                The units into which <paramref name="value"/> was converted.
+            </param>
+            <returns>
+                The converted quantity expressed in <paramref name="bytesUnits"/> units.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.BytesFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.Bytes"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.BytesFormatProvider.Singleton">
+            <summary>
+                Gets the single instance of the <see cref="T:Microsoft.Performance.SDK.BytesFormatProvider"/> class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesFormatProvider.GetFormat(System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.BytesFormatProvider.Format(System.String,System.Object,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.SignedBytesFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.LargeSignedBytesFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.BytesUnits">
+            <summary>
+                Represents units measuring quantities of bytes.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.BytesUnits.Bytes">
+            <summary>
+                Represents bytes.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.BytesUnits.Kilobytes">
+            <summary>
+                Represents thousands of bytes.
+                Specifically, a multiple of 1024.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.BytesUnits.Megabytes">
+            <summary>
+                Represents millions of bytes.
+                Specifically, a multiple of (1024 * 1024).
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.BytesUnits.Gigabytes">
+            <summary>
+                Represents billions of bytes.
+                Specifically, a multiple of (1024 * 1024 * 1024).
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.CloneableExtensions">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for
+                interacting with <see cref="T:Microsoft.Performance.SDK.ICloneable`1"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.CloneableExtensions.Clone``1(Microsoft.Performance.SDK.ICloneable{``0})">
+            <summary>
+                Performs a typed clone of the given instance.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of instance returned by the clone
+                method.
+            </typeparam>
+            <param name="self">
+                The instance being cloned.
+            </param>
+            <returns>
+                A clone of <paramref name="self"/> of type <typeparamref name="T"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.CollectionExtensions">
+            <summary>
+                Provides static (Shared in Visual Basic) extensions for interacting
+                with collection instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.CollectionExtensions.AsReadOnly``1(``0[])">
+            <summary>
+                Creates a readonly wrapper for the given array.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type" /> of elements in the array.
+            </typeparam>
+            <param name="self">
+                The array to wrap in a readonly collection.
+            </param>
+            <returns>
+                A readonly wrapper for the given array.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self" /> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.CollectionExtensions.AsReadOnly``1(System.Collections.Generic.IList{``0})">
+            <summary>
+                Creates a readonly wrapper for the given <see cref="T:System.Collections.Generic.IList`1" />.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type" /> of elements in the list.
+            </typeparam>
+            <param name="self">
+                The list to wrap in a readonly collection.
+            </param>
+            <returns>
+                A readonly wrapper for the given list.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self" /> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ComparableExtensions">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.IComparable"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ComparableExtensions.CompareToSafe``1(``0,``0)">
+            <summary>
+                Performs the <see cref="M:System.IComparable`1.CompareTo(`0)" /> operation,
+                handling the case  where any parameter could be null, even the
+                source. It is safe to call this method on a null reference.
+                <para/>
+                This method does NOT guarantee that the input parameter to
+                <see cref="M:System.IComparable`1.CompareTo(`0)"/> is non-null. See remarks below.
+            </summary>
+            <returns>
+                An integer value denoting the ordering of <paramref name="self"/> in
+                relation to <paramref name="compareValue"/>. See <see cref="T:System.IComparable"/>.
+                <para/>
+                A positive value indicates that <paramref name="self"/> is
+                strictly greater than <paramref name="compareValue"/>.
+                <para/>
+                A zero value indicates that <paramref name="self"/> is
+                equal to <paramref name="compareValue"/>.
+                <para/>
+                A negative value indicates that <paramref name="self"/> is
+                strictly less than <paramref name="compareValue"/>.
+            </returns>
+            <remarks>
+                This method does NOT guarantee that the input parameter to
+                <see cref="M:System.IComparable`1.CompareTo(`0)"/> is non-null. This is because the method definition
+                of <see cref="M:System.IComparable`1.CompareTo(`0)"/> accepts a nullable input (i.e. it takes in a <c>T?</c>).
+                Implementations of <see cref="M:System.IComparable`1.CompareTo(`0)"/> that this method may call still must
+                handle null values, because <see cref="M:System.IComparable`1.CompareTo(`0)"/> may be invoked outside of
+                this extension method.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ComparableUtils">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for comparing
+                objects.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ComparableUtils.CompareTo``1(``0,System.Object)">
+            <summary>
+                This is a helper method for implementing IComparable.CompareTo() when you've already implemented IComparable&lt;TThis&gt;.
+            </summary>
+            <param name="this">The left side of the comparison.</param>
+            <param name="obj">The right side of the comparison.</param>
+            <returns>
+                An integer value less than zero (0) if <paramref name="this"/> is
+                considered to be less than <paramref name="obj"/>;
+                An integer value equal to zero (0) if <paramref name="this"/> is
+                considered to be equal to <paramref name="obj"/>;
+                An integer value greater than zero (0) if <paramref name="this"/> is
+                considered to be greater than <paramref name="obj"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DecimalUtils">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.Decimal"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DecimalUtils.TryRoundToInt64(System.Decimal,System.MidpointRounding,System.Int64@)">
+            <summary>
+                Attempts to round the given value to an <see cref="T:System.Int64"/>. If the
+                rounded value is outside of the range of an <see cref="T:System.Int64"/>, then
+                <paramref name="closestValue"/> will be set to the closer of
+                <see cref="F:System.Int64.MinValue"/> or <see cref="F:System.Int64.MinValue"/>.
+            </summary>
+            <param name="value">
+                The value to round.
+            </param>
+            <param name="mode">
+                Specifies the method of rounding to use.
+            </param>
+            <param name="closestValue">
+                The rounded value.
+            </param>
+            <returns>
+                <c>true</c> if the rounded value is in the range [<see cref="F:System.Int64.MinValue" />, <see cref="F:System.Int64.MaxValue" />];
+                otherwise <c>false</c>, setting <paramref name="closestValue"/> to the closer of
+                <see cref="F:System.Int64.MinValue"/> or <see cref="F:System.Int64.MinValue"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DecimalUtils.TryRoundToUInt64(System.Decimal,System.MidpointRounding,System.UInt64@)">
+            <summary>
+                Attempts to round the given value to an <see cref="T:System.UInt64"/>. If the
+                rounded value is outside of the range of an <see cref="T:System.UInt64"/>, then
+                <paramref name="closestValue"/> will be set to the closer of
+                <see cref="F:System.UInt64.MinValue"/> or <see cref="F:System.UInt64.MinValue"/>.
+            </summary>
+            <param name="value">
+                The value to round.
+            </param>
+            <param name="mode">
+                Specifies the method of rounding to use.
+            </param>
+            <param name="closestValue">
+                The rounded value.
+            </param>
+            <returns>
+                <c>true</c> if the rounded value is in the range [<see cref="F:System.UInt64.MinValue" />, <see cref="F:System.UInt64.MaxValue" />];
+                otherwise <c>false</c>, setting <paramref name="closestValue"/> to the closer of
+                <see cref="F:System.UInt64.MinValue"/> or <see cref="F:System.UInt64.MinValue"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DecimalUtils.ConvertToNanoseconds(System.Decimal,Microsoft.Performance.SDK.TimeUnit)">
+            <summary>
+                Converts the given quantity, expressed in the given units,
+                to the equivalent quantity in nanoseconds.
+            </summary>
+            <param name="value">
+                The value to convert.
+            </param>
+            <param name="units">
+                The <see cref="T:Microsoft.Performance.SDK.TimeUnit"/> with which <paramref name="value"/> is
+                currently expressed.
+            </param>
+            <returns>
+                The number of nanoseconds equivalent to <paramref name="value"/>
+                <see cref="T:Microsoft.Performance.SDK.TimeUnit"/>s.
+            </returns>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="units"/> is not a valid member of the <see cref="T:Microsoft.Performance.SDK.TimeUnit"/>
+                enumeration.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DecimalUtils.GetPrecision(System.Decimal)">
+            <summary>
+                Gets the precision of the given <see cref="T:System.Decimal"/>
+                number.
+            </summary>
+            <param name="number">
+                The quantity whose precision is to be measured.
+            </param>
+            <returns>
+                The precision of <paramref name="number"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DelegateFunc">
+            <summary>
+                Provides a means of decorating <see cref="T:System.Func`2"/>s with the IFunc interface.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc.From``2(System.Func{``0,``1})">
+            <summary>
+                Converts the given <see cref="T:System.Func`2"/> into a <see cref="T:Microsoft.Performance.SDK.DelegateFunc`2"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of the parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/>of the result of <paramref name="func"/>.
+            </typeparam>
+            <param name="func">
+                The <see cref="T:System.Func`2"/> to convert.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.DelegateFunc`2"/> wrapper for <paramref name="func"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="func"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc.From``3(System.Func{``0,``1,``2})">
+            <summary>
+                Converts the given <see cref="T:System.Func`3"/> into a <see cref="T:Microsoft.Performance.SDK.DelegateFunc`3"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/>of the result of <paramref name="func"/>.
+            </typeparam>
+            <param name="func">
+                The <see cref="T:System.Func`3"/> to convert.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.DelegateFunc`3"/> wrapper for <paramref name="func"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="func"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc.From``4(System.Func{``0,``1,``2,``3})">
+            <summary>
+                Converts the given <see cref="T:System.Func`4"/> into a <see cref="T:Microsoft.Performance.SDK.DelegateFunc`4"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/>of the result of <paramref name="func"/>.
+            </typeparam>
+            <param name="func">
+                The <see cref="T:System.Func`4"/> to convert.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.DelegateFunc`4"/> wrapper for <paramref name="func"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="func"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc.From``5(System.Func{``0,``1,``2,``3,``4})">
+            <summary>
+                Converts the given <see cref="T:System.Func`5"/> into a <see cref="T:Microsoft.Performance.SDK.DelegateFunc`5"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="T4">
+                The <see cref="T:System.Type"/> of the fourth parameter to <paramref name="func"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/>of the result of <paramref name="func"/>.
+            </typeparam>
+            <param name="func">
+                The <see cref="T:Microsoft.Performance.SDK.DelegateFunc`5"/> to convert.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.DelegateFunc`5"/> wrapper for <paramref name="func"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="func"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DelegateFunc`2">
+            <summary>
+                Wraps a <see cref="T:System.Func`2"/> into an <see cref="T:Microsoft.Performance.SDK.IFunc`2"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of the parameter.
+            </typeparam>
+            <typeparam name="TResult">
+                The return <see cref="T:System.Type"/>.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`2.#ctor(System.Func{`0,`1})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DelegateFunc`2"/>
+                class.
+            </summary>
+            <param name="func">
+                The <see cref="T:System.Func`2"/> to wrap.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`2.Invoke(`0)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DelegateFunc`3">
+            <summary>
+                Wraps a <see cref="T:System.Func`3"/> into an
+                <see cref="T:Microsoft.Performance.SDK.IFunc`3"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter.
+            </typeparam>
+            <typeparam name="TResult">
+                The return <see cref="T:System.Type"/>.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`3.#ctor(System.Func{`0,`1,`2})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DelegateFunc`4"/>
+                class.
+            </summary>
+            <param name="func">
+                The <see cref="T:System.Func`4"/> to wrap.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`3.Invoke(`0,`1)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DelegateFunc`4">
+            <summary>
+                Wraps a <see cref="T:System.Func`4"/> into an
+                <see cref="T:Microsoft.Performance.SDK.IFunc`4"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter.
+            </typeparam>
+            <typeparam name="TResult">
+                The return <see cref="T:System.Type"/>.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`4.#ctor(System.Func{`0,`1,`2,`3})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DelegateFunc`4"/>
+                class.
+            </summary>
+            <param name="func">
+                The <see cref="T:System.Func`4"/> to wrap.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`4.Invoke(`0,`1,`2)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DelegateFunc`5">
+            <summary>
+                Wraps a <see cref="T:System.Func`5"/> into an
+                <see cref="T:Microsoft.Performance.SDK.IFunc`5"/>.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter.
+            </typeparam>
+            <typeparam name="T4">
+                The <see cref="T:System.Type"/> of the fourth parameter.
+            </typeparam>
+            <typeparam name="TResult">
+                The return <see cref="T:System.Type"/>.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`5.#ctor(System.Func{`0,`1,`2,`3,`4})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DelegateFunc`5"/>
+                class.
+            </summary>
+            <param name="func">
+                The <see cref="T:System.Func`5"/> to wrap.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DelegateFunc`5.Invoke(`0,`1,`2,`3)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DoubleExtensions">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.Double"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleExtensions.IsFinite(System.Double)">
+            <summary>
+                Determines whether the given instance represents
+                a finite quantity.
+            </summary>
+            <param name="value">
+                The value to check for finiteness.
+            </param>
+            <returns>
+                <c>true</c> if value represents a finite quantity;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleExtensions.IsNonReal(System.Double)">
+            <summary>
+                Helper method to check if a double is valid.
+            </summary>
+            <param name="value">
+                double to check.</param>
+            <returns>
+                true if the value is invalid, false otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DoubleRange">
+            <summary>
+                Represents a range of values using <see cref="T:System.Double"/>s.
+                The range is taken to be [begin, end)
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.#ctor(System.Double,System.Double)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>
+                class spanning the given interval.
+            </summary>
+            <param name="begin">
+                The beginning of the range.
+            </param>
+            <param name="end">
+                The end of the range.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.Zero">
+            <summary>
+                Gets the empty range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.Begin">
+            <summary>
+                Gets or sets the beginning of this range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.End">
+            <summary>
+                Gets or sets the end of this range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.Length">
+            <summary>
+                Gets the length of this range. The length
+                is the difference between <see cref="P:Microsoft.Performance.SDK.DoubleRange.End"/> and
+                <see cref="P:Microsoft.Performance.SDK.DoubleRange.Begin"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.HasLength">
+            <summary>
+                Gets a value indicating whether this range has a
+                length. An infinite range does not have a length.
+                A range with <see cref="P:Microsoft.Performance.SDK.DoubleRange.Begin"/> equal to <see cref="P:Microsoft.Performance.SDK.DoubleRange.End"/>
+                does not have a length.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleRange.IsFinite">
+            <summary>
+                Gets a value indicating whether this instance is finite.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.op_Equality(Microsoft.Performance.SDK.DoubleRange,Microsoft.Performance.SDK.DoubleRange)">
+            <summary>
+                Determines if two <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered to be
+                equal to <paramref name="second"/>; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.op_Inequality(Microsoft.Performance.SDK.DoubleRange,Microsoft.Performance.SDK.DoubleRange)">
+            <summary>
+                Determines if two <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> instances
+                are considered to *not* be equal.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered not to be
+                equal to <paramref name="second"/>; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.op_Explicit(Microsoft.Performance.SDK.DoubleRange)~Microsoft.Performance.SDK.Int64Range">
+            <summary>
+                Explicitly casts a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> to an
+                <see cref="T:Microsoft.Performance.SDK.Int64Range"/>.
+            </summary>
+            <param name="range">
+                The <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> to cast.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Intersect(Microsoft.Performance.SDK.DoubleRange,Microsoft.Performance.SDK.DoubleRange)">
+            <summary>
+                Gets the intersection of the two ranges, it one exists.
+            </summary>
+            <param name="first">
+                The first range.
+            </param>
+            <param name="second">
+                The second range.
+            </param>
+            <returns>
+                The range of intersection between <paramref name="first"/>
+                and <paramref name="second"/>. If no intersection exists,
+                the <c>null</c> is returned.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Xor(Microsoft.Performance.SDK.DoubleRange,Microsoft.Performance.SDK.DoubleRange)">
+            <summary>
+                Performs and exclusive or of the two <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>s.
+                The exclusive or of two ranges is the collection of all ranges that
+                1) are contained in one range but not the other and
+                2) when the union is taken, the result is equal to the union of the
+                   original ranges.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                A collection of <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> instances that represent
+                the exclusive or of the two ranges.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Parse(System.String)">
+            <summary>
+                Parses the given <see cref="T:System.String"/> into a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>
+                instance. A string representation of a range is "[x, y)" where x and y
+                are doubles.
+            </summary>
+            <param name="s">
+                The <see cref="T:System.String"/> to parse.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="s"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.FormatException">
+                <paramref name="s"/> is not parseable into a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.TryParse(System.String,Microsoft.Performance.SDK.DoubleRange@)">
+            <summary>
+                Tries to parse the given <see cref="T:System.String"/> into a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>
+                instance. A string representation of a range is "[x, y)" where x and y
+                are doubles.
+            </summary>
+            <param name="s">
+                The <see cref="T:System.String"/> to parse.
+            </param>
+            <param name="result">
+                When <paramref name="s"/> is able to be parsed, this contains the result
+                of parsing into a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> is parsed into a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Overlaps(Microsoft.Performance.SDK.DoubleRange)">
+            <summary>
+                Determines whether this range overlaps with the given range.
+                See <see cref="M:Microsoft.Performance.SDK.DoubleUtils.DoRangesOverlap(System.Double,System.Double,System.Double,System.Double)"/> for more information.
+            </summary>
+            <param name="other">
+                The range to check.
+            </param>
+            <returns>
+                <c>true</c> if this instance overlaps with <paramref name="other"/>;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.Equals(Microsoft.Performance.SDK.DoubleRange)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRange.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DoubleRangeConverter">
+            <summary>
+                Converts object instances into <see cref="T:Microsoft.Performance.SDK.DoubleRange"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.DoubleRangeConverter"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleRangeConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.DoubleUtils">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.Double"/>s.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleUtils.BoxedZero">
+            <summary>
+                Gets the value of zero (0), but already boxed into an object.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.DoubleUtils.BoxedOne">
+            <summary>
+                Gets the value of one (1.0), but already boxed.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.GetBoxed(System.Double)">
+            <summary>
+                Gets the boxed value of the given <see cref="T:System.Double"/>.
+            </summary>
+            <param name="value">
+                The value to box.
+            </param>
+            <returns>
+                The boxed value.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.DoRangesOverlap(System.Double,System.Double,System.Double,System.Double)">
+            <summary>
+                Determines whether the two ranges overlap.
+            </summary>
+            <remarks>
+                The begin and end values for each range are implicitly swapped if begin is greater 
+                than end.
+                The range is treated as having an inclusive begin value, and exclusive end value.
+                In other words: [begin, end)
+            </remarks>
+            <param name="firstBegin">
+                The beginning of the first range.
+            </param>
+            <param name="firstEnd">
+                The end of the first range.
+            </param>
+            <param name="secondBegin">
+                The beginning of the second range.
+            </param>
+            <param name="secondEnd">
+                The end of the second range.
+            </param>
+            <returns>
+                <c>true</c> if the ranges overlap; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.Clamp(System.Double,System.Double,System.Double)">
+            <summary>
+                Clamps the given value to the range [min, max].
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="min">
+                The minimum allowable value. The lower bound of the clamp.
+            </param>
+            <param name="max">
+                The maximum allowable value. The upper bound of the clamp.
+            </param>
+            <returns>
+                If value is less than min, then min. If value is between min
+                and max, then value. If value is greater than max, then max.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="max"/> is less than <paramref name="min"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.SafeClamp(System.Double,System.Double,System.Double)">
+            <summary>
+                Clamps the given value to the range [min, max], ensuring
+                that <paramref name="extreme1"/> is less than <paramref name="extreme2"/>
+                when calculating the clamp.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extreme1">
+                The first bound of the clamp.
+            </param>
+            <param name="extreme2">
+                The other bound of the clamp.
+            </param>
+            <returns>
+                The value, if value is in the range specified by <paramref name="extreme1"/>
+                and <paramref name="extreme2"/>. Otherwise, either <paramref name="extreme1"/>
+                or <paramref name="extreme2"/>, whichever is closer.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.IsClamped(System.Double,System.Double,System.Double)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="min">
+                The minimum value.
+            </param>
+            <param name="max">
+                The maximum value.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="min"/> and <paramref name="max"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.SafeIsClamped(System.Double,System.Double,System.Double)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="extreme1">
+                The first extreme of the range.
+            </param>
+            <param name="extreme2">
+                The other extreme of the range.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="extreme1"/> and <paramref name="extreme2"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.ClampToByte(System.Double)">
+            <summary>
+                Clamps the given value to the range of a <see cref="T:System.Byte"/>.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <returns>
+                The value clamped to [<see cref="F:System.Byte.MinValue"/>, <see cref="F:System.Byte.MaxValue"/>].
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.ClampToInt64(System.Double)">
+            <summary>
+                Clamps the given value to the range of an <see cref="T:System.Int64"/>.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <returns>
+                The value clamped to [<see cref="F:System.Int64.MinValue"/>, <see cref="F:System.Int64.MaxValue"/>].
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.ClampToUInt64(System.Double)">
+            <summary>
+                Clamps the given value to the range of an <see cref="T:System.UInt64"/>.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <returns>
+                The value clamped to [<see cref="F:System.UInt64.MinValue"/>, <see cref="F:System.UInt64.MaxValue"/>].
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.ClampToFloat(System.Double)">
+            <summary>
+                Clamps the given value to the range of an <see cref="T:System.Single"/>.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <returns>
+                The value clamped to [<see cref="F:System.Single.MinValue"/>, <see cref="F:System.Single.MaxValue"/>].
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.Max(System.Double,System.Double)">
+            <summary>
+                Returns the max of two values.
+            </summary>
+            <param name="val0">
+                The first value to compare.
+            </param>
+            <param name="val1">
+                The second value to compare.
+            </param>
+            <returns>
+                The maximum of the two values.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.Max(System.Double,System.Double,System.Double)">
+            <summary>
+                Returns the max of three values.
+            </summary>
+            <param name="val0">
+                The first value to compare.
+            </param>
+            <param name="val1">
+                The second value to compare.
+            </param>
+            <param name="val2">
+                The third value to compare.
+            </param>
+            <returns>
+                The maximum of the three values.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.AreClose(System.Double,System.Double)">
+            <summary>
+            AreClose - Returns whether or not two doubles are "close".  That is, whether or 
+            not they are within epsilon of each other.  Note that this epsilon is proportional
+            to the numbers themselves to that AreClose survives scalar multiplication.
+            There are plenty of ways for this to return false even for numbers which
+            are theoretically identical, so no code calling this should fail to work if this 
+            returns false.  This is important enough to repeat:
+            NB: NO CODE CALLING THIS FUNCTION SHOULD DEPEND ON ACCURATE RESULTS - this should be
+            used for optimizations *only*.
+            </summary>
+            <param name="value1"> The first double to compare. </param>
+            <param name="value2"> The second double to compare. </param>
+            <returns>
+                <c>true</c> if <paramref name="value1"/> and <paramref name="value2"/>
+                are considered to be close
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.LessThan(System.Double,System.Double)">
+            <summary>
+            LessThan - Returns whether or not the first double is less than the second double.
+            That is, whether or not the first is strictly less than *and* not within epsilon of
+            the other number.  Note that this epsilon is proportional to the numbers themselves
+            to that AreClose survives scalar multiplication.  Note,
+            There are plenty of ways for this to return false even for numbers which
+            are theoretically identical, so no code calling this should fail to work if this 
+            returns false.  This is important enough to repeat:
+            NB: NO CODE CALLING THIS FUNCTION SHOULD DEPEND ON ACCURATE RESULTS - this should be
+            used for optimizations *only*.
+            </summary>
+            <returns>
+            bool - the result of the LessThan comparison.
+            </returns>
+            <param name="value1"> The first double to compare. </param>
+            <param name="value2"> The second double to compare. </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.GreaterThan(System.Double,System.Double)">
+            <summary>
+            GreaterThan - Returns whether or not the first double is greater than the second double.
+            That is, whether or not the first is strictly greater than *and* not within epsilon of
+            the other number.  Note that this epsilon is proportional to the numbers themselves
+            to that AreClose survives scalar multiplication.  Note,
+            There are plenty of ways for this to return false even for numbers which
+            are theoretically identical, so no code calling this should fail to work if this 
+            returns false.  This is important enough to repeat:
+            NB: NO CODE CALLING THIS FUNCTION SHOULD DEPEND ON ACCURATE RESULTS - this should be
+            used for optimizations *only*.
+            </summary>
+            <returns>
+            bool - the result of the GreaterThan comparison.
+            </returns>
+            <param name="value1"> The first double to compare. </param>
+            <param name="value2"> The second double to compare. </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.DoubleUtils.IsNaN(System.Double)">
+            <summary>
+                Determines if the given value represents the "Not a Number" (NaN)
+                value.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is NaN;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ErrorInfo">
+            <summary>
+                Encapsulates information around an error condition.
+                In order to expose more specific error information,
+                you may derive from this class and add your own
+                properties.
+                <para/>
+                Plugin authors may use this in conjunction with
+                <see cref="T:Microsoft.Performance.SDK.ExtensionException"/> to report errors
+                from their Plugins.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.ErrorInfo.None">
+            <summary>
+                The <see cref="T:Microsoft.Performance.SDK.ErrorInfo"/> instance representing no errors.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.#ctor(System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ErrorInfo"/>
+                class.
+            </summary>
+            <param name="code">
+                A processor specific error code.
+            </param>
+            <param name="message">
+                A human-readable representation of the error.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="code"/> is <c>null</c>.
+                - or -
+                <paramref name="message"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <summary>
+                Serialization constructor.
+            </summary>
+            <param name="info">
+                The data to be deserialized.
+            </param>
+            <param name="context">
+                The context of the serialization.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="info"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ErrorInfo.Code">
+            <summary>
+                Gets the processor specific code for this error.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ErrorInfo.Message">
+            <summary>
+                Gets a human-readable representation of the error.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ErrorInfo.Target">
+            <summary>
+                Gets or sets the target of the error, if any. This
+                property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ErrorInfo.Details">
+            <summary>
+                Gets or sets an array of details about specific errors that
+                led to this reported error. This property may be <c>null</c>
+                or empty.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.ToString">
+            <summary>
+                Gets the string representation of this error object.
+            </summary>
+            <returns>
+                The string representation of this error object.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.ToString(System.String,System.IFormatProvider)">
+            <summary>
+                Formats the value of the current instance using the specified format.
+            </summary>
+            <param name="format">
+                The format to use.
+                - or -
+                A <c>null</c> reference (Nothing in Visual Basic) to use the
+                default format defined for the type of the <see cref="T:System.IFormattable"/>
+                implementation.
+            </param>
+            <param name="formatProvider">
+                The provider to use to format the value.
+                - or -
+                A <c>null</c> reference (Nothing in Visual Basic) to obtain the
+                numeric format information from the current locale setting of
+                the operating system.
+            </param>
+            <returns>
+                The value of the current instance in the specified format.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ErrorInfo.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath">
+            <summary>
+                This helper struct provides methods to manipulate a string in the form of a path to
+                an <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker" />.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCookerPath.EmptySourceParserId">
+            <summary>
+                If the data cooker is not a source data cooker, this is the source parser Id.
+            </summary>
+            <remarks>
+               This must match 
+               Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.DataCookers.DataCookerPathInternal.EmptySourceParserId.
+            </remarks>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCookerPath.Separator">
+            <summary>
+                Separates the consituent parts of the data cooker path in the full string representation. This character is not
+                allowed in path components. If this path is changed, please update the exception comments in <see cref="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.ForSource(System.String,System.String)"/>
+                and <see cref="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.ForComposite(System.String)"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCookerPath.EqualityComparer">
+            <summary>
+                This is used by data cooker paths to compare elements.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Constructor that takes an existing DataCookerPath and duplicates the values.
+            </summary>
+            <param name="other">
+                An existing data cooker path.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCookerPath.CookerPath">
+            <summary>
+                Gets the path of this cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.ForComposite(System.String)">
+            <summary>
+                Creates a new <see cref="F:Microsoft.Performance.SDK.Extensibility.DataCookerType.CompositeDataCooker"/> path.
+            </summary>
+            <param name="dataCookerId">
+                The ID of the data cooker.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more of the parameters is empty, composed only of whitespace, 
+                or contains the '/' character.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataCookerId"/> is null.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.ForSource(System.String,System.String)">
+            <summary>
+                Creates a new <see cref="F:Microsoft.Performance.SDK.Extensibility.DataCookerType.SourceDataCooker"/> path.
+            </summary>
+            <param name="sourceParserId">
+                The ID of the source parser.
+            </param>
+            <param name="dataCookerId">
+                The ID of the data cooker.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more of the parameters is empty, composed only of whitespace, 
+                or contains the '/' character.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                One or more of the parameters is null.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCookerPath.DataCookerType">
+            <summary>
+                Gets the type of the data cooker that this path targets.
+                <seealso cref="P:Microsoft.Performance.SDK.Extensibility.DataCookerPath.DataCookerType"/> for more information about what
+                different types of data cookers mean.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCookerPath.SourceParserId">
+            <summary>
+                Gets the source parser Id.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCookerPath.DataCookerId">
+            <summary>
+                Gets the Data cooker Id.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.op_Equality(Microsoft.Performance.SDK.Extensibility.DataCookerPath,Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Compares two instance of <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/> for equality.
+            </summary>
+            <param name="left">
+                The first instance to compare.
+            </param>
+            <param name="right">
+                The second instance to compare.
+            </param>
+            <returns>
+                <c>true</c> if both instances are considered to be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.op_Inequality(Microsoft.Performance.SDK.Extensibility.DataCookerPath,Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Compares two instance of <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/> for inequality.
+            </summary>
+            <param name="left">
+                The first instance to compare.
+            </param>
+            <param name="right">
+                The second instance to compare.
+            </param>
+            <returns>
+                <c>true</c> if both instances are considered to not be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.Equals(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCookerPath.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCookerType">
+            <summary>
+                The type of a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCookerType.SourceDataCooker">
+            <summary>
+                An <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/> that directly receives input from an
+                <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3"/> and/or one or more
+                <see cref="F:Microsoft.Performance.SDK.Extensibility.DataCookerType.SourceDataCooker"/>s targeting the same <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCookerType.CompositeDataCooker">
+            <summary>
+                An <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/> that consumes events from one or more
+                other <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector">
+            <summary>
+                This class implements <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataSet"/> through reflection to identify output
+                from the derived class. Data to be exposed through <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataSet"/> must be
+                exposed as public properties in the class, attributed with <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.DataOutputAttribute"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector"/>
+                class with the given path.
+            </summary>
+            <param name="dataCookerPath">
+                The path to this cooker.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.OutputIdentifiers">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.QueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.TryQueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath,``0@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector.TryQueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath,System.Object@)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.DataCookerDependencyType">
+            <summary>
+                The interaction between source data cookers determines the order in which source
+                data cookers receive source data to cook.
+            <para/>
+                The default consumption strategy will be determined by the
+                <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy"/>
+                defined on the target SourceDataCooker.
+            <para/>
+                Overriding this means the dependent knows internals of the target SourceDataCooker
+                and that it is safe to do so.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.DataCookerDependencyType.AlignedWithProductionStrategy">
+            <summary>
+                Default behavior: the dependency type will be determined by the data production strategy on
+                the target source data cooker.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.DataCookerDependencyType.AsConsumed">
+            <summary>
+                This data cooker may receive source data during the same iteration as the target
+                data cooker, but only after the target data cooker has already had a chance to
+                cook the same data record.
+            <para/>
+                <see cref="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.EndDataCooking(System.Threading.CancellationToken)"/> will be called based on
+                this dependency ordering.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.DataCookerDependencyType.SamePass">
+            <summary>
+                This data cooker may receive source data anytime during the same parsing pass
+                as the target source data cooker.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.DataOutputAttribute">
+            <summary>
+                This attribute is used by data cookers deriving from <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.CookedDataReflector"/> to identify properties
+                to be exposed as output from an <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataSet"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.DataOutputAttribute.#ctor">
+            <summary>
+                Creates a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/> based on the property name to which this attribute is attached.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.DataOutputAttribute.#ctor(System.String)">
+            <summary>
+                Creates a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/> based on the name provided.
+            </summary>
+            <param name="dataIdentifier">
+                The data cooker id which will later be combined with a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/> to form a
+                <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.DataOutputAttribute.DataIdentifier">
+            <summary>
+                Gets a unique identifier for the data to expose through a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>.
+                <remarks>
+                    This identifier represents the data cooker Id, not the complete <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/>. It will be
+                    combined with a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/> for form a complete  <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>.
+                </remarks>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICompositeDataCookerDescriptor">
+            <summary>
+                A data cooker that does not directly take part in data source processing
+                should implement this interface.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ICompositeDataCookerDescriptor.OnDataAvailable(Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval)">
+            <summary>
+                When all required data becomes available, this method will be called
+                so that the data cooker may retrieve data it requires.
+            </summary>
+            <param name="requiredData">
+                Provides access to data required by the cooker.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval">
+            <summary>
+                Defines methods for retrieving data output from a data cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="identifier">
+                Unique identifier for the data to retrieve.
+            </param>
+            <returns>
+                The uniquely identified data.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="identifier"/> references a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/> that does not exist.
+            </exception>
+            <exception cref="T:System.InvalidCastException">
+                The value at <paramref name="identifier"/> cannot be cast to <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval.QueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="identifier">
+                Unique identifier for the data to retrieve.
+            </param>
+            <returns>
+                The uniquely identified data, as an object.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="identifier"/> references a <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/> that does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval.TryQueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath,``0@)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="identifier">
+                Unique identifier for the data to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval.TryQueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath,System.Object@)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="identifier">
+                Unique identifier for the data to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data, as an object.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataSet">
+            <summary>
+                Implement this interface to expose output from the data cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataSet.OutputIdentifiers">
+            <summary>
+                Gets each piece of data output from the extension has a unique name associated with it.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker">
+            <summary>
+                A data cooker.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCookerDescriptor">
+            <summary>
+                Provides information about a data cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCookerDescriptor.Description">
+            <summary>
+                Gets a description of the data extension.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCookerDescriptor.Path">
+            <summary>
+                Gets the path to this data cooker.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory">
+            <summary>
+                An interface to describe and instantiate a given data cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory.CreateInstance">
+            <summary>
+                Create a new instance of the described data cooker.
+            </summary>
+            <returns>
+                A data cooker.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactoryRetrieval">
+            <summary>
+                Adds a method to retrieve a source data cooker factory for a given data cooker path.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactoryRetrieval.GetSourceDataCookerFactory(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Returns a factory to create a source data cooker for the given data cooker path.
+            </summary>
+            <param name="dataCookerPath">
+                The path to the data cooker for which to create a factory.
+            </param>
+            <returns>
+                A factory to create a data cooker instance.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy">
+            <summary>
+                This defines how data is cooked on a SourceDataCooker, indicating
+                when it is generally safe for consumption by other data cookers.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy.PostSourceParsing">
+            <summary>
+                Does not finish cooking until all records have been received.
+                Data is not ready for consumption until this point.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy.AsConsumed">
+            <summary>
+                Data will be ready for consumption when cooking the
+                individual record has finished.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy.AsRequired">
+            <summary>
+                A source data cooker with this value will run in every stage
+                in which a dependent source data cooker runs.
+            <para/>
+                This is particularly useful for streaming source data cookers,
+                where the data is not stored.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCookerOptions">
+            <summary>
+                Flags to modify data cooker behavior.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCookerOptions.None">
+            <summary>
+                Default behavior.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCookerOptions.ReceiveAllDataElements">
+            <summary>
+                Rather than specifying specific data keys to filter data this cooker receives, it will receive all data
+                elements from the source parser.
+            </summary>
+            <remarks>
+                This will have a performance impact, and should only be used when necessary.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3">
+            <summary>
+                Implement this interface to receive data from a given source as it is being processed.
+            </summary>
+            <typeparam name="T">
+                <see cref="T:System.Type"/> of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                <see cref="T:System.Type"/> that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                <see cref="T:System.Type"/> that will be used to identify data from the source that is relevant to this extension.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.DataKeys">
+            <summary>
+                Gets a set of identifiers that determine which data from the source will
+                be forwarded to this extension.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.Options">
+            <summary>
+                Gets any additional options that apply to this cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.BeginDataCooking(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,System.Threading.CancellationToken)">
+            <summary>
+                This is called just before source parsing begins for the pass through the
+                source for which this data cooker will receive data elements to process.
+            </summary>
+            <param name="dependencyRetrieval">
+                Used to retrieve data from other source data cookers.
+            </param>
+            <param name="cancellationToken">
+                Used to indicate that the user wishes to cancel.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.CookDataElement(`0,`1,System.Threading.CancellationToken)">
+            <summary>
+                Called to cook raw data from the source.
+            </summary>
+            <param name="data">
+                The data from the source to be processed.
+            </param>
+            <param name="context">
+                Additional information to assist processing.
+            </param>
+            <param name="cancellationToken">
+                Used to indicate that the user wishes to cancel.
+            </param>
+            <returns>
+                The result from processing the data.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3.EndDataCooking(System.Threading.CancellationToken)">
+            <summary>
+                This is called at the end of the pass through the source for which this
+                data cooker will received data elements to process.
+            </summary>
+            <param name="cancellationToken">
+                Used to indicate that the user wishes to cancel.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerDependencyTypes">
+            <summary>
+                This interface is used to define specific dependency behaviors for each of the data cookers required
+                by this data cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerDependencyTypes.DependencyTypes">
+            <summary>
+                Gets the definition of the dependency type for each source data cooker required
+                by another source data cooker.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerDescriptor">
+            <summary>
+                Information about a source data cooker that is not dependent on templates.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerDescriptor.DataProductionStrategy">
+            <summary>
+                Gets the definition for how data is produced for this data cooker.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerRegistrar`3">
+            <summary>
+                Implemented so that data extensions may be registered. A data extension must be registered
+                before it can receive data for processing, or before its output may be exposed for consumption.
+            </summary>
+            <typeparam name="T">
+                <see cref="T:System.Type"/> of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                <see cref="T:System.Type"/> that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                <see cref="T:System.Type"/> that will be used to identify data from the source that is relevant to this extension.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerRegistrar`3.RegisteredSourceDataCookers">
+            <summary>
+                Gets access to all registered data cookers.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerRegistrar`3.RegisterSourceDataCooker(Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker{`0,`1,`2})">
+            <summary>
+                Called to register an <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/> for use in processing a source.
+            </summary>
+            <param name="dataCooker">
+                The data extension to register for use.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerRetrieval`3">
+            <summary>
+                Implemented to access source data cookers.
+            </summary>
+            <typeparam name="T">
+                <see cref="T:System.Type"/> of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                <see cref="T:System.Type"/> that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                <see cref="T:System.Type"/> that will be used to identify data from the source that is relevant to this extension.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCookerRetrieval`3.GetSourceDataCooker(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Call to retrieve an instance of the cooker id.
+            </summary>
+            <param name="cookerPath">
+                Identify a cooker.
+            </param>
+            <returns>
+                Data cooker.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3">
+            <summary>
+                This abstract class provides default implementations for source data cookers.
+            </summary>
+            <typeparam name="T">
+                <see cref="T:System.Type"/> of the data element from the source parser.
+            </typeparam>
+            <typeparam name="TContext">
+                <see cref="T:System.Type"/> of contextual information for the data element.
+            </typeparam>
+            <typeparam name="TKey">
+                Identifier for the <see cref="T:System.Type"/> of data element.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.#ctor(System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3"/>
+                class for the given cooker.
+            </summary>
+            <param name="sourceId">
+                The ID of the source parser from which this cooker cooks
+                data.
+            </param>
+            <param name="cookerId">
+                This cooker's ID.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3"/>
+                class for the given cooker.
+            </summary>
+            <param name="dataCookerPath">
+                This cooker's path.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.Description">
+            <summary>
+                Gets the description of this cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.DataKeys">
+            <summary>
+                Gets a collection of the keys for all data
+                produced by this cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.Path">
+            <summary>
+                Gets the path of this cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.CookDataElement(`0,`1,System.Threading.CancellationToken)">
+            <summary>
+                When overridden in a derived class, processes
+                a data element of the source cooker.
+            </summary>
+            <param name="data">
+                The data item being cooked.
+            </param>
+            <param name="context">
+                The overall context of the cooking session.
+            </param>
+            <param name="cancellationToken">
+                Signals that the caller wishes to cancel the operation.
+            </param>
+            <returns>
+                The outcome of processing the data item.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.Options">
+            <summary>
+                Gets the options for this instance.
+                <para />
+                By default, there are no options. Override this
+                member in order to provide different options to
+                the cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.DependencyTypes">
+            <summary>
+                Gets all dependencies of this cooker.
+                <para />
+                By default, there are no dependencies. Override this
+                member in order to declare dependencies for this
+                cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.DataProductionStrategy">
+            <summary>
+                Gets the data production strategy used by this cooker.
+                <para />
+                By default, the strategy is <see cref="F:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.DataProductionStrategy.PostSourceParsing"/>.
+                Override this member in order to use a different <see cref="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.DataProductionStrategy"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.RequiredDataCookers">
+            <summary>
+                Gets the cookers required by this cooker in order to successfully
+                process data.
+                <para/>
+                By default, there are no required cookers. Override this member
+                in order to declare additional requirements.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.BeginDataCooking(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,System.Threading.CancellationToken)">
+            <summary>
+                When overridden in a derived class, performs any processing that
+                must be performed before cooking actually begins. By default,
+                this method does nothing.
+            </summary>
+            <param name="dependencyRetrieval">
+                Provides a means of retrieving the dependencies of this cooker.
+            </param>
+            <param name="cancellationToken">
+                Signals that the caller wishes to cancel the operation.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.SourceDataCooker`3.EndDataCooking(System.Threading.CancellationToken)">
+            <summary>
+                When overridden in a derived class, performs any processing
+                that should occur after source parsing completes. By default,
+                this method does nothing.
+            </summary>
+            <param name="cancellationToken">
+                Signals that the caller wishes to cancel the operation.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath">
+            <summary>
+                This helper class provides methods to manipulate string in the form of paths to
+                data output from a data cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataOutputPath.ForSource(System.String,System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>
+                struct with the given source parser ID, data cooker ID, and
+                output ID.
+            </summary>
+            <param name="sourceParserId">
+                Source parser Id.
+            </param>
+            <param name="dataCookerId">
+                Data cooker Id.
+            </param>
+            <param name="dataOutputId">
+                Data output Id.
+            </param>
+            <returns>
+                DataOutputPath object combined from the given parameters.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                One or more of the parameters is empty or composed only of whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                One or more of the parameters is null.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataOutputPath.ForComposite(System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>
+                struct with the given data cooker ID and output ID.
+            </summary>
+            <param name="dataCookerId">
+                Data cooker Id.
+            </param>
+            <param name="dataOutputId">
+                Data output Id.
+            </param>
+            <returns>
+                DataOutputPath object combined from the given parameters.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                One or more of the parameters is empty or composed only of whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                One or more of the parameters is null.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataOutputPath.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>
+                struct with the given cooker path and output ID.
+            </summary>
+            <param name="cookerPath">
+                Data cooker path.
+            </param>
+            <param name="outputId">
+                Data output Id.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="outputId"/> is empty or composed only of whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="outputId"/> is null.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataOutputPath.OutputId">
+            <summary>
+                Gets the data output identifier.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataOutputPath.CookerPath">
+            <summary>
+                Gets the path to data cooker in which the output data is stored.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataOutputPath.SourceParserId">
+            <summary>
+                Gets the identifier of the source parser associated with this data.
+            </summary>
+            <remarks>
+                This may be null or <see cref="F:System.String.Empty"/> if this <see cref="T:Microsoft.Performance.SDK.Extensibility.DataOutputPath"/>
+                is for a composite cooker.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataOutputPath.DataCookerId">
+            <summary>
+                Identifies the data cooker associated with this data.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataOutputPath.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataProcessingResult">
+            <summary>
+                The result from processing data from a source.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataProcessingResult.Processed">
+            <summary>
+                The data was successfully processed.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataProcessingResult.Ignored">
+            <summary>
+                The data was ignored by the data processor.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataProcessingResult.CorruptData">
+            <summary>
+                The data was reported corrupt by the data processor.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.DataProcessingResult.InvalidVersion">
+            <summary>
+                The version of the event is not supported.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.DataProcessorId">
+            <summary>
+                Identifies a data processor
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataProcessorId.#ctor(System.String)">
+            <summary>
+                Constructor
+            </summary>
+            <param name="dataProcessorId">
+                Data processor Id.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.DataProcessorId.Id">
+            <summary>
+                Gets the Data processor Id.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataProcessorId.Equals(Microsoft.Performance.SDK.Extensibility.DataProcessorId)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataProcessorId.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.DataProcessorId.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensibilityException">
+            <summary>
+                Base class for all SDK extensibility exceptions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensibilityException.#ctor(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensibilityException.#ctor(System.String,System.Exception)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensionTableException">
+            <summary>
+                Represents an exception with an extension table.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensionTableException.#ctor(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.Exceptions.WrongProcessorTableException">
+            <summary>
+                The table is not valid for the given processor.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.Exceptions.WrongProcessorTableException.#ctor(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions">
+            <summary>
+                Additional functionality for the <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval"/> interface.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataOutputPath,``0@)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="dataOutputPath">
+                Unique identifier for the data to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <exception cref="T:System.InvalidOperationException">
+                The specified <paramref name="dataOutputPath"/> was not found.
+            </exception>
+            <exception cref="T:System.InvalidCastException">
+                The value at <paramref name="dataOutputPath"/> cannot be cast to <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.QueryOutput(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="cookerPath">
+                Identifies the data cooker to query.
+            </param>
+            <param name="outputId">
+                Identifies which data on the data cooker to retrieve.
+            </param>
+            <returns>
+                The uniquely identified data.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                The specified <paramref name="outputId"/> was not found on the data cooker 
+                <paramref name="cookerPath"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.TryQueryOutput(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String,System.Object@)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="cookerPath">
+                Identifies the data cooker to query.
+            </param>
+            <param name="outputId">
+                Identifies which data on the data cooker to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="cookerPath">
+                Identifies the data cooker to query.
+            </param>
+            <param name="outputId">
+                Identifies which data on the data cooker to retrieve.
+            </param>
+            <returns>
+                The uniquely identified data.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                The specified <paramref name="outputId"/> was not found on the data cooker 
+                <paramref name="cookerPath"/>.
+            </exception>
+            <exception cref="T:System.InvalidCastException">
+                The value at <paramref name="outputId"/> cannot be cast to <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String,``0@)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="cookerPath">
+                Identifies the data cooker to query.
+            </param>
+            <param name="outputId">
+                Identifies which data on the data cooker to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <exception cref="T:System.InvalidOperationException">
+                The specified <paramref name="outputId"/> was not found on the data cooker 
+                <paramref name="cookerPath"/>.
+            </exception>
+            <exception cref="T:System.InvalidCastException">
+                The value at <paramref name="outputId"/> cannot be cast to <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.ICookedDataRetrievalExtensions.TryQueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.String,``0@)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="retrieval">
+                Instance on which to act.
+            </param>
+            <param name="cookerPath">
+                Identifies the data cooker to query.
+            </param>
+            <param name="outputId">
+                Identifies which data on the data cooker to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.IDataCookerDependent">
+            <summary>
+                Should be applied to any data extension type that may require data cookers.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.IDataCookerDependent.RequiredDataCookers">
+            <summary>
+                Gets the required data cooker identifiers.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval">
+            <summary>
+                This interface is used to query cooked data or data processors.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.IKeyedDataType`1">
+            <summary>
+                The data exposed by an <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3"/> must implement this interface.
+            </summary>
+            <typeparam name="TKey">
+                A type that acts a key identifier for the data.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.IKeyedDataType`1.GetKey">
+            <summary>
+                The type returned from this is used to determine which <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker`3"/> will receive this data for processing.
+            </summary>
+            <returns>
+                The type used as a key for this data.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.ITableExtension">
+            <summary>
+                Basic information about a table extension.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.ITableExtension.TableDescriptor">
+            <summary>
+                Gets a table descriptor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.ITableExtension.BuildTableAction">
+            <summary>
+                Gets a table build action.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.ITableExtension.IsDataAvailableFunc">
+            <summary>
+                Gets a has data function for checking if a table has data. This property may be null.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor`3">
+            <summary>
+                This interface exposes a method to process data from a source.
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor`3.ProcessDataElement(`0,`1,System.Threading.CancellationToken)">
+            <summary>
+                Processes data from the source.
+            </summary>
+            <param name="data">
+                The data from the source to be processed.
+            </param>
+            <param name="context">
+                Additional information to assist processing.
+            </param>
+            <param name="cancellationToken">
+                Signal used to signify that the caller wants to cancel the operation.
+            </param>
+            <returns>
+                The result from processing the data.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3">
+            <summary>
+                A source parser is responsible for parsing a source, interacting with an
+                <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor`3"/> to distribute data elements from the source,
+                and exposing source related data.
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3.DataSourceInfo">
+            <summary>
+                Gets information about a data source, including the
+                time range encompassed by the data source.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor">
+            <summary>
+                Implement this interface to describe a source parser for use in processing.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.Id">
+            <summary>
+                Gets the ID of the source processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.DataElementType">
+            <summary>
+                Gets the Type that will be passed into a data extension for the source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.DataContextType">
+            <summary>
+                Gets the type that provides context for processing data of type <see cref="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.DataElementType"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.DataKeyType">
+            <summary>
+                Gets the type that is used as a key for indexing <see cref="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.DataElementType"/> elements.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.MaxSourceParseCount">
+            <summary>
+                Gets the maximum number of times that this parse may run.
+                When a source must be parsed multiple times based on data cooker dependencies,
+                this establishes the maximum number of times the source may be parsed.
+                Set to <see cref="F:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParsingConstants.UnlimitedPassCount"/> for an unrestricted
+                number of passes.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessingSession`3">
+            <summary>
+                Adds a method used to process a data source.
+                    <remarks>
+                    This is expected to be called by
+                    <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/> during <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/>.
+                    </remarks>
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessingSession`3.ProcessSource(Microsoft.Performance.SDK.Processing.ILogger,System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+                Called to process the source.
+            </summary>
+            <param name="logger">
+                Log messages.
+            </param>
+            <param name="progress">
+                Progress updates.
+            </param>
+            <param name="cancellationToken">
+                Cancellation token.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessor`3">
+            <summary>
+                Implemented by a source to control processing.
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessor`3.PrepareForProcessing(System.Boolean,System.Collections.Generic.IReadOnlyCollection{`2})">
+            <summary>
+                This is called by the runtime before a call to <see cref="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessor`3.ProcessSource(Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor{`0,`1,`2},Microsoft.Performance.SDK.Processing.ILogger,System.IProgress{System.Int32},System.Threading.CancellationToken)"/>, giving the source
+                parser some extra data. Some parsers may be able to optimize source processing knowing which
+                data elements (identified by <paramref name="requestedDataKeys"/>) will be needed by source cookers.
+            </summary>
+            <param name="allEventsConsumed">
+                When this is true, all events will be processed while parsing the data source. When false, 
+                only events identified by <paramref name="requestedDataKeys"/> will be processed.
+            </param>
+            <param name="requestedDataKeys">
+                The set of data keys specifically required by source data cookers that will take part in
+                the upcoming call to <see cref="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessor`3.ProcessSource(Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor{`0,`1,`2},Microsoft.Performance.SDK.Processing.ILogger,System.IProgress{System.Int32},System.Threading.CancellationToken)"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessor`3.ProcessSource(Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor{`0,`1,`2},Microsoft.Performance.SDK.Processing.ILogger,System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+                The source parser should begin processing the source data set when this is called.
+            </summary>
+            <param name="dataProcessor">
+                Each data element will be passed to this by calling <c>dataProcessor.ProcessDataElement</c>.
+                </param>
+            <param name="logger">
+                Provides a way for the source parser to log status messages.
+            </param>
+            <param name="progress">
+                Used to indicate progress parsing the source.
+            </param>
+            <param name="cancellationToken">
+                Used to request the operation be canceled.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceSessionFactory">
+            <summary>
+                Implementors are responsible for creating <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceProcessingSession`3"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceSessionFactory.CreateSourceSession``3(Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser{``0,``1,``2})">
+            <summary>
+                Creates a source session associated with the given custom data processor.
+            </summary>
+            /// <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+            <param name="customDataProcessor">
+                Custom data processor.
+            </param>
+            <returns>
+                A source session associated with the custom data processor.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3">
+            <summary>
+                This implements some basic elements of <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser`3"/>.
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to key data from the source for distribution.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.DataElementType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.DataContextType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.DataKeyType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.MaxSourceParseCount">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.Id">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.PrepareForProcessing(System.Boolean,System.Collections.Generic.IReadOnlyCollection{`2})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.ProcessSource(Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor{`0,`1,`2},Microsoft.Performance.SDK.Processing.ILogger,System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParser`3.DataSourceInfo">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParsingConstants">
+            <summary>
+                Contains constants relevant to parsing data sources.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Extensibility.SourceParsing.SourceParsingConstants.UnlimitedPassCount">
+            <summary>
+                This may be set on <see cref="P:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParserDescriptor.MaxSourceParseCount"/> to allow
+                as many passes through the source as necessary.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Extensibility.TypeExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods
+                for interacting with <see cref="T:System.Type"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.TypeExtensions.IsPublicAndInstantiatableOfType(System.Type,System.Type)">
+            <summary>
+                Determines if the candidate type is public, instantiable and of the expected type.
+            </summary>
+            <param name="candidateType">
+                Candidate type.
+            </param>
+            <param name="expectedType">
+                Expected type.
+            </param>
+            <returns>
+                True if criteria is met.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="candidateType"/> is <c>null</c>.
+                - or -
+                <paramref name="expectedType"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Extensibility.TypeExtensions.IsInstantiatableOfType(System.Type,System.Type)">
+            <summary>
+                Determines if the candidate type is instantiable and of the expected type.
+            </summary>
+            <param name="candidateType">
+                Candidate type.
+            </param>
+            <param name="expectedType">
+                Expected type.
+            </param>
+            <returns>
+                True if criteria is met.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="candidateType"/> is <c>null</c>.
+                - or -
+                <paramref name="expectedType"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ExtensionException">
+            <summary>
+                Represents any error that can be thrown by a user
+                extension (ProcessingSource, CustomDataProcessor, etc) to
+                uniformly report fatal error conditions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor(System.String,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor(Microsoft.Performance.SDK.ErrorInfo)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor(Microsoft.Performance.SDK.ErrorInfo,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.#ctor(Microsoft.Performance.SDK.ErrorInfo,System.String,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ExtensionException"/>
+                class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ExtensionException.Error">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.ErrorInfo"/> associated with this exception.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ExtensionException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Guard">
+            <summary>
+                This class provides for easy declaration of guard clauses in methods.
+                <para/>
+                Many of the these methods take a `message` and additional parameters. When
+                calling an overload that takes `message` and additional values, a token expansion
+                will occur. This lets the user place standard information into the message without
+                having to copy the values being passed to the method into the message. This reduces
+                duplication of effort and ensures that the message stays consistent with the other
+                values being utilized for the exception. Each method will document the tokens that
+                it supports.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.NotNull(System.Object,System.String)">
+            <summary>
+                Throws an exception if the given value is <c>null</c>.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="paramName">
+                The name of the parameter to emit in the <see cref="T:System.ArgumentNullException"/>
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="value"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.NotNullOrWhiteSpace(System.String,System.String)">
+            <summary>
+                Throws an exception if the given value is <c>null</c> or
+                composed of exclusively whitespace characters.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="paramName">
+                The name of the parameter to emit in the <see cref="T:System.ArgumentException"/>
+                or <see cref="T:System.ArgumentNullException"/>
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="value"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="value"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.NotDefault``1(``0,System.String)">
+            <summary>
+                Throws an exception is <paramref name="value"/> is equivalent
+                to the default value of <typeparamref name="T"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of object being checked.
+            </typeparam>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="value"/> is equivalent to the default value of
+                <see cref="T:System.Type"/> <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.IsTrue(System.Boolean)">
+            <summary>
+                Throws an exception if the given condition is false.
+            </summary>
+            <param name="condition">
+                The condition to check.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="condition"/> is <c>false</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.IsTrue(System.Boolean,System.String)">
+            <summary>
+                Throws an exception if the given condition is false.
+            </summary>
+            <param name="condition">
+                The condition to check.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="condition"/> is <c>false</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.IsFalse(System.Boolean)">
+            <summary>
+                Throws an exception if the given condition is true.
+            </summary>
+            <param name="condition">
+                The condition to check.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="condition"/> is <c>true</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.IsFalse(System.Boolean,System.String)">
+            <summary>
+                Throws an exception if the given condition is true.
+            </summary>
+            <param name="condition">
+                The condition to check.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="condition"/> is <c>true</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.GreaterThan``1(``0,``0,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not greater
+                than the <paramref name="compareValue"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not greater than <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.GreaterThan``1(``0,``0,System.String,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not greater
+                than the <paramref name="compareValue"/>.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+                {compareValue} - <paramref name="compareValue"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not greater than <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.GreaterThanOrEqualTo``1(``0,``0,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not greater
+                than or equal to the <paramref name="compareValue"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not greater than or equal to
+                <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.GreaterThanOrEqualTo``1(``0,``0,System.String,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not greater
+                than or equal to the <paramref name="compareValue"/>.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+                {compareValue} - <paramref name="compareValue"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not greater than or equal to
+                <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.LessThan``1(``0,``0,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not less
+                than the <paramref name="compareValue"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not less than <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.LessThan``1(``0,``0,System.String,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not less
+                than the <paramref name="compareValue"/>.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+                {compareValue} - <paramref name="compareValue"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not less than <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.LessThanOrEqualTo``1(``0,``0,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not less
+                than or equal to the <paramref name="compareValue"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not less than or equal to <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.LessThanOrEqualTo``1(``0,``0,System.String,System.String)">
+            <summary>
+                Throws an exception if <paramref name="candidate"/> is not less
+                than or equal to the <paramref name="compareValue"/>.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+                {compareValue} - <paramref name="compareValue"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values being compared.
+            </typeparam>
+            <param name="candidate">
+                The value to compare.
+            </param>
+            <param name="compareValue">
+                The value against which <paramref name="candidate"/> is to be compared.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the <see cref="T:System.ArgumentException"/>.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="candidate"/> is not less than or equal to
+                <paramref name="compareValue"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.None``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String)">
+            <summary>
+                Makes sure that none of the items in a collection satisfy the given 
+                predicate.
+                <para/>
+                The empty collection vacuously satisfies this condition.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must not be satisfied by any element in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more elements in <paramref name="source"/> satisfies
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.None``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String,System.String)">
+            <summary>
+                Makes sure that none of the items in a collection satisfy the given 
+                predicate.
+                <para/>
+                The empty collection vacuously satisfies this condition.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must not be satisfied by any element in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more elements in <paramref name="source"/> satisfies
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.Any``1(System.Collections.Generic.IEnumerable{``0},System.String)">
+            <summary>
+                Makes sure that the collection has at least one element.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="source"/> has no elements.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.Any``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String)">
+            <summary>
+                Makes sure that at least one of the elements in a collection satisfies the given 
+                predicate.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must be satisfied by at least one element in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                None of the elements in <paramref name="source"/> satisfy
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.Any``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String,System.String)">
+            <summary>
+                Makes sure that at least one of the elements in a collection satisfies the given 
+                predicate.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must be satisfied by at least one element in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                None of the elements in <paramref name="source"/> satisfy
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.All``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String)">
+            <summary>
+                Makes sure that all of the items in a collection satisfy the given 
+                predicate.
+                <para/>
+                The empty collection vacuously satisfies this condition.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must be satisfied by all elements in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more elements in <paramref name="source"/> fails to satisfy
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Guard.All``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean},System.String,System.String)">
+            <summary>
+                Makes sure that all of the items in a collection satisfy the given 
+                predicate.
+                <para/>
+                The empty collection vacuously satisfies this condition.
+                <para/>
+                Tokens supported:
+                {paramName} - <paramref name="paramName"/> value
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of items in <paramref name="source"/>.
+            </typeparam>
+            <param name="source">
+                The collection to validate.
+            </param>
+            <param name="predicate">
+                The predicate which must be satisfied by all elements in the
+                collection.
+            </param>
+            <param name="paramName">
+                The parameter name to emit in the exception.
+            </param>
+            <param name="message">
+                A message to emit in the exception.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more elements in <paramref name="source"/> fails to satisfy
+                <paramref name="predicate"/>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.HashCodeUtils">
+            <summary>
+                Provides fast methods for computing hash codes.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <param name="hc10">
+                The tenth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <param name="hc10">
+                The tenth integer.
+            </param>
+            <param name="hc11">
+                The eleventh integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <param name="hc10">
+                The tenth integer.
+            </param>
+            <param name="hc11">
+                The eleventh integer.
+            </param>
+            <param name="hc12">
+                The twelfth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <param name="hc10">
+                The tenth integer.
+            </param>
+            <param name="hc11">
+                The eleventh integer.
+            </param>
+            <param name="hc12">
+                The twelfth integer.
+            </param>
+            <param name="hc13">
+                The thirteenth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.HashCodeUtils.CombineHashCodeValues(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Combines the given integers into another integer.
+                <para/>
+                This uses the method that the BCL uses in its classes
+                internally.
+            </summary>
+            <param name="hc1">
+                The first integer.
+            </param>
+            <param name="hc2">
+                The second integer.
+            </param>
+            <param name="hc3">
+                The third integer.
+            </param>
+            <param name="hc4">
+                The fourth integer.
+            </param>
+            <param name="hc5">
+                The fifth integer.
+            </param>
+            <param name="hc6">
+                The sixth integer.
+            </param>
+            <param name="hc7">
+                The seventh integer.
+            </param>
+            <param name="hc8">
+                The eight integer.
+            </param>
+            <param name="hc9">
+                The ninth integer.
+            </param>
+            <param name="hc10">
+                The tenth integer.
+            </param>
+            <param name="hc11">
+                The eleventh integer.
+            </param>
+            <param name="hc12">
+                The twelfth integer.
+            </param>
+            <param name="hc13">
+                The thirteenth integer.
+            </param>
+            <param name="hc14">
+                The fourteenth integer.
+            </param>
+            <returns>
+                A new integer representing a combination of the
+                given integers.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IAssemblyLoader">
+            <summary>
+                Loads assemblies.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.IAssemblyLoader.SupportsIsolation">
+            <summary>
+                Gets a value indicating whether this loader supports
+                loading assemblies into an isolated context.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IAssemblyLoader.IsAssembly(System.String)">
+            <summary>
+                Determines whether the given path is a valid
+                assembly.
+            </summary>
+            <param name="path">
+                The path to check.
+            </param>
+            <returns>
+                <c>true</c> if the path is to an assembly;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IAssemblyLoader.LoadAssembly(System.String,Microsoft.Performance.SDK.ErrorInfo@)">
+            <summary>
+                Loads the given assembly from the given path.
+            </summary>
+            <param name="assemblyPath">
+                The path of the assembly to load.
+            </param>
+            <param name="error">
+                Contains the error(s) that occurred, if any, while
+                loading the assembly. If the assembly loads,
+                then this parameter is set to <see cref="F:Microsoft.Performance.SDK.ErrorInfo.None"/>.
+            </param>
+            <returns>
+                The loaded assembly, if possible; null otherwise.
+                If this method returns <c>null</c>, then the
+                <paramref name="error"/> parameter will contain
+                details as to the failure.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ICloneable`1">
+            <summary>
+               Supports cloning, which creates a new instance of a class with the same value
+               as an existing instance.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of object being cloned.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ICloneable`1.CloneT">
+            <summary>
+                Creates a new object that is a copy of the current instance.
+            </summary>
+            <returns>
+                A new object that is a copy of this instance.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ICustomTypeConverter">
+            <summary>
+                Provides a means of specifying a conversion to
+                a new <see cref="T:System.Type"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ICustomTypeConverter.GetOutputType">
+            <summary>
+                Gets the <see cref="T:System.Type"/> into which
+                this instance converts other instances of
+                <see cref="T:System.Object"/>s.
+            </summary>
+            <returns>
+                The conversion <see cref="T:System.Type"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IDataColumn">
+            <summary>
+                The core interface for defining a column. A column is a
+                projection of data with metadata.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataColumn.Configuration">
+            <summary>
+                Gets the configuration of this column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataColumn.DataType">
+            <summary>
+                Gets the <see cref="T:System.Type"/> of data projected by this column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataColumn.ProjectorInterface">
+            <summary>
+                Gets the <see cref="T:System.Type"/> of the concrete projector that
+                projects the data for this column.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IDataColumn.Project(System.Int32)">
+            <summary>
+                Projects the data in this column for the given row.
+            </summary>
+            <param name="index">
+                The row whose value is to be retrieved.
+            </param>
+            <returns>
+                The projected value at the given row.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IDataColumn`1">
+            <summary>
+                A typed column.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data projected by the
+                column.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataColumn`1.Projector">
+            <summary>
+                Gets the projector that projects the data for this column.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IDataColumn`1.ProjectTyped(System.Int32)">
+            <summary>
+                Projects the data in this column for the given row.
+            </summary>
+            <param name="index">
+                The row whose value is to be retrieved.
+            </param>
+            <returns>
+                The projected value at the given row.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1">
+            <summary>
+                Represents a data column that can display values in a
+                hierarchical format. For example, stacks are hierarchical.
+                <para/>
+                Expanding on the example, a stack is a collection of values
+                that should logically be treated as one value. As one expands
+                the stack, each call becomes its own row. This column type allows
+                for you to provide the means of displaying those expansions in
+                a meaningful way.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data exposed by this column.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1.CollectionInfoProvider">
+            <summary>
+                Provides the mechanism by which hierarchical data is 
+                displayed. In the case of stacks, for example, it would
+                define how each value should have an additional indentation
+                level the deeper in the stack one goes.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.AddNewTableOption">
+            <summary>
+                Used with <see cref="M:Microsoft.Performance.SDK.Processing.IDynamicTableBuilder.AddDynamicTable(Microsoft.Performance.SDK.Processing.AddNewTableOption)"/> to specify where
+                the new table should be added.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AddNewTableOption.CurrentView">
+            <summary>
+                The table should be added to the existing analysis view.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AddNewTableOption.NewView">
+            <summary>
+                The table should be added to a new analysis view.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.AggregationMode">
+            <summary>
+                Defines the method of aggregation for values in a column.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.None">
+            <summary>
+                No aggregation is to be performed.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Average">
+            <summary>
+                Average of the values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Sum">
+            <summary>
+                Sum the values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Count">
+            <summary>
+                The count of all values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Min">
+            <summary>
+                Take the minimum value.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Max">
+            <summary>
+                Take the maximum value.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.UniqueCount">
+            <summary>
+                The count of unique values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.Peak">
+            <summary>
+                The peak values.
+                todo: __CDS__
+                What is this really?
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationMode.WeightedAverage">
+            <summary>
+                The weighted average of the values.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.AggregationOverTime">
+            <summary>
+                Defines the different aggregations that can be performed over time.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationOverTime.Current">
+            <summary>
+                Aggregates the current values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationOverTime.Rate">
+            <summary>
+                Aggregates the rate of the values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationOverTime.Cumulative">
+            <summary>
+                Performs a cumulative aggregation.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationOverTime.Outstanding">
+            <summary>
+                Performs an outstanding aggregation.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.AggregationOverTime.OutstandingPeak">
+            <summary>
+                Performs an aggregation of the peak.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.Show(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.String,System.Object[])">
+            <summary>
+                Displays an informational message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.Show(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+                Displays an informational message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="formatProvider">
+                An object that supplies culture-specific formatting information.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.ShowWarning(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.String,System.Object[])">
+            <summary>
+                Displays a warning message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.ShowWarning(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+                Displays a warning message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="formatProvider">
+                An object that supplies culture-specific formatting information.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.ShowError(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.String,System.Object[])">
+            <summary>
+                Displays an error message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.ShowError(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+                Displays an error message box with the formatted text and objects.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="formatProvider">
+                An object that supplies culture-specific formatting information.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.TryGetAuthProvider``2(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,Microsoft.Performance.SDK.Auth.IAuthProvider{``0,``1}@)">
+            <summary>
+                Attempts to get an <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> that can provide authentication
+                for <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> of type <typeparamref name="TAuth"/>.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="provider">
+                The found provider, or <c>null</c> if no registered provider can provide authentication for
+                <typeparamref name="TAuth"/>.
+            </param>
+            <typeparam name="TAuth">
+                The type of the <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> for which to attempt to get a provider.
+            </typeparam>
+            <typeparam name="TResult">
+                The type of the result of a successful authentication for <typeparamref name="TAuth"/>.
+            </typeparam>
+            <returns>
+                <c>true</c> if a provider was found; <c>false</c> otherwise. If <c>false</c> is returned,
+                <paramref name="provider"/> will be <c>null</c>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ApplicationEnvironmentExtensions.TryGetPluginOption``1(Microsoft.Performance.SDK.Processing.IApplicationEnvironment,System.Guid,``0@)">
+            <summary>
+                Attempts to get the plugin option of type <typeparamref name="T"/> with the given GUID.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> instance.
+            </param>
+            <param name="optionGuid">
+                The <see cref="T:System.Guid"/> of the option to get.
+            </param>
+            <param name="option">
+                The found option if this method returns <c>true</c>; <c>null</c> otherwise.
+            </param>
+            <typeparam name="T">
+                The concrete type of the <see cref="!:PluginOption"/> to get. Must be a subclass of <see cref="!:PluginOption"/>.
+            </typeparam>
+            <returns>
+                <c>true</c> if the option was found; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ButtonResult">
+            <summary>
+                Represents the button pressed by a user
+                on a message box.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ButtonResult.None">
+            <summary>
+                No result is specified.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ButtonResult.OK">
+            <summary>
+                User chose OK.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ButtonResult.Cancel">
+            <summary>
+                User chose Cancel.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ButtonResult.Yes">
+            <summary>
+                User chose Yes.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ButtonResult.No">
+            <summary>
+                User chose No.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Buttons">
+            <summary>
+                Represents buttons on a message box.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.Buttons.OK">
+            <summary>
+                The box will have the OK button.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.Buttons.OKCancel">
+            <summary>
+                The box will have OK and Cancel buttons.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.Buttons.YesNoCancel">
+            <summary>
+                The box will have Yes, No, and Cancel buttons.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.Buttons.YesNo">
+            <summary>
+                The box will have Yes and No buttons.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ChartType">
+            <summary>
+                Defines the different charts that can be used when graphing
+                table data.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.Line">
+            <summary>
+                Graph using a line.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.StackedLine">
+            <summary>
+                Graph using stacked lines.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.StackedBars">
+            <summary>
+                Graph using bars.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.StateDiagram">
+            <summary>
+                Graph using a state diagram.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.PointInTime">
+            <summary>
+                Graph using points.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ChartType.Flame">
+            <summary>
+                Graph using flames.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder">
+            <summary>
+                Base class for classes that can build/extend upon columns that are
+                part of a table.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor">
+            <summary>
+                Describes a column variant, where a column variant is defined as an alternative
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> of an <see cref="T:Microsoft.Performance.SDK.Processing.IDataColumn"/> that has
+                been added to a table.
+            </summary>
+            <param name="Guid">
+                The unique identifier for the column variant. This value must be unique within a single column's
+                set of variants, but may be reused across columns.
+            </param>
+            <param name="Properties">
+                The metadata properties to associate with the data column this variant represents.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor.#ctor(System.Guid,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties)">
+            <summary>
+                Describes a column variant, where a column variant is defined as an alternative
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> of an <see cref="T:Microsoft.Performance.SDK.Processing.IDataColumn"/> that has
+                been added to a table.
+            </summary>
+            <param name="Guid">
+                The unique identifier for the column variant. This value must be unique within a single column's
+                set of variants, but may be reused across columns.
+            </param>
+            <param name="Properties">
+                The metadata properties to associate with the data column this variant represents.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor.Guid">
+            <summary>
+                The unique identifier for the column variant. This value must be unique within a single column's
+                set of variants, but may be reused across columns.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor.Properties">
+            <summary>
+                The metadata properties to associate with the data column this variant represents.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties">
+            <summary>
+                Describes the metadata properties of a data column represented by a column variant.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties.Label">
+            <summary>
+                Gets or initializes the human-readable label of the column variant.
+            </summary>
+            <exception cref="T:System.ArgumentException">
+                The supplied value is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                The supplied value is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties.Description">
+            <summary>
+                Gets or initializes an optional human-readable description of the column variant.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties.ColumnName">
+            <summary>
+                Gets or initializes an optional value to use as the variant's <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Name"/>
+                when this variant is active. If this value is not set, the base column's name will be used.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder">
+            <summary>
+                A builder for configuring modes on a column that has been
+                configured as having mutually exclusive modes.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder.WithMode``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Adds a mode to the column.
+            </summary>
+            <param name="modeDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the mode.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column for this mode.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> that has been
+                configured with the new mode.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="modeDescriptor"/> or <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder.WithHierarchicalMode``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{``0})">
+            <summary>
+                Adds a hierarchical mode to the column.
+            </summary>
+            <param name="modeDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the mode.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column for this mode.
+            </param>
+            <param name="collectionProvider">
+                The collection provider for the column.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> that has been
+                configured with the new mode.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="modeDescriptor"/>, <paramref name="projection"/>, or
+                <paramref name="collectionProvider"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder.WithMode``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a mode to the column.
+            </summary>
+            <param name="modeDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the mode.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column for this mode.
+            </param>
+            <param name="builder">
+                A callback that builds sub-variants of the added mode and returns its final column configuration.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> that has been
+                configured with the new mode.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="modeDescriptor"/> or <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder.WithHierarchicalMode``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{``0},System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a hierarchical mode to the column.
+            </summary>
+            <param name="modeDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the mode.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column for this mode.
+            </param>
+            <param name="collectionProvider">
+                The collection provider for the column.
+            </param>
+            <param name="builder">
+                A callback that builds sub-variants of the added mode and returns its final column configuration.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> that has been
+                configured with the new mode.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="modeDescriptor"/>, <paramref name="projection"/>,
+                or <paramref name="collectionProvider"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder.WithDefaultMode(System.Guid)">
+            <summary>
+                Sets the default mode for the column.
+            </summary>
+            <param name="modeIdentifierGuid">
+                The <see cref="T:System.Guid"/> of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> that
+                identifies the mode to set as the default.
+            </param>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder"/> that has been
+                configured with the default mode.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                The mode with the given <paramref name="modeIdentifierGuid"/> has not been
+                added as an available mode.
+            </exception>
+            <remarks>
+                If this method is not called, the first mode added will be the default mode.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder">
+            <summary>
+                A builder for configuring the root column that has been added to a table.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder.WithModes(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties)">
+            <summary>
+                Specifies that the added column should be a modal column that
+                has several top-level modes. The base projection/column specified
+                by the column being constructed is one of, and the first, available top-level modes.
+            </summary>
+            <param name="baseProjectionProperties">
+                The metadata properties that the base projection's mode will have.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> to continue building
+                column modes.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="baseProjectionProperties"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder.WithModes(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantProperties,System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Specifies that the added column should be a modal column that
+                has several top-level modes. The base projection/column specified
+                by the column being constructed is one of, and the first, available top-level modes.
+            </summary>
+            <param name="baseProjectionProperties">
+                The metadata properties that the base projection's mode will have.
+            </param>
+            <param name="builder">
+                A callback that builds sub-variants of the added mode represented by the base
+                column and returns the final column configuration.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder"/> to continue building
+                column modes.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="baseProjectionProperties"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder">
+            <summary>
+                A builder for columns that can have nested toggled variants.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder.WithToggle``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Adds a new toggleable variant to the column. The added toggleable variant
+                is nested at the "end" of the chain of toggleable variants already
+                added via calls to this method.
+            </summary>
+            <param name="toggleDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the toggle. The
+                <see cref="!:ColumnVariantDescriptor.Name"/> represents the name of the toggled
+                on variant.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column when this toggle is on.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder"/> that has been
+                configured with the added toggle.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="toggleDescriptor"/> or <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder.WithHierarchicalToggle``1(Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{``0})">
+            <summary>
+                Adds a new toggleable variant to the column. The added toggleable variant
+                is nested at the "end" of the chain of toggleable variants already
+                added via calls to this method.
+            </summary>
+            <param name="toggleDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor"/> for the toggle. The
+                <see cref="!:ColumnVariantDescriptor.Name"/> represents the name of the toggled
+                on variant.
+            </param>
+            <param name="projection">
+                The projection that will be used to generate the column when this toggle is on.
+            </param>
+            <param name="collectionProvider">
+                The collection provider for the column.
+            </param>
+            <typeparam name="T">
+                The type of data that the projection will produce.
+            </typeparam>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder"/> that has been
+                configured with the added toggle.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="toggleDescriptor"/>, <paramref name="projection"/>,
+                or <paramref name="collectionProvider"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnBuilding.ToggleableColumnBuilder.WithToggledModes(System.String,System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.ModalColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a set of modes to the column that are nested inside of a toggle with no
+                associated projection.
+            </summary>
+            <param name="toggleText">
+                The text to display for the toggle that represents the modes.
+            </param>
+            <param name="builder">
+                A callback that builds the modes and returns the final column configuration.
+            </param>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder"/> that has been
+                configured with the added toggled modes.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="toggleText"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration">
+            <summary>
+                Defines the information for how to configure a column in a table.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfiguration.#ctor(Microsoft.Performance.SDK.Processing.ColumnMetadata)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                class.
+            </summary>
+            <param name="metadata">
+                The metadata about the column.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="metadata"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfiguration.#ctor(Microsoft.Performance.SDK.Processing.ColumnMetadata,Microsoft.Performance.SDK.Processing.UIHints)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                class.
+            </summary>
+            <param name="metadata">
+                The metadata about the column.
+            </param>
+            <param name="hints">
+                Optional hints about displaying this column in the UI. This parameter
+                may be <c>null</c>. If this parameter is <c>null</c>, then
+                <see cref="M:Microsoft.Performance.SDK.Processing.UIHints.Default"/> will be used for this instance.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="metadata"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfiguration.#ctor(Microsoft.Performance.SDK.Processing.ColumnMetadata,Microsoft.Performance.SDK.Processing.UIHints,System.Nullable{System.Guid})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                class.
+            </summary>
+            <param name="metadata">
+                The metadata about the column.
+            </param>
+            <param name="hints">
+                Optional hints about displaying this column in the UI. This parameter
+                may be <c>null</c>. If this parameter is <c>null</c>, then
+                <see cref="M:Microsoft.Performance.SDK.Processing.UIHints.Default"/> will be used for this instance.
+            </param>
+            <param name="variantGuid">
+                Optional unique identifier of the column variant to use.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="metadata"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfiguration.#ctor(Microsoft.Performance.SDK.Processing.ColumnConfiguration)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                class from an existing instance.
+            </summary>
+            <param name="other">
+                The instance from which to make a copy.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="other"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnConfiguration.Metadata">
+            <summary>
+                Gets or initializes the metadata for this instance.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">
+                The supplied value is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnConfiguration.VariantGuid">
+            <summary>
+                Gets or initializes the unique identifier of the column variant to use.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnConfiguration.DisplayHints">
+            <summary>
+                Gets or initializes any hints from the addin on how to render the column.
+            </summary>
+            <remarks>
+                todo: __CDS__ sensible defaults in the application layer.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfiguration.ToString">
+            <summary>
+                Gets the <see cref="T:System.String"/> representation of this instance.
+            </summary>
+            <returns>
+                The <see cref="T:System.String"/> representation of this instance.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnConfigurationEqualityComparer">
+            <summary>
+                Compares instances of <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                for equality.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnConfigurationEqualityComparer.Default">
+            <summary>
+                Gets the default <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> for
+                <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/> instances.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnConfigurationExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting with
+                <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfigurationExtensions.SetFormatProvider(Microsoft.Performance.SDK.Processing.ColumnConfiguration,System.IFormatProvider)">
+            <summary>
+                Sets the format provider for the given configuration.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/> to be modified.
+            </param>
+            <param name="formatProvider">
+                The new <see cref="T:System.IFormatProvider"/> for the configuration.
+                This parameter may be <c>null</c>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfigurationExtensions.WithDynamicName(Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.String})">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/> that
+                is a clone of the given ColumnConfiguration, except
+                for the name projection, which is replaced by the given
+                name projection.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/> to be modified.
+            </param>
+            <param name="nameProjection">
+                The new name projection.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="nameProjection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnConfigurationExtensions.IsMetadataColumn(Microsoft.Performance.SDK.Processing.ColumnConfiguration)">
+            <summary>
+                Determines if the given <see cref="T:Microsoft.Performance.SDK.Processing.ColumnConfiguration"/>
+                is considered to be a metadata column. The metadata columns
+                are found in the <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> class,
+                for example <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.PivotColumn"/>.
+            </summary>
+            <param name="self">
+                The column to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is one of the <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/>
+                metadata columns; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnFormats">
+            <summary>
+                Provides constants for formatting column values as
+                <see cref="T:System.String"/>s. These are the format strings
+                as used in the .NET formatting infrastructure. See
+                <see cref="P:Microsoft.Performance.SDK.Processing.UIHints.CellFormat"/> and
+                <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.FormatProvider"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnFormats.PercentFormat">
+            <summary>
+                Render the value as a percent to two decimal places.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnFormats.HexFormat">
+            <summary>
+                Render the value as a hexadecimal value.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnFormats.NumberFormat">
+            <summary>
+                Render the value as a whole number with no decimal places.
+                todo: __CDS__
+                Document the rounding (if any)
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnFormats.NumberClipboardFormat">
+            <summary>
+                Render the value as a whole number with no decimal places,
+                as appropriate for copying to the clipboard.
+                todo: __CDS__
+                Document the rounding (if any)
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnMetadata">
+            <summary>
+                Represents the metadata about a table column.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.#ctor(System.Guid,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnMetadata"/>
+                class.
+            </summary>
+            <param name="guid">
+                The unique identifier for this column. This MAY NOT be
+                the default (empty) <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Guid"/>.
+            </param>
+            <param name="name">
+                The name of this column.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="guid"/> is equal to <c>default(Guid)</c>.
+                - or -
+                <paramref name="name"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="name"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.#ctor(System.Guid,System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnMetadata"/>
+                class.
+            </summary>
+            <param name="guid">
+                The unique identifier for this column. This MAY NOT be
+                the default (empty) <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Guid"/>.
+            </param>
+            <param name="name">
+                The name of this column.
+            </param>
+            <param name="description">
+                A user friendly description of this column.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="guid"/> is equal to <c>default(Guid)</c>.
+                - or -
+                <paramref name="name"/> is whitespace.
+                - or -
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="name"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.#ctor(System.Guid,System.String,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.String},System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnMetadata"/>
+                class.
+            </summary>
+            <param name="guid">
+                The unique identifier for this column. This MAY NOT be
+                the default (empty) <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Guid"/>.
+            </param>
+            <param name="defaultName">
+                The name to use on the column when there are multiple candidates
+                in the projection.
+            </param>
+            <param name="nameProjection">
+                The projection that allows the name of the column to change
+                based on the data in a row.
+            </param>
+            <param name="description">
+                A user friendly description of this column.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="guid"/> is equal to <c>default(Guid)</c>.
+                - or -
+                <paramref name="defaultName"/> is whitespace.
+                - or -
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="defaultName"/> is <c>null</c>.
+                - or -
+                <paramref name="nameProjection"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.#ctor(Microsoft.Performance.SDK.Processing.ColumnMetadata)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnMetadata"/>
+                class from another instance.
+            </summary>
+            <param name="other">
+                The instance from which to make a copy.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="other"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Guid">
+            <summary>
+                Gets the unique identifier for this column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Name">
+            <summary>
+                Gets or initializes the name of this column. If this column has a dynamic
+                name, then this property always returns the name as based
+                on the data in the first row. Use <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.NameProjection"/>
+                for dynamic names.
+            </summary>
+            <exception cref="T:System.ArgumentException">
+                The supplied value is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                The supplied value is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.IsNameConstant">
+            <summary>
+                Gets a value indicating whether the name of this column is
+                constant. If this property returns <c>false</c>, then the
+                <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.NameProjection"/> can be used to get the dynamic
+                name.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.NameProjection">
+            <summary>
+                Gets the name projector. This projector is only
+                useful if <see cref="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.IsNameConstant"/> is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.ShortDescription">
+            <summary>
+            Gets the user friendly short description of this column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.Description">
+            <summary>
+                Gets the user friendly description of this column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.IsPercent">
+            <summary>
+                Gets or sets a value indicating whether this column
+                represents a percent value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.IsDynamic">
+            <summary>
+                Gets or sets a value indicating whether the column has
+                dynamic content. This will instruct callers to always use the
+                column if it is available.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ColumnMetadata.FormatProvider">
+            <summary>
+                Gets or sets the format provider to use to format the
+                data in the cell. This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.Clone">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ColumnMetadata.CloneT">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ColumnRole">
+            <summary>
+                Defines a common set of column roles that that are guaranteed to be successfully saved/restored in a serialized <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration" />.
+                <br/>Plugins may use any string value defined in this class to communicate column roles to any SDK driver. 
+                <br/><br/>If a <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration" /> includes a column role value that is not defined here, it is not guaranteed to:
+                <br/>- Be de/serialized correctly
+                <br/>- Be understood by an SDK driver
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnRole.StartTime">
+            <summary>
+                Indicates the start timestamp.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnRole.EndTime">
+            <summary>
+                Indicates the end timestamp.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnRole.Duration">
+            <summary>
+                Indicates duration in time.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ColumnRole.ResourceId">
+            <summary>
+                How to partition the data across physical resources.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.CustomDataProcessor">
+            <summary>
+                Provides a base class for implementing custom data processors that
+                simplifies some of the management of tables and processing.
+                This class is meant to be used in conjunction with <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.#ctor(Microsoft.Performance.SDK.Processing.ProcessorOptions,Microsoft.Performance.SDK.Processing.IApplicationEnvironment,Microsoft.Performance.SDK.Processing.IProcessorEnvironment)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.CustomDataProcessor"/> class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.DataDerivedTables">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.ApplicationEnvironment">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> for this processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.ProcessorEnvironment">
+            <summary>
+                Gets the session services available for this processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.EnabledTables">
+            <summary>
+                Gets a collection of tables that have been enabled for this processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.Options">
+            <summary>
+                Gets the command line options that have been passed to this processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessor.Logger">
+            <summary>
+                Used to log data specific to this data processor.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.EnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.TryEnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.CreateTableService(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                When overridden in a derived class, creates an instance of the service defined by the
+                given table's <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.ServiceInterface"/>.
+            </summary>
+            <param name="table">
+                The table whose service is to be created.
+            </param>
+            <returns>
+                The created service, if the table specifies a service; <c>null</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.GetDataSourceInfo">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.DoesTableHaveData(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.GetEnabledTables">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.ProcessAsyncCore(System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+                Asynchronously processes the data source.
+            </summary>
+            <param name="progress">
+                Provides a method of updating the application as to this
+                processor's progress.
+            </param>
+            <param name="cancellationToken">
+                A means of the application signalling to the processor that
+                it should abort processing.
+            </param>
+            <returns>
+                A <see cref="T:System.Threading.Tasks.Task"/> representing the asynchronous operation.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.BuildTableCore(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)">
+            <summary>
+                When overridden in a derived class, builds the requested
+                table using the given <see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>.
+            </summary>
+            <param name="tableDescriptor">
+                The descriptor of the requested table.
+            </param>
+            <param name="tableBuilder">
+                The builder to use to build the table.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.OnBeforeEnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                This is called before a table has been enabled on this data processor.
+            </summary>
+            <param name="tableDescriptor">
+                Table that will be enabled.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.OnAfterEnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                This is called after a table has been enabled on this data processor. The default implementation does
+                nothing.
+            </summary>
+            <param name="tableDescriptor">
+                Table that was enabled.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.AddTableGeneratedFromDataProcessing(Microsoft.Performance.SDK.Processing.TableDescriptor,System.Action{Microsoft.Performance.SDK.Processing.ITableBuilder})">
+            <summary>
+                When a custom data processor needs to generate tables dynamically based on data content, call this
+                method to register the table with the runtime.
+            </summary>
+            <remarks>
+                If the build action is not <c>null</c>, it will be called directly to build the table. Otherwise, it
+                will be built through <see cref="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.BuildTableCore(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)"/>.
+            </remarks>
+            <param name="tableDescriptor">
+                Descriptor for the generated table.
+            </param>
+            <param name="buildAction">
+                Action called to create the requested table. This may be <c>null</c>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                A data derived table with the same table id has already been added.
+                - or -
+                A static table with the same id has already been enabled.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+               <see cref="M:Microsoft.Performance.SDK.Processing.CustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/> has already been called. 
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3">
+            <summary>
+            This is a helper class that handles some of the logic required for a custom data processor that
+            implements <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3"/>.
+            </summary>
+            <typeparam name="T">Type of data from the source to be processed</typeparam>
+            <typeparam name="TContext">Type that contains context about the data from the source</typeparam>
+            <typeparam name="TKey">Type that will be used to identify data from the source that is relevant to this extension</typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.#ctor(Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceParser{`0,`1,`2},Microsoft.Performance.SDK.Processing.ProcessorOptions,Microsoft.Performance.SDK.Processing.IApplicationEnvironment,Microsoft.Performance.SDK.Processing.IProcessorEnvironment)">
+            <summary>
+            This constructor will setup the data processor so that it can use the data extension framework - allowing
+            table and data cookers both internally and external to this plugin.
+            </summary>
+            <param name="sourceParser">The source data parser</param>
+            <param name="options">Processor options</param>
+            <param name="applicationEnvironment">Application environment</param>
+            <param name="processorEnvironment">Processor environment</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.#ctor(Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser{`0,`1,`2})">
+            <summary>
+            This constructor is intended for use within the unified scenario - where a data processor might need to
+            spawn additional data processors. Data from the unified data processor will be copied to the spawned
+            data processor as appropriate.
+            </summary>
+            <param name="other">An existing custom data processor</param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceParser">
+            <inheritdoc cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3"/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession">
+            <inheritdoc cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3"/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceParserId">
+            <inheritdoc cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.GetDataSourceInfo">
+            <summary>
+            Returns the DataSourceInfo from the source parser.
+            </summary>
+            <returns>Information regarding the processed source</returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.EnableCooker(Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <inheritdoc/>
+            <remarks>
+                Returns data from a source data cooker registered with <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/>.
+            </remarks>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="dataOutputPath"/> does not target the data processor.
+                - or -
+                <paramref name="dataOutputPath"/>'s data cooker is not available.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.QueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <inheritdoc/>
+            <remarks>
+                Returns data from a source data cooker registered with <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/>.
+            </remarks>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="dataOutputPath"/> does not target the data processor.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                The data cooker referenced by <paramref name="dataOutputPath"/> is not enabled on the data processor.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.TryQueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath,``0@)">
+            <inheritdoc />
+            <remarks>
+                Returns data from a source data cooker registered with <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/>.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.TryQueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath,System.Object@)">
+            <inheritdoc />
+            <remarks>
+                Returns data from a source data cooker registered with <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/>.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.ProcessAsyncCore(System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc cref="T:Microsoft.Performance.SDK.Processing.CustomDataProcessor"/>
+            <summary>
+            Adds to the base class functionality, validating that the <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceParser"/> and
+            <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/> have been initialized, and then uses the <see cref="P:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.SourceProcessingSession"/>
+            to process the source.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.BuildTableCore(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)">
+            <inheritdoc />
+            <remarks>
+                This implementation does nothing. To build a table that does not provide
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>, override this method.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.EnableCookerCore(Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory)">
+            <summary>
+            Enables an implementation to perform additional processing during a call to <see cref="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.EnableCooker(Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory)"/>.
+            </summary>
+            <param name="sourceDataCookerFactory">Source data cooker factory</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.OnDataCookerEnabled(Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking.ISourceDataCooker{`0,`1,`2})">
+            <summary>
+            Override to be notified when a source data cooker has been enabled for the session.
+            </summary>
+            <param name="sourceDataCooker">The cooker that was enabled.</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.CustomDataProcessorWithSourceParser`3.OnAllCookersEnabled">
+            <summary>
+            Override to be notified when all cookers have been enabled for the session.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataColumn`1">
+            <summary>
+                Represents a column of data in a table. This class is usable
+                on its own, or new columns may be derived.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data projected by this column.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumn`1.#ctor(Microsoft.Performance.SDK.Processing.ColumnMetadata,Microsoft.Performance.SDK.Processing.UIHints,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,`0})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataColumn`1" />
+                class.
+            </summary>
+            <param name="metadata">
+                The metadata about the column.
+            </param>
+            <param name="displayHints">
+                Hints to give callers on how to render this column. This parameter
+                may be <c>null</c>.
+            </param>
+            <param name="projection">
+                The projection that projects the data in the column.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="metadata"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumn`1.#ctor(Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,`0})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataColumn`1" />
+                class.
+            </summary>
+            <param name="configuration">
+                The configuration of this column.
+            </param>
+            <param name="projection">
+                The projection that projects the data in the column.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="configuration"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataColumn`1.Configuration">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataColumn`1.DataType">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataColumn`1.ProjectorInterface">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataColumn`1.Projector">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataColumn`1.Item(System.Int32)">
+            <summary>
+                Projects the data in this column for the given row.
+            </summary>
+            <param name="index">
+                The row whose value is to be retrieved.
+            </param>
+            <returns>
+                The projected value at the given row.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumn`1.Project(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumn`1.ProjectTyped(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumn`1.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataColumnExtensions">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.IDataColumn"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataColumnExtensions.SetFormatProvider(Microsoft.Performance.SDK.Processing.IDataColumn,System.IFormatProvider)">
+            <summary>
+                Sets the format provider for the given column.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IDataColumn"/> to be modified.
+            </param>
+            <param name="formatProvider">
+                The new <see cref="T:System.IFormatProvider"/> for the configuration.
+                This parameter may be <c>null</c>.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSource">
+            <summary>
+                Base of all Data Source implementations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSource.#ctor(System.Uri)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataSource"/>
+                class with the given <see cref="P:Microsoft.Performance.SDK.Processing.DataSource.Uri"/>.
+            </summary>
+            <param name="uri">
+                The URI of the data.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="uri"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSource.Uri">
+            <summary>
+                Gets the <see cref="P:Microsoft.Performance.SDK.Processing.DataSource.Uri" /> of the data.
+            </summary>
+            <returns>
+                The URI of the data.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSource.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSource.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSource.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceAttribute">
+            <summary>
+                Base attribute for denoting a Data Source that feeds into
+                a <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>. This class cannot be instantiated.
+                <para/>
+                Because users can implement their own
+                <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s, they can implement an
+                Attribute that implements this class with their
+                Data Source as the type parameter.
+                <para />
+                <example>
+                This example shows a sample implementation:
+                <code>
+                    public sealed class SqlServerDataSourceAttribute
+                        : DataSourceAttribute
+                    {
+                        public SqlServerDataSourceAttribute()
+                            : base(typeof(SqlServerDataSource))
+                        {
+                        }
+                    }
+                    
+                    [ProcessingSource(/* properties elided */)]
+                    [SqlServerDataSource(/* properties elided */)]
+                    public sealed class SqlProcessingSource
+                        : ProcessingSource
+                    {
+                        // implementation elided
+                    }
+                </code>
+                Any instances of the SqlServerDataSource Data Source will be
+                routed to this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> for further analysis during
+                processing.
+                </example>
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.#ctor(System.Type)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceAttribute"/>
+                class.
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> of the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> corresponding to this attribute.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="type"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.#ctor(System.Type,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceAttribute"/>
+                class.
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> of the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> corresponding to this attribute.
+            </param>
+            <param name="description">
+                A description of the Data Source denoted by this attribute.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="type"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is null.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Type">
+            <summary>
+                Gets the <see cref="T:System.Type"/> of Data Source denoted by
+                this <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceAttribute"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Description">
+            <summary>
+                Gets the description of the Data Source.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Accepts(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                This method is used to filter any incoming <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s so that only
+                <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that could conceivably be processed by the decorated
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> are passed to the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> for evaluation.
+            </summary>
+            <param name="dataSource">
+                The Data Source to check.
+            </param>
+            <returns>
+                <c>true</c> if it is feasible for this Data Source to be supported;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="dataSource"/> is not assignable to the <see cref="T:System.Type"/>
+                specified by this instance. See <see cref="P:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Type"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.AcceptsCore(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                When overridden in a derived class, this method is used to filter any
+                incoming Data Sources so that only Data Sources that could conceivably
+                be processed by the decorated <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> are passed to the
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> for evaluation.
+                <para />
+                This method returns <c>true</c> if it is not overridden. This method should
+                be overridden if your Data Source is potentially useful to lots of different
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>s (e.g. a file) but you know for a fact that most Custom
+                Data Sources would not be able to do anything with them, and so you want to
+                filter a subset of said Data Sources to your <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+                <para/>
+                For example, The <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute" /> uses this method to
+                reject any <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSource"/>s that do not have the prescribed extension.
+                This way, only files with the relevant extension get passed to the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>
+                for further inspection. See the <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute"/> class for
+                the implementation.
+                <para />
+                It is guaranteed that the runtime will only pass instances of <paramref name="dataSource"/> that
+                are of the <see cref="P:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Type"/> specified by <see cref="P:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Type"/>.
+                It is guaranteed that the runtime will not pass <c>null</c> to this method.
+            </summary>
+            <param name="dataSource">
+                The Data Source to check.
+            </param>
+            <returns>
+                <c>true</c> if it is feasible for this Data Source to be supported;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceAttribute.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceExtensions.IsFile(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Determines whether the given <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> represents
+                a file.
+            </summary>
+            <param name="dataSource">
+                The Data Source.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>represents a file;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceExtensions.IsExtensionlessFile(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Determines whether the given <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> represents
+                an extensionless file.
+            </summary>
+            <param name="dataSource">
+                The Data Source.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> represents an extensionless
+                file; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceExtensions.IsDirectory(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Determines whether the given <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> represents
+                a directory.
+            </summary>
+            <param name="dataSource">
+                The Data Source.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> represents a directory;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.DataSourceGroup">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceGrouping.DataSourceGroup.#ctor(System.Collections.Generic.IReadOnlyCollection{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.IProcessingMode)">
+            <summary>
+                Initializes a new instance of <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.DataSourceGroup"/>.
+            </summary>
+            <param name="dataSources">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s in this group. This parameter may not be <c>null</c>.
+            </param>
+            <param name="processingMode">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingMode"/> that this group should be processed in. This parameter may not
+                be <c>null</c>.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSources"/> or <paramref name="processingMode"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.DataSourceGroup.DataSources">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.DataSourceGroup.ProcessingMode">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup">
+            <summary>
+                A collection of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that a <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> can process together
+                in a specified <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingMode"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup.DataSources">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s in this group.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup.ProcessingMode">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingMode"/> for this group.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGrouper">
+            <summary>
+                An (optional) interface that <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> instances can implement to specify how
+                its supported <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s are capable of being grouped for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGrouper.CreateValidGroups(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Groups the specified <paramref name="dataSources" /> into groups of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that
+                can be processed together by a <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor" />.
+                <para />
+                The returned value must include every valid combination of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource" />s in the given
+                <paramref name="dataSources" />.
+            </summary>
+            <param name="dataSources">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> instances to be grouped. This will be every opened <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>
+                that the implementing <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> specified it can open.
+                <para />
+                Every <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> inside a returned <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>'s
+                <see cref="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup.DataSources"/> property must be one of these instances.
+            </param>
+            <param name="options">
+                Options that will be passed to the implementing <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> for processing. This
+                can be used, for instance, to limit the types of <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>s that will be returned.
+            </param>
+            <returns>
+                All valid groups of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s given the specified <paramref name="options"/>. Every
+                <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> inside a returned <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>'s <see cref="P:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup.DataSources"/>
+                property must be one of these instances.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroupResolver">
+            <summary>
+                Responsible for choosing the <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/> instances that will be used for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroupResolver.Resolve(System.Guid,System.Collections.Generic.IReadOnlyCollection{Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup})">
+            <summary>
+                Selects which <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>s to use for processing from <paramref name="allValidGroups"/>.
+                Each returned <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/> will be processed independently by a unique
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>.
+            </summary>
+            <param name="processingSourceGuid">
+                The <see cref="T:System.Guid"/> of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/> to resolve groups for.
+            </param>
+            <param name="allValidGroups">
+                All <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>s that can be processed by the <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>
+                created by the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/> with the specified <paramref name="processingSourceGuid"/>.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>s to use for processing. Each returned <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>
+                MUST be an instance from <paramref name="allValidGroups"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DataSourceInfo">
+            <summary>
+                Provides information about a data source, including the
+                time range encompassed by the data source.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.DataSourceInfo.Default">
+            <summary>
+                Gets the instance representing default <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceInfo"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.DataSourceInfo.None">
+            <summary>
+                Gets the instance representing no <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceInfo"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DataSourceInfo.#ctor(System.Int64,System.Int64,System.DateTime)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceInfo"/>
+                class.
+                <para />
+                The timestamps are relative to the beginning of the wallclock
+                time spanned by this data source, and are not actual times (e.g. UTC).
+                For more information, see remarks below.
+            </summary>
+            <param name="firstEventTimestampNanoseconds">
+                The timestamp, in nanoseconds, of the first data point, relative to
+                the beginning of the wallclock time spanned by this data source.
+            </param>
+            <param name="lastEventTimestampNanoseconds">
+                The timestamp, in nanoseconds, of the last data point, relative to
+                the beginning of the wallclock time spanned by this data source.
+            </param>
+            <param name="firstEventWallClockUtc">
+                The UTC wallclock time of the first data point, i.e. the absolute time
+                of the data point referred to in <paramref name="firstEventTimestampNanoseconds"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="firstEventTimestampNanoseconds"/> is less than zero (0.)
+                - or -
+                <paramref name="lastEventTimestampNanoseconds"/> is less than
+                <paramref name="firstEventTimestampNanoseconds"/>.
+            </exception>
+            <remarks>
+                Timestamps are relative to the beginning of the wallclock time spanned
+                by this data source. "The beginning of the time spanned by this data
+                source" is not explicitly passed to this class as a parameter since it
+                can be inferred with <paramref name="firstEventTimestampNanoseconds"/> and
+                <paramref name="firstEventWallClockUtc"/>.
+                <para />
+                For example, consider the following scenario:
+                    - A data source begins collecting information at 9:00:00.000 UTC
+                      (9am UTC)
+                    - The first even the data source observes occurs at 9:00:05.000 UTC
+                      (5 seconds later)
+                In this scenario, <paramref name="firstEventWallClockUtc"/> should be
+                9:00:05.000 UTC and <paramref name="firstEventTimestampNanoseconds"/>
+                should be 5x10^9 (i.e. 5 seconds in nanoseconds). These two pieces of
+                information encode that the first event happened at 9:00:05.000,
+                5 seconds after the data source begins, which must be 9:00:00.000.
+                <para />
+                If a data source's first even coincides with the start of the data source,
+                <paramref name="firstEventTimestampNanoseconds"/> will always be 0.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.FirstEventTimestampNanoseconds">
+            <summary>
+                Gets the timestamp of the first event in nanoseconds, relative to
+                the beginning of the wallclock time spanned by this data source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.EndTimestampNanoseconds">
+            <summary>
+                Gets the timestamp of the last event in nanoseconds, relative to
+                the beginning of the wallclock time spanned by this data source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.FirstEventWallClockUtc">
+            <summary>
+                Gets the wallclock time of the first event in the data stream, in UTC.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.Errors">
+            <summary>
+                Gets the collection of errors encountered while processing the
+                data source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.StartWallClockUtc">
+            <summary>
+                Gets the wallclock time of the beginning of the time spanned by
+                this data source, in UTC.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.EndWallClockUtc">
+            <summary>
+                Gets the wallclock time of the end of the time spanned by
+                this data source, in UTC.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DataSourceInfo.TimeZones">
+            <summary>
+                Gets or initializes the time zones that are of significance to this data source, keyed by a label
+                that describes the significance of the time zone.
+            </summary>
+            <example>
+                If the data source was a trace file recorded on a machine in the Eastern Time Zone, an entry in this
+                dictionary might be "Trace Local" => EST.
+            </example>
+            <example>
+                If the data source was a trace recorded on a web server where the host was in the Eastern Time Zone and
+                the client was in the Pacific Time Zone, entries in this dictionary might be "Host Local" => EST and
+                "Client Local" => PST.
+            </example>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DefaultProcessingMode">
+            <summary>
+                A default <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingMode"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.DefaultProcessingMode.Id">
+            <summary>
+                Gets the <see cref="P:Microsoft.Performance.SDK.Processing.IProcessingMode.Guid"/> for the <see cref="T:Microsoft.Performance.SDK.Processing.DefaultProcessingMode"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DefaultProcessingMode.Guid">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DefaultProcessingMode.Name">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DefaultProcessingMode.Description">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DirectoryDataSource">
+            <summary>
+                Represents a directory backed data source for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSource.#ctor(System.String)">
+            <summary>
+                Initializes a new <see cref="T:Microsoft.Performance.SDK.Processing.DirectoryDataSource"/> with the specified
+                directory path.
+            </summary>
+            <param name="path">
+                The path to the directory.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.DirectoryDataSource.FullPath">
+            <summary>
+                Gets the full path of the directory.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSource.Equals(System.Object)">
+            <inheritdoc cref="M:System.Object.Equals(System.Object)"/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSource.GetHashCode">
+            <inheritdoc cref="M:System.Object.GetHashCode"/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute">
+            <summary>
+                Attribute to mark an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> implementation as processing
+                directories.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute"/>
+                class, with a description of directories that would be acceptable.
+            </summary>
+            <param name="description">
+                A description of the directories accepted by the data source
+                decorated with this attribute.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="description"/> is null.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute.Equals(Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.DirectoryDataSourceAttribute.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute">
+            <summary>
+                Attribute to mark an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> implementation as processing
+                files that do not have extensions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute"/>
+                class.
+            </summary>
+            <param name="description">
+                A description of the file type exposed by this attribute.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="description"/> is null.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.Equals(Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ExtensionlessFileDataSourceAttribute.AcceptsCore(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.FileDataSource">
+            <summary>
+                Represents a file backed data source for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSource.#ctor(System.String)">
+            <summary>
+                Initializes a new <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSource"/> with the specified file path.
+            </summary>
+            <param name="path">
+                The path to the file.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="path"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="path"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.FileDataSource.FullPath">
+            <summary>
+                Gets the full path of the file.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSource.Equals(System.Object)">
+            <inheritdoc cref="M:System.Object.Equals(System.Object)"/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSource.GetHashCode">
+            <inheritdoc cref="M:System.Object.GetHashCode"/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute">
+            <summary>
+                Attribute to mark an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> implementation as processing
+                files of a specific type. This is used to instruct callers to route files
+                with a given extension to the decorated <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute"/>
+                class.
+            </summary>
+            <param name="fileExtension">
+                The extension of files that should be processed by this data source.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="fileExtension"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="fileExtension"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.#ctor(System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute"/>
+                class.
+            </summary>
+            <param name="fileExtension">
+                The extension of files that should be processed by this data source.
+            </param>
+            <param name="description">
+                A description of the file type exposed by this attribute.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="fileExtension"/> is whitespace.
+                - or -
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="fileExtension"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is whitespace.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.FileExtension">
+            <summary>
+                Gets the file extension supported by the decorated class,
+                not including the leading period (".")
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.Equals(Microsoft.Performance.SDK.Processing.FileDataSourceAttribute)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.FileDataSourceAttribute.AcceptsCore(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Formatting.DefaultFormatAttribute">
+            <summary>
+                Declares the default format string of an <see cref="T:System.IFormatProvider"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.DefaultFormatAttribute.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.DefaultFormatAttribute"/>
+                class with the given default format.
+            </summary>
+            <param name="defaultFormat">
+                A composite format string representing the default format.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.DefaultFormatAttribute.DefaultFormat">
+            <see cref="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultFormat(System.IFormatProvider)"/> is the public interface.
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Formatting.DelimiterAttribute">
+            <summary>
+                Targets are collection access provider types. When
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICollectionAccessProvider`2"/> flattens a collection, it delimits elements
+                with this character.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.DelimiterAttribute.#ctor(System.Char)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.DelimiterAttribute"/>
+                class for the given delimiter.
+            </summary>
+            <param name="delimiter">
+                The delimiter character.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.DelimiterAttribute.DefaultDelimiter">
+            <summary>
+                Gets the default delimiter character.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.DelimiterAttribute.Delimiter">
+            <summary>
+                Gets the delimiter represented by this instance.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions">
+            <summary>
+                Additional functionality for <see cref="T:System.IFormatProvider"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.Validate(System.IFormatProvider)">
+            <summary>
+                Performs some basic validation on an IFormatProvider, including the existence of a default format and
+                supported formats.
+            </summary>
+            <param name="formatProvider">
+                The format provider to validate.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                If the format provider cannot be validated, this exception is thrown with additional information.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.FormatToUse(System.IFormatProvider,System.String)">
+            <summary>
+                Determines which format to use from a format provider, preferring <paramref name="format"/>.
+            </summary>
+            <param name="formatProvider">
+                Target format provider.
+            </param>
+            <param name="format">
+                Preferred format.
+            </param>
+            <returns>
+                The preferred format if it exists in the provider, otherwise the default format. If
+                no format can be found, <c>null</c> is returned.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultFormat(System.IFormatProvider)">
+            <summary>
+                Returns the default format for the given provider.
+            </summary>
+            <param name="formatProvider">
+                Target format provider.
+            </param>
+            <returns>
+                The default format for the target provider, or <c>null</c> if no format exists.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.SupportedFormats(System.IFormatProvider)">
+            <summary>
+                Returns the available formats from the target format provider.
+            </summary>
+            <param name="formatProvider">
+                Target format provider.
+            </param>
+            <returns>
+                An enumeration of <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultSupportedFormat(System.IFormatProvider)">
+            <summary>
+                Finds and returns the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/> that matches the <see cref="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultFormat(System.IFormatProvider)"/>
+                for the target format provider.
+            </summary>
+            <param name="formatProvider">
+                Target format provider.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/> whose format matches the <see cref="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultFormat(System.IFormatProvider)"/> for the
+                target format provider, or <c>default</c> if there isn't a match.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                Thrown if there is more than one <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/> that matches the
+                <see cref="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.DefaultFormat(System.IFormatProvider)"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.IFormatProviderExtensions.Units(System.IFormatProvider,System.String)">
+            <summary>
+                Return the units from the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/> associated with the target format provider where
+                the specified <paramref name="format"/> matches the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/>.
+            </summary>
+            <param name="formatProvider">
+                Target format provider.
+            </param>
+            <param name="format">
+                Format of the <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/> whose unit value to return.
+            </param>
+            <returns>
+                A unit value from a <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat"/>, or <c>null</c>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat">
+            <summary>
+                This describes a string format for an <see cref="T:System.IFormatProvider"/>.
+                Includes: the format itself, a description, and an optional unit value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat.Format">
+            <summary>
+                Gets the string format.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat.Description">
+            <summary>
+                Gets a description of the string format.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormat.Units">
+            <summary>
+                Gets the unit specified for the string format, or <c>null</c>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormatAttribute">
+            <summary>
+                Declares a format that an <see cref="T:System.IFormatProvider"/> supports.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormatAttribute.#ctor(System.Int32,System.String,System.String)">
+            <summary>
+                Basic constructor doesn't require units.
+            </summary>
+            <param name="ordinal">
+                This provides ordering when multiple supported formats exist.
+            </param>
+            <param name="format">
+                The string format.
+            </param>
+            <param name="description">
+                A description of the format.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormatAttribute.#ctor(System.Int32,System.String,System.String,System.String)">
+            <summary>
+                Complete constructor includes unit of measure.
+            </summary>
+            <param name="ordinal">
+                This provides ordering when multiple supported formats exist.
+            </param>
+            <param name="format">
+                The string format.
+            </param>
+            <param name="description">
+                A description of the format.
+            </param>
+            <param name="units">
+                A unit of measure for the format.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormatAttribute.Ordinal">
+            <summary>
+                Gets the ordinal used to order multiple <see cref="T:Microsoft.Performance.SDK.Processing.Formatting.SupportedFormatAttribute"/>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.HierarchicalDataColumn`1">
+            <summary>
+                Represents a data column that can display values in a
+                hierarchical format. For example, stacks are hierarchical.
+                <para/>
+                Expanding on the example, a stack is a collection of values
+                that should logically be treated as one value. As one expands
+                the stack, each call becomes its own row. This column type allows
+                for you to provide the means of displaying those expansions in
+                a meaningful way.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data exposed by this column.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.HierarchicalDataColumn`1.#ctor(Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,`0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{`0})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.HierarchicalDataColumn`1"/>
+                class.
+            </summary>
+            <param name="configuration">
+                The configuration of this column.
+            </param>
+            <param name="projection">
+                The projection that projects the data in the column.
+            </param>
+            <param name="collectionProvider">
+                The providers that define how to display the hierarchical data.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="configuration"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+                - or -
+                <paramref name="collectionProvider"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HierarchicalDataColumn`1.CollectionInfoProvider">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.HighlightEntry">
+            <summary>
+                Provides information to SDK drivers that allow highlighting/selecting 
+                regions of time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.StartTimeColumnName">
+            <summary>
+                Gets or sets the name of the start time column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.StartTimeColumnGuid">
+            <summary>
+                 Gets or sets the ID of the start time column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.EndTimeColumnName">
+            <summary>
+                 Gets or sets the name of the end time column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.EndTimeColumnGuid">
+            <summary>
+                 Gets or sets the ID of the end time column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.DurationColumnName">
+            <summary>
+                 Gets or sets the name of the duration column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.DurationColumnGuid">
+            <summary>
+                 Gets or sets the ID of the duration column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.HighlightQuery">
+            <summary>
+                 Gets or sets a query that specify the highlight.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.HighlightEntry.HighlightColor">
+            <summary>
+                 Gets or sets the color of the highlight.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment">
+            <summary>
+                Exposes information about the application environment in
+                which the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> is being executed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.ApplicationName">
+            <summary>
+            The name of the application, if specified. This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.RuntimeName">
+            <summary>
+            The name of the runtime in which this application runs. This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.IsInteractive">
+            <summary>
+                Gets a value indicating whether the current process supports
+                user interaction.
+            </summary>
+            <remarks>
+                This flag is useful to determine whether the code is
+                running in context where user interaction is available.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.Serializer">
+            <summary>
+                Gets the serializer to use for deserializing <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> instances.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.TableDataSynchronizer">
+            <summary>
+                Provides the interface to be used to notify that data in
+                a table has changed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.VerboseOutput">
+            <summary>
+                Gets a value indicating whether Verbose output has
+                been enabled 
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.SourceDataCookerFactoryRetrieval">
+            <summary>
+                Used to get a factory for a given source data cooker.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.SourceSessionFactory">
+            <summary>
+                A factory to create a SourceSession.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.DisplayMessage(Microsoft.Performance.SDK.Processing.MessageType,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+                Displays the given message of the given type to the user,
+                using the formatting information specified by the <paramref name="formatProvider"/>.
+                The message is displayed in a message box.
+            </summary>
+            <param name="messageType">
+                The type of message being displayed.
+            </param>
+            <param name="formatProvider">
+                An object that supplies culture-specific formatting information.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.MessageBox(Microsoft.Performance.SDK.Processing.MessageType,System.IFormatProvider,Microsoft.Performance.SDK.Processing.Buttons,System.String,System.String,System.Object[])">
+            <summary>
+                Displays the given message of the given type to the user,
+                using the formatting information specified by the <paramref name="formatProvider"/>.
+                The message is displayed in a message box with buttons.
+            </summary>
+            <param name="messageType">
+                The type of message being displayed.
+            </param>
+            <param name="formatProvider">
+                An object that supplies culture-specific formatting information.
+            </param>
+            <param name="buttons">
+                The buttons on the message box.
+            </param>
+            <param name="caption">
+                A simple description about what is being asked.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="args">
+                The objects to format using <paramref name="format"/>.
+            </param>
+            <returns>
+                <c>true</c> if the user selects 'yes'; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV2">
+            <summary>
+                Extends <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/> to provide additional functionality.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV2.TryGetAuthProvider``2(Microsoft.Performance.SDK.Auth.IAuthProvider{``0,``1}@)">
+            <summary>
+                Attempts to get an <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> that can provide authentication
+                for <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> of type <typeparamref name="TAuth"/>.
+            </summary>
+            <param name="provider">
+                The found provider, or <c>null</c> if no registered provider can provide authentication for
+                <typeparamref name="TAuth"/>.
+            </param>
+            <typeparam name="TAuth">
+                The type of the <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> for which to attempt to get a provider.
+            </typeparam>
+            <typeparam name="TResult">
+                The type of the result of a successful authentication for <typeparamref name="TAuth"/>.
+            </typeparam>
+            <returns>
+                <c>true</c> if a provider was found; <c>false</c> otherwise. If <c>false</c> is returned,
+                <paramref name="provider"/> will be <c>null</c>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV3">
+            <summary>
+                Extends <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV2"/> to provide additional functionality.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV3.TryGetPluginOption``1(System.Guid,``0@)">
+            <summary>
+                Attempts to get the plugin option of type <typeparamref name="T"/> with the given GUID.
+            </summary>
+            <param name="optionGuid">
+                The <see cref="T:System.Guid"/> of the option to get.
+            </param>
+            <param name="option">
+                The found option if this method returns <c>true</c>; <c>null</c> otherwise.
+            </param>
+            <typeparam name="T">
+                The concrete type of the <see cref="!:PluginOption"/> to get. Must be a subclass of <see cref="!:PluginOption"/>.
+            </typeparam>
+            <returns>
+                <c>true</c> if the option was found; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ICollectionAccessProvider`2">
+            <summary>
+                Provides a mechanism for transforming elements of a collection into a different type. This is used
+                transform rows from a hierarchical column into sub-elements.
+            </summary>
+            <typeparam name="TCollection">Input type to be transformed into <c>T</c></typeparam>
+            <typeparam name="T">Output type</typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ICollectionAccessProvider`2.PastEndValue">
+             <summary>
+             A constant that is not a member of any collection.
+            
+             When 0 &gt;= index &lt; GetCount(),
+             GetValue(collection, index).CompareTo(PastEndValue) must not be 0.
+             
+             If a collection may include the default value, use a non-default
+             value for PastEndValue.
+             
+             x.CompareTo() must properly test for equality of x with
+             PastEndValue. x.CompareTo() does not need to test whether x is
+             less than or greater than PastEndValue.
+             
+             Column cells show PastEndValue.ToString() when data is 
+             unavailable. Consider meaningful output such as "n/a".
+             </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICollectionAccessProvider`2.GetParent(`0)">
+            <summary>
+                Gets the parent of the given collection.
+            </summary>
+            <param name="collection">
+                The collection.
+            </param>
+            <returns>
+                The parent of the collection.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICollectionAccessProvider`2.GetValue(`0,System.Int32)">
+            <summary>
+            The data engine calls this function for all collections that return
+            !IsNull(collection), regardless of the result of
+            GetCount(collection). The purpose of this quirk is to allow access
+            providers to assign special values to special collections, Idle
+            stacks for example.
+            
+            Special value collections work correctly if HasUniqueStart()
+            returns false!
+            
+            The dataengine calls this function once for IsNull(collection) to
+            get the value of a null collection.
+            
+            Returns the value of element in the collection if index is
+            within bounds; otherwise if index is out-of-bounds, returns
+            PastEndValue.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ICollectionInfoProvider`1">
+            <summary>
+                Provides information about a collection.
+            </summary>
+            <typeparam name="TCollection">
+                The <see cref="T:System.Type"/> of collection.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ICollectionInfoProvider`1.HasUniqueStart">
+            <summary>
+                Gets a value indicating whether the collection has
+                a unique starting value.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICollectionInfoProvider`1.GetCount(`0)">
+            <summary>
+                Gets the count of elements in the collection.
+            </summary>
+            <param name="collection">
+                The collection.
+            </param>
+            <returns>
+                The count of elements in <paramref name="collection"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor">
+            <summary>
+                Implementations of this interface process a data source
+                in order to create tables showing the data in the source.
+                This is the core of how data is transformed into graphable /
+                analyzable data.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.EnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Instructs the processor that a table is being
+                requested by the user. This means that the processor
+                should do whatever is necessary in <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/>
+                to make sure the table can be used.
+                <para />
+                This method must be thread-safe.
+            </summary>
+            <param name="tableDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that instructs the
+                processor as to which table is being requested.
+            </param>
+            <exception cref="T:Microsoft.Performance.SDK.Extensibility.Exceptions.ExtensionTableException">
+                The requested table cannot be enabled.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/> has already been called.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.TryEnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Instructs the processor that a table is being
+                requested by the user. This means that the processor
+                should do whatever is necessary in ProcessAsync to
+                make sure the table can be used.
+                <para />
+                This method must be thread-safe.
+            </summary>
+            <param name="tableDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that instructs the
+                processor as to which table is being requested.
+            </param>
+            <returns>
+                <c>true</c> if the table was enabled; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)">
+            <summary>
+                Asynchronously processes the data source.
+            </summary>
+            <param name="progress">
+                Provides a method of updating the application as to this
+                processor's progress.
+            </param>
+            <param name="cancellationToken">
+                A means of the application signaling to the processor that
+                it should abort processing.
+            </param>
+            <returns>
+                A <see cref="T:System.Threading.Tasks.Task"/> representing the asynchronous operation.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/> has already been called.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.GetDataSourceInfo">
+            <summary>
+                Gets information about the processed data source.
+                This method will be called after <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/>
+                has completed successfully.
+            </summary>
+            <returns>
+                Information about the data source that was processed.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)">
+            <summary>
+                Instructs the processor to build the requested table
+                into an actual structure.
+                <para />
+                This method must be thread-safe.
+            </summary>
+            <param name="table">
+                The table to build.
+            </param>
+            <param name="tableBuilder">
+                The builder to use to build the table.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.CreateTableService(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Instructs the processor to return the appropriate service
+                for the given table, if any.
+            </summary>
+            <param name="table">
+                The table whose service is to be created.
+            </param>
+            <returns>
+                The created service, if the table has a service. <c>null</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.DoesTableHaveData(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                This method is used to communicate whether the given table has any
+                data to show as a result of processing. This method is never called
+                before <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)"/>. If this method returns <c>false</c>,
+                then the table will not be exposed.
+            </summary>
+            <param name="table">
+                The table being interrogated.
+            </param>
+            <returns>
+                <c>true</c> if the table has at least one row of data;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.GetEnabledTables">
+            <summary>
+                Gets the tables that have been enabled on this processor.
+            </summary>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> of tables that have been enabled on this processor.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ISourceParserRetrieval">
+            <summary>
+                Provides access to data from a <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>'s source parser cookers.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ISourceParserRetrieval.SourceParserId">
+            <summary>
+                Source parser identifier
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser">
+            <summary>
+                Wraps the <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> with additional functionality required to operate with a
+                source parser and data extensions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser.EnableCooker(Microsoft.Performance.SDK.Extensibility.DataCooking.ISourceDataCookerFactory)">
+            <summary>
+                Enables a source data cooker, causing it to take part in processing the source data.
+            </summary>
+            <param name="sourceDataCookerFactory">
+                A factory for creating the source data cooker to enable.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3">
+            <summary>
+                Wraps ICustomDataProcessorWithSourceParser as a generic that is specific to a give source parser.
+            </summary>
+            <typeparam name="T">
+                Type of data from the source to be processed.
+            </typeparam>
+            <typeparam name="TContext">
+                Type that contains context about the data from the source.
+            </typeparam>
+            <typeparam name="TKey">
+                Type that will be used to identify data from the source that is relevant to this extension.
+            </typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3.SourceParser">
+            <summary>
+                The source parser responsible for parsing the source and handing data to the
+                <see cref="T:Microsoft.Performance.SDK.Extensibility.SourceParsing.ISourceDataProcessor`3"/> for further processing.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser`3.SourceProcessingSession">
+            <summary>
+                The source session, responsible for processing the source through the source
+                parser, and distributing data to source data cookers as appropriate.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IDataDerivedTables">
+            <summary>
+            When implemented by a custom data processor, this enables a form of dynamically generated table. These tables
+            are created while processing the data source.
+            </summary>
+            <remarks>
+            These tables will not show up in some table lists, as these tables won't always be available from the given
+            <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataDerivedTables.DataDerivedTables">
+            <summary>
+            These tables are generated while processing the data source.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IDataSource">
+            <summary>
+                Represents a source of data.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IDataSource.Uri">
+            <summary>
+                Gets the <see cref="P:Microsoft.Performance.SDK.Processing.IDataSource.Uri" /> of the data.
+            </summary>
+            <returns>
+                The URI of the data.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IDynamicTableBuilder">
+            <summary>
+                Defines the interface for building dynamic tables.
+                <para />
+                For more information on dynamic tables, please refer to
+                <see cref="M:Microsoft.Performance.SDK.Processing.IProcessorEnvironment.RequestDynamicTableBuilder(Microsoft.Performance.SDK.Processing.TableDescriptor)"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IDynamicTableBuilder.AddDynamicTable(Microsoft.Performance.SDK.Processing.AddNewTableOption)">
+            <summary>
+                Adds a new table to the UI. This method is used in conjunction with
+                <see cref="M:Microsoft.Performance.SDK.Processing.IProcessorEnvironment.RequestDynamicTableBuilder(Microsoft.Performance.SDK.Processing.TableDescriptor)"/> to add brand new
+                tables.
+            </summary>
+            <param name="option">
+                Specifies where to add the new table.
+            </param>
+            <exception cref="T:System.InvalidOperationException">
+                This object was not created by
+                <see cref="M:Microsoft.Performance.SDK.Processing.IProcessorEnvironment.RequestDynamicTableBuilder(Microsoft.Performance.SDK.Processing.TableDescriptor)"/>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ILogger">
+            <summary>
+                Provides a means of logging information.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Verbose(System.String,System.Object[])">
+            <summary>
+                Logs a verbose message.
+            </summary>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Verbose(System.Exception,System.String,System.Object[])">
+            <summary>
+                Logs a verbose message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="e">
+                The <see cref="T:System.Exception"/> to log.
+            </param>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Info(System.String,System.Object[])">
+            <summary>
+                Logs an informational message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Info(System.Exception,System.String,System.Object[])">
+            <summary>
+                Logs an informational message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="e">
+                The <see cref="T:System.Exception"/> to log.
+            </param>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Warn(System.String,System.Object[])">
+            <summary>
+                Logs a warning message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Warn(System.Exception,System.String,System.Object[])">
+            <summary>
+                Logs a warning message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="e">
+                The <see cref="T:System.Exception"/> to log.
+            </param>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Error(System.String,System.Object[])">
+            <summary>
+                Logs an error message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Error(System.Exception,System.String,System.Object[])">
+            <summary>
+                Logs an error message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="e">
+                The <see cref="T:System.Exception"/> to log.
+            </param>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Fatal(System.String,System.Object[])">
+            <summary>
+                Logs a fatal message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ILogger.Fatal(System.Exception,System.String,System.Object[])">
+            <summary>
+                Logs a fatal message with an <see cref="T:System.Exception"/>.
+            </summary>
+            <param name="e">
+                The <see cref="T:System.Exception"/> to log.
+            </param>
+            <param name="fmt">
+                A composite format string.
+            </param>
+            <param name="args">
+                An array of objects to be formatted.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.INullableInfoProvider`1">
+            <summary>
+                Encapsulates null checks against instances of a
+                <see cref="T:System.Type"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of values.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.INullableInfoProvider`1.IsNull(`0)">
+            <summary>
+                Determines whether the given instance is
+                considered to be <c>null</c>.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is considered
+                to be <c>null</c>; false otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessingMode">
+            <summary>
+                A mode of processing 1 or more <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource" />s in a single call to
+                <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.ProcessAsync(System.IProgress{System.Int32},System.Threading.CancellationToken)" />.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingMode.Guid">
+            <summary>
+                Gets a globally-unique identifier for this processing mode.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingMode.Name">
+            <summary>
+                Gets the human-readable name of this processing mode.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingMode.Description">
+            <summary>
+                Gets a human-readable description of this processing mode.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessingOptionsResolver">
+            <summary>
+                Responsible for choosing the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> that will be used for processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingOptionsResolver.GetProcessorOptions(System.Guid,Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup)">
+            <summary>
+                Get the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> for an <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/> processed by a <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="processingSourceGuid"> Guid for a <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to process the data sources. </param>
+            <param name="dataSourceGroup"> A group of data sources. </param>
+            <returns> 
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to pass to the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> 
+                with the given <paramref name="processingSourceGuid"/> when it is asked to create an 
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> to process the given <paramref name="dataSourceGroup"/>.
+                
+                It is invalid to return <c>null</c>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.SerializationSource">
+            <summary>
+                Enumerates the different sources of serialized table configuration
+                data.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SerializationSource.PrebuiltTableConfiguration">
+            <summary>
+                The tables configurations are pre-built and persisted.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessingSource">
+            <summary>
+                This interface is used to expose the tables associated
+                with processing a given data source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingSource.DataTables">
+            <summary>
+                Gets the collection of tables exposed by this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>
+                which are not marked as <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.IsMetadataTable"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingSource.MetadataTables">
+            <summary>
+                Gets the collection of tables exposed by this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>
+                which are marked as <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.IsMetadataTable"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingSource.CommandLineOptions">
+            <summary>
+                Gets the options that are supported by this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessingSource.PluginOptions">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/>s for plugin options that are supported by this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <remarks>
+                Plugins can obtain a <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue"/> for each <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/> returned by
+                this property by querying <see cref="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironmentV3.TryGetPluginOption``1(System.Guid,``0@)"/>.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.GetAboutInfo">
+            <summary>
+                Gets information about this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo"/> for this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.SetApplicationEnvironment(Microsoft.Performance.SDK.Processing.IApplicationEnvironment)">
+            <summary>
+                Sets the application environment for the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="applicationEnvironment">
+                The application environment.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.SetLogger(Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Provides the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> an application-appropriate logging mechanism.
+            </summary>
+            <param name="logger">
+                Used to log information.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.CreateProcessor(Microsoft.Performance.SDK.Processing.IDataSource,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Creates a new processor for processing the specified data source.
+            </summary>
+            <param name="dataSource">
+                The data source to process.
+            </param>
+            <param name="processorEnvironment">
+                The environment for this specific processor instance.
+            </param>
+            <param name="options">
+                The command line options to pass to the processor.
+            </param>
+            <returns>
+                The created <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/>, <paramref name="processorEnvironment"/>, or <paramref name="options"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.CreateProcessor(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Creates a new processor for processing the specified data sources.
+            </summary>
+            <param name="dataSources">
+                The data sources to process.
+            </param>
+            <param name="processorEnvironment">
+                The environment for this specific processor instance.
+            </param>
+            <param name="options">
+                The command line options to pass to the processor.
+            </param>
+            <returns>
+                The created <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSources"/>, <paramref name="processorEnvironment"/>, or <paramref name="options"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.CreateProcessor(Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Creates a new processor for processing the specified data sources.
+            </summary>
+            <param name="dataSourceGroup">
+                The data source group to process.
+            </param>
+            <param name="processorEnvironment">
+                The environment for this specific processor instance.
+            </param>
+            <param name="options">
+                The command line options to pass to the processor.
+            </param>
+            <returns>
+                The created <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSourceGroup"/>, <paramref name="processorEnvironment"/>, or <paramref name="options"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                This <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> implements <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGrouper"/>, but does not provide a
+                valid a way to process a <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.GetSerializationStream(Microsoft.Performance.SDK.Processing.SerializationSource)">
+            <summary>
+                Retrieves a stream for serializing data. This method may return
+                <c>null</c>.
+                <para />
+                Source: PrebuiltTableConfiguration => TableConfigurations[]
+            </summary>
+            <param name="source">
+                Identifies the stream source.
+            </param>
+            <returns>
+                Serialization stream.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.IsDataSourceSupported(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Returns a value indicating whether the given Data Source can
+                be opened by this instance.
+            </summary>
+            <param name="dataSource">
+                The Data Source of interest.
+            </param>
+            <returns>
+                <c>true</c> if this instance can actually process the given Data Source;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSource.DisposeProcessor(Microsoft.Performance.SDK.Processing.ICustomDataProcessor)">
+            <summary>
+                Provides a method for this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to do any
+                special cleanup operations for processors created by
+                this instance, if applicable.
+                <para />
+                It is guaranteed that the <paramref name="processor"/>
+                passed to this method was created by this instance.
+            </summary>
+            <param name="processor">
+                The processor to dispose.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider">
+            <summary>
+                Provides an interface for providing tables that are exposed
+                by <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider.Discover(Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer)">
+            <summary>
+                Returns the collection of tables that should be associated with an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+                <para/>
+                See also <seealso cref="M:Microsoft.Performance.SDK.Processing.ProcessingSource.#ctor(Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider)"/>.
+            </summary>
+            <param name="tableConfigSerializer">
+                The serializer used to deserialize table configurations.
+            </param>
+            <returns>
+                A collection of <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>s.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessorEnvironment">
+            <summary>
+                Presents the services offered by the application for
+                a given session. You use this interface to interact with
+                the caller on a session by session basis.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessorEnvironment.CreateLogger(System.Type)">
+            <summary>
+                Used to generate a processor-specific logger.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessorEnvironment.RequestDynamicTableBuilder(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Requests a new table builder from the application.
+                See <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand(System.String,Microsoft.Performance.SDK.Processing.TableCommandCallback)"/>.
+                <para/>
+                Note that this is used to create tables from tables that already
+                exist in the UI (as created by <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)"/>.
+                Scenarios where you would use this are in:
+                <list type="bullet">
+                    <item>A table command to create a new table. See <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand(System.String,Microsoft.Performance.SDK.Processing.TableCommandCallback)"/>.</item>
+                </list>
+            </summary>
+            <param name="descriptor">
+                The description of the table you are going to build. This descriptor
+                can be completely unique, and does not necessarily need to correspond
+                to an already known / existing table.
+            </param>
+            <returns>
+                A new table builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="descriptor"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                The services are not in a state that allows for requesting new tables.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessorEnvironmentV2">
+            <summary>
+                Presents the services offered by the application for
+                a given session. You use this interface to interact with
+                the caller on a session by session basis.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProcessorEnvironmentV2.TableDataSynchronizerFactory">
+            <summary>
+                Gets a factory to creates an instance of <see cref="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization"/> specific to the 
+                processor.
+                <para/>
+                This may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProcessorTableDataSynchronizationFactory">
+            <summary>
+                Used to create an <see cref="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization"/> specific to a given processor.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IProcessorTableDataSynchronizationFactory.Create(Microsoft.Performance.SDK.Processing.ICustomDataProcessor)">
+            <summary>
+                Create an <see cref="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization"/> specific to <paramref name="processor"/>.
+            </summary>
+            <param name="processor">
+                The processor with which the <see cref="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization"/> will be associated.
+            </param>
+            <returns>
+                An instance of <see cref="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProjection`2">
+            <summary>
+            Exposes a function that has one parameter of the type specified by the <typeparamref name="TSource"/> parameter and returns a value of the type specified by the <typeparam name="TResult"/> parameter.
+            </summary>
+            <typeparam name="TSource">The type of the function parameter.</typeparam>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProjection`1">
+            <summary>
+            Exposes a function that has an input parameter of type 'int' and returns a value of the type specified by the <typeparam name="TResult"/> parameter.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProjectionDescription">
+            <summary>
+            Exposes information about a function that has one parameter of a specified type and returns a value of another specified type.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProjectionDescription.SourceType">
+            <summary>
+            Gets the type of the parameter of the function representing the selector.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProjectionDescription.ResultType">
+            <summary>
+            Gets the type of the values returned by the function representing the selector.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IProjector`2">
+            <summary>
+            Exposes a function that has one parameter of the type specified by the <typeparamref name="TSource"/> parameter and returns a value of the type specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="TSource">The type of the function parameter.</typeparam>
+            <typeparam name="TResult">The type of the function result.</typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IProjector`2.Item(`0)">
+            <summary>
+            Get the element for the specified value.
+            </summary>
+            <param name="value">The function parameter.</param>
+            <returns></returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ISpecializedKeyComparer`1">
+            <summary>
+            Adds a method to retrieve a specialized key comparer.
+            </summary>
+            <typeparam name="TKey">The type to be compared</typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ISpecializedKeyComparer`1.ProjectionModes">
+            <summary>
+            Provides a set of modes that may provide specialized comparisons.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ISpecializedKeyComparer`1.GetSpecializedKeyComparer(System.String)">
+            <summary>
+            Returns an <see cref="T:System.Collections.Generic.IComparer`1"/> type based on the mode passed in. Return <c>null</c> if no
+            specialized comparer exists for the given mode.
+            </summary>
+            <param name="mode">Used to determine the return value</param>
+            <returns>A specialized comparer, or <c>null</c> to use a default comparer.</returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ITableBuilder">
+            <summary>
+                ITableBuilder is the only way to get ITableBuilderWithRowCount to force the
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to set a row count.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ITableBuilder.BuiltInTableConfigurations">
+            <summary>
+                Gets the collection of <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/>s that
+                are already known for this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ITableBuilder.DefaultConfiguration">
+            <summary>
+                Gets the default configuration for this table.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand(System.String,Microsoft.Performance.SDK.Processing.TableCommandCallback)">
+            <summary>
+                Registers a command that users can execute against this table.
+            </summary>
+            <param name="commandName">
+                The name of the command. This name ultimately shows up in the context
+                menu in the UI when the user right clicks a table. The name of the command
+                is *NOT* case sensitive, and must be unique for the table. Any whitespace
+                around the name is trimmed, so " name " will be stored as "name".
+            </param>
+            <param name="callback">
+                The callback to execute when the user chooses this command.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="commandName"/> is <c>null</c>.
+                - or -
+                <paramref name="callback"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="commandName"/> is whitespace.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                A command with <paramref name="commandName"/> has already been added
+                to this instance, irrespective of casing.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand2(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext},System.Action{Microsoft.Performance.SDK.Processing.TableCommandContext})">
+            <summary>
+                Registers a command that users can execute against this table.
+            </summary>
+            <param name="commandName">
+                The human-readable name to associate with the command.
+            </param>
+            <param name="canExecute">
+                The callback to execute to determine if the user can choose this command.
+            </param>
+            <param name="onExecute">
+                The callback to execute when the user chooses this command.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="commandName"/> is <c>null</c>.
+                - or -
+                <paramref name="canExecute"/> is <c>null</c>.
+                - or -
+                <paramref name="onExecute"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="commandName"/> is whitespace.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                A command with <paramref name="commandName"/> has already been added
+                to this instance, irrespective of casing.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)">
+            <summary>
+                Registers a command that users can execute against this table.
+                <para/>
+                Compared to <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand2(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext},System.Action{Microsoft.Performance.SDK.Processing.TableCommandContext})"/>,
+                this overload uses <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandContext2"/>, whose selected rows
+                also carry sub-row indices for hierarchical columns, and expects the callback
+                to return a <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandResult"/> asynchronously.
+            </summary>
+            <param name="commandName">
+                The human-readable name to associate with the command.
+            </param>
+            <param name="canExecute">
+                The callback to execute to determine if the user can choose this command.
+            </param>
+            <param name="onExecute">
+                The asynchronous callback to execute when the user chooses this command.
+                Callbacks that do not need to return a value should return
+                <see cref="P:Microsoft.Performance.SDK.Processing.VoidTableCommandResult.Instance"/>.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="commandName"/> is <c>null</c>.
+                - or -
+                <paramref name="canExecute"/> is <c>null</c>.
+                - or -
+                <paramref name="onExecute"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="commandName"/> is whitespace.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                A command with <paramref name="commandName"/> has already been added
+                to this instance via <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)"/>, irrespective of casing.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableConfiguration(Microsoft.Performance.SDK.Processing.TableConfiguration)">
+            <summary>
+                Adds a configuration for this table to the builder.
+            </summary>
+            <param name="configuration">
+                The configuration to add.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="configuration"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.SetDefaultTableConfiguration(Microsoft.Performance.SDK.Processing.TableConfiguration)">
+            <summary>
+                Sets the given configuration as the default for this table.
+            </summary>
+            <param name="configuration">
+                The configuration to set as the default.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="configuration"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilder.SetRowCount(System.Int32)">
+            <summary>
+                Sets the number of rows that are in the table.
+            </summary>
+            <param name="numberOfRows">
+                The number of rows in the table.
+            </param>
+            <returns>
+                A table builder that can be used to add columns.
+                The returned builder will reflect all other changes
+                made to this instance.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount">
+            <summary>
+                Provides a means of adding columns to a data table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.RowCount">
+            <summary>
+                Gets the count of rows in the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.Columns">
+            <summary>
+                Gets the collection of columns that have been added to
+                the builder instance.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.AddColumn(Microsoft.Performance.SDK.Processing.IDataColumn)">
+            <summary>
+                Adds a column to this builder instance.
+            </summary>
+            <param name="column">
+                The column to add.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="column"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.AddColumnWithVariants(Microsoft.Performance.SDK.Processing.IDataColumn,System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a column that can be configured with multiple variants to this builder instance.
+            </summary>
+            <param name="column">
+                The column to add.
+            </param>
+            <param name="variantsBuilder">
+                The builder that can be used to add variants to the column.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="column"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.ReplaceColumn(Microsoft.Performance.SDK.Processing.IDataColumn,Microsoft.Performance.SDK.Processing.IDataColumn)">
+            <summary>
+                Replaces the given column with another column.
+                If the column to replace does not exist, then the
+                other column is simply added.
+            </summary>
+            <param name="oldColumn">
+                The column to replace.
+            </param>
+            <param name="newColumn">
+                The column to use to replace <paramref name="oldColumn"/>.
+            </param>
+            <returns>
+                This instance of the builder.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="oldColumn"/> is <c>null</c>.
+                - or -
+                <paramref name="newColumn"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.SetTableRowDetailsGenerator(System.Func{System.Int32,System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.TableRowDetailEntry}})">
+            <summary>
+                Sets the function to be used to generate details for a given row in the table.
+                <para/>
+                The function will take the row number being examined by the user, and should
+                return a collection of one or more entries given details for that row. This can
+                be used to support information on a row by row basis that does not make
+                sense in a columnar format.
+                <para/>
+                This method is not required to be called; it is perfectly acceptable
+                to not support details. This method may be called only zero (0) or one (1)
+                time(s) per instance.
+            </summary>
+            <param name="generator">
+                The function that should be used by the application to retrieve the details
+                for a given row.
+            </param>
+            <returns>
+                An <see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount"/> that may be used to continue
+                building the table.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer">
+            <summary>
+                Used to perform serialization operations against <see cref="T:Microsoft.Performance.SDK.Processing.TableConfigurations"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer.DeserializeTableConfigurations(System.IO.Stream)">
+            <summary>
+                Deserializes the content of a <see cref="T:System.IO.Stream"/> into a collection
+                of <see cref="T:Microsoft.Performance.SDK.Processing.TableConfigurations"/> instances.
+            </summary>
+            <param name="stream">
+                The <see cref="T:System.IO.Stream"/> from which to deserialize.
+            </param>
+            <returns>
+                The deserialized configurations.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer.DeserializeTableConfigurations(System.IO.Stream,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Deserializes the content of a <see cref="T:System.IO.Stream"/> into a collection
+                of <see cref="T:Microsoft.Performance.SDK.Processing.TableConfigurations"/> instances.
+            </summary>
+            <param name="stream">
+                The <see cref="T:System.IO.Stream"/> from which to deserialize.
+            </param>
+            <param name="logger">
+                Used to log any relevant messages.
+            </param>
+            <returns>
+                The deserialized configurations.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ITableDataSynchronization">
+            <summary>
+                Provides a way to synchronize data changes in columns with the user interface displaying the columns.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableDataSynchronization.SubmitColumnChangeRequest(System.Collections.Generic.IEnumerable{System.Guid},System.Action,System.Action,System.Boolean)">
+            <summary>
+                The data of these columns is changing and that should be reflected by the user interface.
+                Note that the second action, if provided, will only be executed once all tables affected
+                by the first action are updated and ready. It's the equivalent of calling this twice, with
+                the guarantee that the operations execute sequentially.
+            </summary>
+            <remarks>
+                This is a multi-step process to ensure data read from tables is synchronized with changes:
+                1. Lock tables affected by the change (based on <paramref name="columns"/>) and wait
+                   for all existing operations on those tables to complete.
+                2. Execute <paramref name="onReadyForChange"/> on a background thread.
+                3. On UI-thread, notify all affected columns that data has changed and re-apply the preset.
+                   Note that this may result in work on background threads for sorting/grouping.
+                4. Mark table as ready.
+                5. Execute <paramref name="onChangeComplete"/>.
+            </remarks>
+            <param name="columns">
+                Identifiers for the columns that are changing.
+            </param>
+            <param name="onReadyForChange">
+                Callback when the tables are ready for the change.
+            </param>
+            <param name="onChangeComplete">
+                Callback when the tables are finished updated post change.
+            </param>
+            <param name="requestInitialFilterReevaluation">
+                Reset initial filter from table configuration.
+                <seealso cref="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialFilterQuery"/>
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableDataSynchronization.SubmitColumnChangeRequest(System.Func{Microsoft.Performance.SDK.Processing.IProjectionDescription,System.Boolean},System.Action,System.Action,System.Boolean)">
+            <summary>
+                The data of these columns is changing and that should be reflected by the user interface.
+                Note that the second action, if provided, will only be executed once all tables affected
+                by the first action are updated and ready. It's the equivalent of calling this twice, with
+                the guarantee that the operations execute sequentially.
+            </summary>
+            <remarks>
+                This is a multi-step process to ensure data read from tables is synchronized with changes:
+                1. Lock tables affected by the change (based on <paramref name="predicate"/>) and wait
+                   for all existing operations on those tables to complete.
+                2. Execute <paramref name="onReadyForChange"/> on a background thread.
+                3. On UI-thread, notify all affected columns that data has changed and re-apply the preset.
+                   Note that this may result in work on background threads for sorting/grouping.
+                4. Mark table as ready.
+                5. Execute <paramref name="onChangeComplete"/>.
+            </remarks>
+            <param name="predicate">
+                A predicate used to decide which projections are changing.
+            </param>
+            <param name="onReadyForChange">
+                Callback when the tables are ready for the change.
+            </param>
+            <param name="onChangeComplete">
+                Callback when the tables are finished updated post change.
+            </param>
+            <param name="requestInitialFilterReevaluation">
+                Reset table filters that depend on the changed columns.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ITableService">
+            <summary>
+                Presents a way for a caller to be informed that a
+                table's data has changed, and give the caller a opportunity to
+                rebuild the table.
+            </summary>
+        </member>
+        <member name="E:Microsoft.Performance.SDK.Processing.ITableService.Invalidated">
+            <summary>
+                Event that is raised when the current data in the table
+                is no longer valid.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ITableService.OnProcessorConnected">
+            <summary>
+                This method is used by the caller when the processor has come
+                back into focus. This occurs when the user changes sessions,
+                and thus this method is called for every processor in the
+                session to which the user has selected. Here you would do
+                anything that might be required to determine if your data is
+                invalid, raise <see cref="E:Microsoft.Performance.SDK.Processing.ITableService.Invalidated"/>, etc.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IVisibleDomainRegion">
+            <summary>
+                Defines the domain region that is currently visible in
+                the SDK driver.
+            </summary>
+            <remarks>
+                Currently, only <seealso cref="T:Microsoft.Performance.SDK.TimeRange"/>s are supported domains.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IVisibleDomainRegion.Domain">
+            <summary>
+                Gets the currently visible domain in the SDK driver.
+            </summary>
+            <remarks>
+                Currently, only <seealso cref="T:Microsoft.Performance.SDK.TimeRange"/>s are supported domains.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IVisibleDomainRegion.AggregateVisibleRows``2(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.AggregationMode)">
+            <summary>
+                Aggregates the given projection using the specified aggregation
+                mode, aggregating only those values that are currently visible.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of result from the projection.
+            </typeparam>
+            <typeparam name="TAggregate">
+                The <see cref="T:System.Type"/> of the aggregated result.
+            </typeparam>
+            <param name="projection">
+                The projection whose results are to be aggregated.
+            </param>
+            <param name="aggregationMode">
+                The way in which to aggregate the data in the projection.
+            </param>
+            <returns>
+                The aggregated result.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="aggregationMode"/> is <see cref="F:Microsoft.Performance.SDK.Processing.AggregationMode.None"/>
+                - or -
+                <paramref name="aggregationMode"/> is not a valid member
+                of the <see cref="T:Microsoft.Performance.SDK.Processing.AggregationMode"/> enumeration.
+                - or -
+                <paramref name="aggregationMode"/> is <see cref="F:Microsoft.Performance.SDK.Processing.AggregationMode.None"/>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection">
+            <summary>
+                Specifies that the projection is sensitive to a currently visible
+                domain, either directly or indirectly.
+                <para/>
+                If the projection itself does not depend on a visible domain,
+                but is composed of projections that do, then the projection
+                should implement this interface and delegate to the composing
+                projections appropriately.
+            </summary>
+            <example>
+                A projection that maps a time range to its percent of the total
+                current visible time range would be sensitive to the visible domain,
+                since when the visible time-domain changes the percentage values must be
+                updated.
+            </example>
+            <remarks>
+                Currently, only <seealso cref="T:Microsoft.Performance.SDK.TimeRange"/>s are supported domains.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection.NotifyVisibleDomainChanged(Microsoft.Performance.SDK.Processing.IVisibleDomainRegion)">
+            <summary>
+                Notifies this instance that the visible domain has been changed, and
+                that data should be recalculated if necessary based on the new
+                domain.
+            </summary>
+            <param name="visibleDomain">
+                The current visible domain.
+            </param>
+            <returns>
+                <c>true</c> if the projection has changed due to the new visible domain,
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="visibleDomain"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection.DependsOnVisibleDomain">
+            <summary>
+                Gets a value indicating whether this instance actually
+                depends on the visible domain.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.MessageType">
+            <summary>
+                Enumerates the message types that can be displayed to the user.
+                See <see cref="M:Microsoft.Performance.SDK.Processing.IApplicationEnvironment.DisplayMessage(Microsoft.Performance.SDK.Processing.MessageType,System.IFormatProvider,System.String,System.Object[])"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.MessageType.Information">
+            <summary>
+                The message is informational.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.MessageType.Warning">
+            <summary>
+                The message is a warning.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.MessageType.Error">
+            <summary>
+                The message is an error.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Option">
+            <summary>
+                Defines an option that is accepted on the command line for a
+                <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Option.#ctor(System.Object,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.Option"/>
+                class.
+            </summary>
+            <param name="id">
+                An identifier for this option.
+            </param>
+            <param name="name">
+                The long name of the option.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="name"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="id"/> is <c>null</c>.
+                - or -
+                <paramref name="name"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Option.#ctor(System.Object,System.String,System.Int32,System.Int32)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.Option"/>
+                class.
+            </summary>
+            <param name="id">
+                An identifier for this option.
+            </param>
+            <param name="name">
+                The long name of the option.
+            </param>
+            <param name="minParam">
+                The minimum number of parameters accepted by the option.
+            </param>
+            <param name="maxParam">
+                The maximum number of parameters accepted by the option.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="name"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="id"/> is <c>null</c>.
+                - or -
+                <paramref name="name"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="minParam"/> is less than zero (0.)
+                - or -
+                <paramref name="maxParam"/> is less than zero (0.)
+                - or -
+                <paramref name="maxParam"/> is less than <paramref name="minParam"/>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.Id">
+            <summary>
+                Gets the id for this option.
+            </summary>
+            <remarks>
+                Any object reference or boxed value type may be supplied. Enumeration values are 
+                usually a good choice.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.Name">
+            <summary>
+                Gets the name for this option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.Description">
+            <summary>
+                Gets or sets a description of this option.
+                This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.Examples">
+            <summary>
+                Gets or sets a collection of examples on how to use this option.
+                This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.ArgumentNames">
+            <summary>
+                Gets or sets names to use for arguments to this option when
+                displayed in a help capacity. This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.IsDeprecated">
+            <summary>
+                Gets or sets a value indicating whether this option is deprecated.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.MinimumParameterCount">
+            <summary>
+                Gets the minimum number of parameters accepted by this option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.Option.MaximumParameterCount">
+            <summary>
+                Gets the maximum number of parameters accepted by this option.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Option.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.OptionExample">
+            <summary>
+                Presents an example of how to use the option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.OptionExample.Argument">
+            <summary>
+                Gets or sets a string that shows how the argument
+                should be presented to the user. If argument is
+                null, then only the option itself is rendered.
+                <example>
+                    --option=argument    
+                </example>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.OptionExample.Description">
+            <summary>
+                Gets or sets a description of the example, if any.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionExample.Equals(Microsoft.Performance.SDK.Processing.OptionExample)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionExample.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionExample.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.OptionInstance">
+            <summary>
+                Represents an instance of an option on the command line.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstance.#ctor(System.Object)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.OptionInstance"/>
+                class.
+            </summary>
+            <param name="optionId">
+                The id of the option.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="optionId"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstance.#ctor(System.Object,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.OptionInstance"/>
+                class.
+            </summary>
+            <param name="optionId">
+                The id of the option.
+            </param>
+            <param name="argument">
+                The argument passed to the option.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="optionId"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstance.#ctor(System.Object,System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.OptionInstance"/>
+                class.
+            </summary>
+            <param name="optionId">
+                The id of the option.
+            </param>
+            <param name="arguments">
+                The arguments passed to the option.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="arguments"/> is <c>null</c>.
+                - or -
+                <paramref name="optionId"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.OptionInstance.Id">
+            <summary>
+                Gets the ID of the option that caused this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.OptionInstance.Arguments">
+            <summary>
+                Gets the arguments provided to this option.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstance.ToString">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.OptionInstanceExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.OptionInstance"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstanceExtensions.IsOptionPresent(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.OptionInstance},System.Object)">
+            <summary>
+                Determines whether the given instance contains the
+                given option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="id">
+                The flag to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="id"/> is present in
+                <paramref name="self"/>; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OptionInstanceExtensions.TryGetOptionArguments(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.OptionInstance},System.Object,System.Collections.Generic.IEnumerable{System.String}@)">
+            <summary>
+                Attempts to get all of the arguments passed to a given
+                option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="id">
+                The option whose arguments are to be retrieved.
+            </param>
+            <param name="arguments">
+                The arguments, if the option is found. If the option
+                exists but there are no arguments, this method will still
+                return <c>true</c> and this parameter will be set to
+                the empty collection.
+            </param>
+            <returns>
+                <c>true</c> if the option was found; <c>false</c>
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsEmbeddedResourceAttribute">
+            <summary>
+            Attribute specifies an embedded resource of prebuilt table configurations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsEmbeddedResourceAttribute.#ctor(System.String)">
+            <summary>
+            Creates an attribute with a given embedded resource path
+            </summary>
+            <param name="resourcePath">
+            Path to an embedded resource file containing serialized table configurations.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsEmbeddedResourceAttribute.EmbeddedResourcePath">
+            <summary>
+            Gets a path to an embedded resource path containing serialized table configurations.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsFilePathAttribute">
+            <summary>
+            Attribute specifies an external resource of prebuilt table configurations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsFilePathAttribute.#ctor(System.String)">
+            <summary>
+            Creates an attribute with a given a file path
+            </summary>
+            <param name="resourcePath">
+            Path to an embedded resource file containing serialized table configurations.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsFilePathAttribute.ExternalResourceFilePath">
+            <summary>
+            Gets a path to a file containing serialized table configurations.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessedEventData`1">
+            <summary>
+            A helper class for building up data without having to reallocate.
+            </summary>
+            <typeparam name="T">Data type to store</typeparam>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.Count">
+            <summary>
+            The number of data elements added.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.System#Collections#Generic#IReadOnlyCollection{T}#Count">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.Item(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.AddEvent(`0)">
+            <summary>
+            Add a data element.
+            </summary>
+            <param name="newEvent">Data element to add.</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.Clear">
+            <summary>
+            Remove all added events.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.FinalizeData">
+            <summary>
+            Prepare data for indexing once all data elements have been added.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.Item(System.UInt32)">
+            <summary>
+            Access data elements through indexing.
+            </summary>
+            <param name="index">Index</param>
+            <returns>Data element</returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessedEventData`1.GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessingSource">
+            <summary>
+                Provides a base class for implementing <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>s that
+                contains default logic for discovering tables, providing their
+                descriptors.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.#ctor(Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>
+                class.
+            </summary>
+            <param name="tableDiscoverer">
+                Object used to provide the tables that are exposed by this <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>.
+            </param>
+            <remarks>
+                All discovered tables will be associated with this <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>. When a consumer
+                requests the Engine to enable or build a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that is in this list, the
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> will be passed into
+                <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.EnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)"/> or
+                <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ITableBuilder)"/> for the
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> returned from
+                <see cref="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessor(Microsoft.Performance.SDK.Processing.IDataSource,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)"/>
+                or
+                <see cref="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessor(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)"/>.
+            </remarks>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="tableDiscoverer"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.DataTables">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.MetadataTables">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.CommandLineOptions">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.PluginOptions">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.AllTables">
+            <summary>
+                Gets a mapping of <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> to the concrete
+                <see cref="T:System.Type" /> of Table described by the descriptor. This
+                mapping includes the data and metadata tables.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.ApplicationEnvironment">
+            <summary>
+                This is set by default when the <see cref="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetApplicationEnvironment(Microsoft.Performance.SDK.Processing.IApplicationEnvironment)"/> is called by the runtime.
+                <seealso cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSource.Logger">
+            <summary>
+                This is set when <see cref="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetLogger(Microsoft.Performance.SDK.Processing.ILogger)"/> is called by the runtime.
+                <seealso cref="T:Microsoft.Performance.SDK.Processing.ILogger"/>
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetApplicationEnvironment(Microsoft.Performance.SDK.Processing.IApplicationEnvironment)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetLogger(Microsoft.Performance.SDK.Processing.ILogger)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.GetAboutInfo">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessor(Microsoft.Performance.SDK.Processing.IDataSource,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessor(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessor(Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.GetSerializationStream(Microsoft.Performance.SDK.Processing.SerializationSource)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.IsDataSourceSupported(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.DisposeProcessor(Microsoft.Performance.SDK.Processing.ICustomDataProcessor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessorCore(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                When implemented in a derived class, creates a new
+                instance implementing <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>
+                to process the specified data sources.
+            </summary>
+            <param name="dataSources">
+                The data sources to be processed by the processor.
+                This parameter is guaranteed to be non-null, and all
+                elements in the collection are guaranteed to be non-null.
+            </param>
+            <param name="processorEnvironment">
+                The environment for this specific processor instance.
+            </param>
+            <param name="options">
+                The options to pass to the processor.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>. It is an error
+                to return <c>null</c> from this method.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateProcessorCore(Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup,Microsoft.Performance.SDK.Processing.IProcessorEnvironment,Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                When implemented in a derived class, creates a new
+                instance implementing <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>
+                to process the specified <paramref name="dataSourceGroup"/>.
+            </summary>
+            <param name="dataSourceGroup">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/> to be processed by the processor.
+                This parameter is guaranteed to be non-null, and all
+                elements in the collection are guaranteed to be non-null.
+            </param>
+            <param name="processorEnvironment">
+                The environment for this specific processor instance.
+            </param>
+            <param name="options">
+                The options to pass to the processor.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/>. It is an error
+                to return <c>null</c> from this method.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                This <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/> implements <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGrouper"/>, but does not override
+                this method.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.IsDataSourceSupportedCore(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                When overridden in a derived class, returns a value indicating whether the
+                given Data Source can be opened by this instance.
+            </summary>
+            <param name="dataSource">
+                The Data Source of interest.
+            </param>
+            <returns>
+                <c>true</c> if this instance can actually process the given Data Source;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetApplicationEnvironmentCore(Microsoft.Performance.SDK.Processing.IApplicationEnvironment)">
+            <summary>
+                A derived class may implement this to perform additional actions when an <see cref="T:Microsoft.Performance.SDK.Processing.IApplicationEnvironment"/>
+                is made available.
+            </summary>
+            <param name="applicationEnvironment">
+                The handle back to the application environment.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.SetLoggerCore(Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                A derived class may implement this to perform additional actions when a logger is made available.
+            </summary>
+            <param name="logger">
+                The <seealso cref="T:Microsoft.Performance.SDK.Processing.ILogger"/> used to log information.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.RefreshTables">
+            <summary>
+                Refreshes the tables expoed by this <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/>. This method
+                will re-run the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> associated with
+                this <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSource"/> and update <see cref="P:Microsoft.Performance.SDK.Processing.ProcessingSource.DataTables"/> and
+                <see cref="P:Microsoft.Performance.SDK.Processing.ProcessingSource.MetadataTables"/> accordingly.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">
+                The application environment has not yet been set.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSource.CreateTableProvider">
+            <summary>
+                A derived class may implement this to provide a custom <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <returns>
+                A table provider for the processing source.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute">
+            <summary>
+                This attribute is used to mark a concrete class as an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.#ctor(System.String,System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute"/>
+                class.
+            </summary>
+            <param name="guid">
+                The unique identifier for this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>. This MAY NOT be
+                the default (empty) <see cref="P:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Guid"/>.
+            </param>
+            <param name="name">
+                The name of this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </param>
+            <param name="description">
+                A user friendly description of this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="guid"/> is whitespace.
+                - or -
+                <paramref name="guid"/> parsed to a value
+                equal to <c>default(Guid)</c>.
+                - or -
+                <paramref name="name"/> is whitespace.
+                - or -
+                <paramref name="description"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="guid"/> is <c>null</c>.
+                - or -
+                <paramref name="name"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Guid">
+            <summary>
+                Gets the unique identifier for this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Name">
+            <summary>
+                Gets the name of this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Description">
+            <summary>
+                Gets the description of this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Equals(Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessingSourceAttribute.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo">
+            <summary>
+                Represents information about an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo.Owners">
+            <summary>
+                Gets or sets the contact information of the owners
+                of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo.ProjectInfo">
+            <summary>
+                Gets or sets the project information of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>, if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo.LicenseInfo">
+            <summary>
+                Gets or sets the license information of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>, if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo.CopyrightNotice">
+            <summary>
+                Gets or sets the copyright notice of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>, if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessingSourceInfo.AdditionalInformation">
+            <summary>
+                Gets or sets any additional information about the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to convey to the user. 
+                Each entry in the array is logically a new paragraph.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ContactInfo">
+            <summary>
+                Represents contact information for an entity.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ContactInfo.Name">
+            <summary>
+                Gets or sets the name of the contact, if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ContactInfo.Address">
+            <summary>
+                Gets or sets the address of the contact, if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ContactInfo.EmailAddresses">
+            <summary>
+                Gets or sets the email address of the contact,
+                if any.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ContactInfo.PhoneNumbers">
+            <summary>
+                Gets or sets the phone numbers of the contact, if any.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.LicenseInfo">
+            <summary>
+                Represents the license information for a <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.LicenseInfo.Name">
+            <summary>
+                Gets or sets the name of the license.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.LicenseInfo.Uri">
+            <summary>
+                Gets or sets the URI where the license text may be found.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.LicenseInfo.Text">
+            <summary>
+                Gets or sets the full text of the license, if desired.
+                This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProjectInfo">
+            <summary>
+                Represents project information about the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProjectInfo.Uri">
+            <summary>
+                Gets or sets the URI to the page for this project.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessorEnvironment">
+            <inheritdoc cref="T:Microsoft.Performance.SDK.Processing.IProcessorEnvironment"/>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessorEnvironment.TableDataSynchronizerFactory">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorEnvironment.CreateLogger(System.Type)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorEnvironment.RequestDynamicTableBuilder(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+            <remarks>
+                This implementation does not support the concept of dynamic table builder and always returns 
+                <c>null</c>.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.IsOptionPresent(Microsoft.Performance.SDK.Processing.ProcessorOptions,Microsoft.Performance.SDK.Processing.Option)">
+            <summary>
+                Determines whether the given instance contains the
+                given option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="flag">
+                The flag to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="flag"/> is present in
+                <paramref name="self"/>; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="flag"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.IsOptionPresent(Microsoft.Performance.SDK.Processing.ProcessorOptions,System.Object)">
+            <summary>
+                Determines whether the given instance contains the
+                given option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="id">
+                The flag to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="id"/> is present in
+                <paramref name="self"/>; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.TryGetOptionArgument(Microsoft.Performance.SDK.Processing.ProcessorOptions,Microsoft.Performance.SDK.Processing.Option,System.String@)">
+            <summary>
+                Attempts to get the argument of a given option.
+                If the option allows for multiple options or the
+                option is not present, then this method will return
+                <c>false</c>.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="option">
+                The option whose argument is to be retrieved.
+            </param>
+            <param name="argument">
+                The argument, if it exists; <c>null</c> otherwise.
+            </param>
+            <returns>
+                <c>true</c> if the argument was found; <c>false</c>
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="option"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.TryGetOptionArgument(Microsoft.Performance.SDK.Processing.ProcessorOptions,System.Object,System.String@)">
+            <summary>
+                Attempts to get the argument of a given option.
+                If the option allows for multiple options or the
+                option is not present, then this method will return
+                <c>false</c>.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="id">
+                The option whose argument is to be retrieved.
+            </param>
+            <param name="argument">
+                The argument, if it exists; <c>null</c> otherwise.
+            </param>
+            <returns>
+                <c>true</c> if the argument was found; <c>false</c>
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="id"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.TryGetOptionArguments(Microsoft.Performance.SDK.Processing.ProcessorOptions,Microsoft.Performance.SDK.Processing.Option,System.Collections.Generic.IEnumerable{System.String}@)">
+            <summary>
+                Attempts to get all of the arguments passed to a given
+                option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="option">
+                The option whose arguments are to be retrieved.
+            </param>
+            <param name="arguments">
+                The arguments, if the option is found. If the option
+                exists but there are no arguments, this method will still
+                return <c>true</c> and this parameter will be set to
+                the empty collection.
+            </param>
+            <returns>
+                <c>true</c> if the option was found; <c>false</c>
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="option"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptionExtensions.TryGetOptionArguments(Microsoft.Performance.SDK.Processing.ProcessorOptions,System.Char,System.Collections.Generic.IEnumerable{System.String}@)">
+            <summary>
+                Attempts to get all of the arguments passed to a given
+                option.
+            </summary>
+            <param name="self">
+                The instance to interrogate.
+            </param>
+            <param name="id">
+                The option whose arguments are to be retrieved.
+            </param>
+            <param name="arguments">
+                The arguments, if the option is found. If the option
+                exists but there are no arguments, this method will still
+                return <c>true</c> and this parameter will be set to
+                the empty collection.
+            </param>
+            <returns>
+                <c>true</c> if the option was found; <c>false</c>
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.ProcessorOptions">
+            <summary>
+                Provides a means of passing options to a data processor.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.ProcessorOptions.Default">
+            <summary>
+                Gets the instance that represents default <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptions.#ctor(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.OptionInstance})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptions.#ctor(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.ProcessorOptions.#ctor(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.OptionInstance},System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/>
+                class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessorOptions.Options">
+            <summary>
+                Gets the collection of options that should be passed
+                to the processor.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.ProcessorOptions.Arguments">
+            <summary>
+                Gets the collection of free arguments that should be
+                passed to the processor.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for creating
+                Projections that are useful in a variety of contexts.
+                <para/>
+                All projections generated by this class properly handle the
+                <see cref="T:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection"/> interface.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.ClipTimeToVisibleDomain">
+            <summary>
+                Creates instances of <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> that are sensitive to the current visible domain.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.ClipTimeToVisibleDomain.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.Timestamp})">
+            <summary>
+                Create a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> projection that is clipped to a
+                <see cref="T:Microsoft.Performance.SDK.Processing.VisibleDomainRegionContainer"/>.
+                See also <seealso cref="T:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection"/>.
+            </summary>
+            <param name="timestampProjection">
+                Original projection.
+            </param>
+            <returns>
+                A visible domain sensitive projection.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.ClipTimeToVisibleDomain.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimeRange})">
+            <summary>
+                Create a <see cref="T:Microsoft.Performance.SDK.TimeRange"/> projection that is clipped to a
+                <see cref="T:Microsoft.Performance.SDK.Processing.VisibleDomainRegionContainer"/>.
+                See also <seealso cref="T:Microsoft.Performance.SDK.Processing.IVisibleDomainSensitiveProjection"/>.
+            </summary>
+            <param name="timeRangeProjection">
+                Original projection.
+            </param>
+            <returns>
+                A visible domain sensitive projection.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.ClipTimeToVisibleDomain.CreatePercent(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimeRange})">
+            <summary>
+                Creates a new percent projection that is defined by the current viewport.
+            </summary>
+            <param name="timeRangeColumn">
+                Original projection.
+            </param>
+            <returns>
+                A viewport sensitive projection.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.IntToDouble">
+            <summary>
+                Helper class containing useful methods for generating projections.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.IntToDouble.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.Int32})">
+            <summary>
+                This will create a projection that typecasts an <see cref="T:System.Int32"/> value to a <see cref="T:System.Double"/>.
+            </summary>
+            <param name="column">
+                Projection that returns an integer.
+            </param>
+            <returns>
+                Projection that returns a double.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.Percent">
+            <summary>
+                Creates instances of <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> that project their values as percentages.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Percent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.Double},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.Double})">
+            <summary>
+                Creates a projector that results in a dividing the value of the numerator projection
+                by the value of the denominator projection.
+            </summary>
+            <param name="numeratorColumn">
+                Numerator projection.
+            </param>
+            <param name="divisorColumn">
+                Denominator projection.
+            </param>
+            <returns>
+                Projection of the computed division.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Percent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimestampDelta},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimestampDelta})">
+            <summary>
+                Creates a projector that results in a dividing the value of the numerator projection
+                by the value of the denominator projection.
+            </summary>
+            <param name="numeratorColumn">
+                Numerator projection.
+            </param>
+            <param name="divisorColumn">
+                Denominator projection.
+            </param>
+            <returns>
+                Projection of the computed division.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Percent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.Int32},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.UInt64})">
+            <summary>
+                Creates a projector that results in a dividing the value of the numerator projection
+                by the value of the denominator projection.
+            </summary>
+            <param name="numeratorColumn">
+                Numerator projection.
+            </param>
+            <param name="divisorColumn">
+                Denominator projection.
+            </param>
+            <returns>
+                Projection of the computed division.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Percent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.UInt64},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.UInt64})">
+            <summary>
+                Creates a projector that results in a dividing the value of the numerator projection
+                by the value of the denominator projection.
+            </summary>
+            <param name="numeratorColumn">
+                Numerator projection.
+            </param>
+            <param name="divisorColumn">
+                Denominator projection.
+            </param>
+            <returns>
+                Projection of the computed division.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.AggregateInVisibleDomain``2(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Creates a projection that projects each value to the aggregate of all
+                of the original projection's data whose domain is within the current
+                visible domain.
+            </summary>
+            <typeparam name="T">
+                The return <see cref="T:System.Type"/> of the projection.
+            </typeparam>
+            <typeparam name="TAggregate">
+                The <see cref="T:System.Type"/> of the aggregated result.
+            </typeparam>
+            <param name="projection">
+                The projection to aggregate.
+            </param>
+            <returns>
+                The new projection.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.CacheOnFirstUse``1(System.Int32,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Creates a projection that caches the results of its
+                computations. The first time the projection is invoked
+                for a given integer will compute the value for that
+                integer, and subsequent invocations with the same integer
+                will always return the cached value.
+            </summary>
+            <typeparam name="T">
+                The return <see cref="T:System.Type"/> of the projection.
+            </typeparam>
+            <param name="rowCount">
+                Defines the domain of the projection. This is the upper
+                bound on the range of integers that can be expected to
+                be passed to the projection. This parameter must be
+                non-negative.
+            </param>
+            <param name="projection">
+                The projection whose results are to be cached.
+            </param>
+            <returns>
+                A new projection that caches the results of 
+                <paramref name="projection"/> on their first use.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="rowCount"/> is less than zero (0.)
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Compose``3(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},System.Func{``1,``2})">
+            <summary>
+                Performs a functional composition of the given projection
+                with another function.
+                <para />
+                Let f(x) and g(x) be projections. Then f.Compose(g) will result
+                in a projection equivalent to g(f(x)).
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the input.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the result of the first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the result of the second projection,
+                and thus the overall newly created projection.
+            </typeparam>
+            <param name="f">
+                The first projection in the composition.
+            </param>
+            <param name="g">
+                The function to compose with <paramref name="f"/>.
+            </param>
+            <returns>
+                A projection that is the composition of <paramref name="f"/>
+                with <paramref name="g"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="f"/> is <c>null</c>.
+                - or -
+                <paramref name="g"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Compose``3(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``1,``2})">
+            <summary>
+                Performs a functional composition of the given projection
+                with another projection.
+                <para />
+                Let f(x) and g(x) be projections. Then f.Compose(g) will result
+                in a projection equivalent to g(f(x)).
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the input.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the result of the first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the result of the second projection,
+                and thus the overall newly created projection.
+            </typeparam>
+            <param name="f">
+                The first projection in the composition.
+            </param>
+            <param name="g">
+                The projection to compose with <paramref name="f"/>.
+            </param>
+            <returns>
+                A projection that is the composition of <paramref name="f"/>
+                with <paramref name="g"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="f"/> is <c>null</c>.
+                - or -
+                <paramref name="g"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Constant``1(``0)">
+            <summary>
+                Creates a projection that always returns the given value,
+                regardless of the input.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of <paramref name="value"/>.
+            </typeparam>
+            <param name="value">
+                The value that should always be returned by the projection.
+            </param>
+            <returns>
+                A projection that always returns <paramref name="value"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.IsConstant``2(Microsoft.Performance.SDK.Processing.IProjection{``0,``1})">
+            <summary>
+                Determines whether the given projection is a constant projection.
+                That is, was the projection created with <see cref="M:Microsoft.Performance.SDK.Processing.Projection.Constant``2(``1)"/>.
+            </summary>
+            <typeparam name="T">
+                The argument <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The result <see cref="T:System.Type"/>.
+            </typeparam>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> to interrogate.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is constant;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Constant``2(``1)">
+            <summary>
+                Creates a projection that always returns the given value,
+                regardless of the input.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of <paramref name="value"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the result.
+            </typeparam>
+            <param name="value">
+                The value that should always be returned by the projection.
+            </param>
+            <returns>
+                A projection that always returns <paramref name="value"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Create``1(System.Func{System.Int32,``0})">
+            <summary>
+                Creates a projection from the given delegate. The given
+                delegate must be a publicly accessible method on a publicly
+                accessible class. If you need to create a projection from 
+                an anonymous method (e.g. a lambda) then use
+                <see cref="M:Microsoft.Performance.SDK.Processing.Projection.CreateUsingFuncAdaptor``1(System.Func{System.Int32,``0})"/>.
+            </summary>
+            <remarks>
+                This method exists for performance reasons. Anonymous methods
+                always have an associated object created for them, and thus
+                using anonymous methods will cause lots of garbage to get created.
+                It is preferable to create one instance of an object that captures
+                the closure for all of the projection functions that you need and
+                create projections from that one instance.
+            </remarks>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> returned by the delegate.
+            </typeparam>
+            <param name="staticGenerator">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="staticGenerator"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="staticGenerator"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="staticGenerator"/> does not represent
+                a publicly accessible method on a publicly accessible class.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Create``2(System.Func{``0,``1})">
+            <summary>
+                Creates a projection from the given delegate. The given
+                delegate must be a publicly accessible method on a publicly
+                accessible class. If you need to create a projection from 
+                an anonymous method (e.g. a lambda) then use
+                <see cref="M:Microsoft.Performance.SDK.Processing.Projection.CreateUsingFuncAdaptor``2(System.Func{``0,``1})"/>.
+            </summary>
+            <remarks>
+                This method exists for performance reasons. Anonymous methods
+                always have an associated object created for them, and thus
+                using anonymous methods will cause lots of garbage to get created.
+                It is preferable to create one instance of an object that captures
+                the closure for all of the projection functions that you need and
+                create projections from that one instance.
+            </remarks>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> taken as an argument to the delegate.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> returned by the delegate.
+            </typeparam>
+            <param name="staticGenerator">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="staticGenerator"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="staticGenerator"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="staticGenerator"/> does not represent
+                a publicly accessible method on a publicly accessible class.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.CreateUsingFuncAdaptor``1(System.Func{System.Int32,``0})">
+            <summary>
+                Creates a projection from the given delegate.
+                Please see the remarks on <see cref="M:Microsoft.Performance.SDK.Processing.Projection.Create``1(System.Func{System.Int32,``0})"/>
+                for performance considerations.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> returned by the delegate.
+            </typeparam>
+            <param name="staticGenerator">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="staticGenerator"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="staticGenerator"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.CreateUsingFuncAdaptor``2(System.Func{``0,``1})">
+            <summary>
+                Creates a projection from the given delegate.
+                Please see the remarks on <see cref="M:Microsoft.Performance.SDK.Processing.Projection.Create``2(System.Func{``0,``1})"/>
+                for performance considerations.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> taken as an argument to the delegate.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> returned by the delegate.
+            </typeparam>
+            <param name="func">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="func"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="func"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Create``1(Microsoft.Performance.SDK.IFunc{System.Int32,``0})">
+            <summary>
+                Creates a projection from the given <see cref="T:Microsoft.Performance.SDK.IFunc`2"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> returned by the delegate.
+            </typeparam>
+            <param name="staticGenerator">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="staticGenerator"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="staticGenerator"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Create``2(Microsoft.Performance.SDK.IFunc{``0,``1})">
+            <summary>
+                Creates a projection from the given <see cref="T:Microsoft.Performance.SDK.IFunc`2"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of the delegate's argument.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> returned by the projection.
+            </typeparam>
+            <param name="staticGenerator">
+                The delegate to convert to a projection.
+            </param>
+            <returns>
+                A projection representing <paramref name="staticGenerator"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="staticGenerator"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Identity``1">
+            <summary>
+                Returns a projection representing the identity operation.
+                The created projection simply returns its argument.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> being projection.
+            </typeparam>
+            <returns>
+                A projection equivalent to the identity function.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Index``1(System.Collections.Generic.IReadOnlyList{``0})">
+            <summary>
+                Creates a projection representing the operation of indexing
+                into the given <see cref="T:System.Collections.Generic.IReadOnlyList`1"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data in the <see cref="T:System.Collections.Generic.IReadOnlyList`1"/>.
+            </typeparam>
+            <param name="data">
+                The <see cref="T:System.Collections.Generic.IReadOnlyList`1"/> to be indexed.
+            </param>
+            <returns>
+                A projection that indexes into <paramref name="data"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="data"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.PrepopulatedCache``1(System.Int32,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Creates a projection that caches the results of its
+                computations. The entire domain of the projection is
+                evaluated and cached upon creation. Subsequent
+                invocations of the projection will result in their
+                cached value.
+            </summary>
+            <typeparam name="T">
+                The return <see cref="T:System.Type"/> of the projection.
+            </typeparam>
+            <param name="rowCount">
+                Defines the domain of the projection. This is the upper
+                bound on the range of integers that can be expected to
+                be passed to the projection. This parameter must be
+                non-negative.
+            </param>
+            <param name="projection">
+                The projection whose results are to be cached.
+            </param>
+            <returns>
+                A new projection that caches the results of 
+                <paramref name="projection"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="rowCount"/> is less than zero (0.)
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``2(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.StaticFunc{``0,``1})">
+            <summary>
+                Projects the results of one (1) projections using
+                a static function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B and g: A -> C
+                <para />
+                Let h(x, y) be a static method with x e B and y e C,
+                so h: (B, C) -> D
+                <para />
+                Then this method creates p(x), p : A -> D
+                such that p(x) = h(f(x), g(x)).
+            </summary>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``3(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.StaticFunc{``1,``2})">
+            <summary>
+                Projects the results of one (1) projections using
+                a static function.
+            </summary>
+            <typeparam name="A">
+                The initial input <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``3(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.StaticFunc{``0,``1,``2})">
+            <summary>
+                Projects the results of two (2) projections using
+                a static function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B and g: A -> C
+                <para />
+                Let h(x, y) be a static method with x e B and y e C,
+                so h: (B, C) -> D
+                <para />
+                Then this method creates p(x), p : A -> D
+                such that p(x) = h(f(x), g(x)).
+            </summary>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/> and <paramref name="projection2"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``4(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``0,``2},Microsoft.Performance.SDK.StaticFunc{``1,``2,``3})">
+            <summary>
+                Projects the results of two (2) projections using
+                a static function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B and g: A -> C
+                <para />
+                Let h(x, y) be a static method with x e B and y e C,
+                so h: (B, C) -> D
+                <para />
+                Then this method creates p(x), p : A -> D
+                such that p(x) = h(f(x), g(x)).
+            </summary>
+            <typeparam name="A">
+                The initial input <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/> and <paramref name="projection2"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``4(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``2},Microsoft.Performance.SDK.StaticFunc{``0,``1,``2,``3})">
+            <summary>
+                Projects the results of three (3) projections using
+                a static function.
+                <para />
+                Let f(x), g(x), and h(x) be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D
+                <para />
+                Let k(x, y, z) be a static method with x e B, y e C,
+                and z e D so k: (B, C, D) -> E
+                <para />
+                Then this method creates p(x), p : A -> E
+                such that p(x) = k(f(x), g(x), h(x)).
+            </summary>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                and <paramref name="projection3"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``5(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``0,``2},Microsoft.Performance.SDK.Processing.IProjection{``0,``3},Microsoft.Performance.SDK.StaticFunc{``1,``2,``3,``4})">
+            <summary>
+                Projects the results of three (3) projections using
+                a static function.
+                <para />
+                Let f(x), g(x), and h(x) be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D
+                <para />
+                Let k(x, y, z) be a static method with x e B, y e C,
+                and z e D so k: (B, C, D) -> E
+                <para />
+                Then this method creates p(x), p : A -> E
+                such that p(x) = k(f(x), g(x), h(x)).
+            </summary>
+            <typeparam name="A">
+                The initial input <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                and <paramref name="projection3"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``5(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``2},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``3},Microsoft.Performance.SDK.StaticFunc{``0,``1,``2,``3,``4})">
+            <summary>
+                Projects the results of four (4) projections using
+                a static function.
+                <para />
+                Let f(x), g(x), h(x), and k(x) be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D ; k : A -> E
+                <para />
+                Let m(x, y, z, a) be a static method with x e B, y e C,
+                z e D, and a e E so k: (B, C, D, E) -> F
+                <para />
+                Then this method creates p(x), p : A -> F
+                such that p(x) = m(f(x), g(x), h(x), k(x)).
+            </summary>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="E">
+                The <see cref="T:System.Type"/> of result returned by the
+                fourth projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="projection4">
+                The fourth projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                <paramref name="projection3"/>, <paramref name="projection4"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="projection4"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Project``6(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``0,``2},Microsoft.Performance.SDK.Processing.IProjection{``0,``3},Microsoft.Performance.SDK.Processing.IProjection{``0,``4},Microsoft.Performance.SDK.StaticFunc{``1,``2,``3,``4,``5})">
+            <summary>
+                Projects the results of four (4) projections using
+                a static function.
+                <para />
+                Let f(x), g(x), h(x), and k(x) be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D ; k : A -> E
+                <para />
+                Let m(x, y, z, a) be a static method with x e B, y e C,
+                z e D, and a e E so k: (B, C, D, E) -> F
+                <para />
+                Then this method creates p(x), p : A -> F
+                such that p(x) = m(f(x), g(x), h(x), k(x)).
+            </summary>
+            <typeparam name="A">
+                The <see cref="T:System.Type"/> of input into the projection.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="E">
+                The <see cref="T:System.Type"/> of result returned by the
+                fourth projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="projection4">
+                The fourth projection.
+            </param>
+            <param name="projector">
+                The static method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                <paramref name="projection3"/>, <paramref name="projection4"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="projection4"/> is <c>null</c>.
+                - or -
+                <paramref name="projector"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="projector"/> is not static.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``2(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},System.Func{System.Int32,``0,``1})">
+            <summary>
+                Selects the results of one (1) projection along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) be a projection, with f: A -> B
+                <para />
+                Let g(i, x) be a function with i e A, x e B, so g: (A, B) -> C
+                <para />
+                Then this method creates p(x), p : A -> C
+                such that p(x) = g(x, f(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``2(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.IFunc{System.Int32,``0,``1})">
+            <summary>
+                Selects the results of one (1) projection along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) be a projection, with f: A -> B
+                <para />
+                Let g(i, x) be a function with i e A, x e B, so g: (A, B) -> C
+                <para />
+                Then this method creates p(x), p : A -> C
+                such that p(x) = g(x, f(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``3(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.IFunc{``0,``1,``2})">
+            <summary>
+                Selects the results of one (1) projection along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) be a projection, with f: A -> B
+                <para />
+                Let g(i, x) be a function with i e A, x e B, so g: (A, B) -> C
+                <para />
+                Then this method creates p(x), p : A -> C
+                such that p(x) = g(x, f(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="A">
+                The <see cref="T:System.Type"/> of input.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``3(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},System.Func{System.Int32,``0,``1,``2})">
+            <summary>
+                Selects the results of two (2) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B ; g: A -> C
+                <para />
+                Let m(i, x, y) be a function with i e A, x e B, y e C,
+                and so m: (A, B, C) -> E
+                <para />
+                Then this method creates p(x), p : A -> E
+                such that p(x) = m(x, f(x), g(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/> and <paramref name="projection2"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``3(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.IFunc{System.Int32,``0,``1,``2})">
+            <summary>
+                Selects the results of two (2) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B ; g: A -> C
+                <para />
+                Let m(i, x, y) be a function with i e A, x e B, y e C,
+                and so m: (A, B, C) -> E
+                <para />
+                Then this method creates p(x), p : A -> E
+                such that p(x) = m(x, f(x), g(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/> and <paramref name="projection2"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``4(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``0,``2},Microsoft.Performance.SDK.IFunc{``0,``1,``2,``3})">
+            <summary>
+                Selects the results of two (2) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x) and g(x) be projections, with
+                f: A -> B ; g: A -> C
+                <para />
+                Let m(i, x, y) be a function with i e A, x e B, y e C,
+                and so m: (A, B, C) -> E
+                <para />
+                Then this method creates p(x), p : A -> E
+                such that p(x) = m(x, f(x), g(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="A">
+                The <see cref="T:System.Type"/> of input.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/> and <paramref name="projection2"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``4(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``2},System.Func{System.Int32,``0,``1,``3})">
+            <summary>
+                Selects the results of three (3) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x), g(x), and h(x) be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D
+                <para />
+                Let m(i, x, y, z) be a function with i e A, x e B, y e C,
+                z e D, and so m: (A, B, C, D) -> F
+                <para />
+                Then this method creates p(x), p : A -> F
+                such that p(x) = m(x, f(x), g(x), h(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                and <paramref name="projection3"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``4(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``1},Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``2},Microsoft.Performance.SDK.IFunc{System.Int32,``0,``1,``2,``3})">
+            <summary>
+                Selects the results of three (3) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x), g(x), h(x), be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D ; k : A -> E
+                <para />
+                Let m(i, x, y, z) be a function with i e A, x e B, y e C,
+                z e D, and so m: (A, B, C, D) -> F
+                <para />
+                Then this method creates p(x), p : A -> F
+                such that p(x) = m(x, f(x), g(x), h(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                and <paramref name="projection3"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.Select``5(Microsoft.Performance.SDK.Processing.IProjection{``0,``1},Microsoft.Performance.SDK.Processing.IProjection{``0,``2},Microsoft.Performance.SDK.Processing.IProjection{``0,``3},Microsoft.Performance.SDK.IFunc{``0,``1,``2,``3,``4})">
+            <summary>
+                Selects the results of three (3) projections along with
+                the initial integer argument using the given combination
+                function.
+                <para />
+                Let f(x), g(x), h(x), be projections, with
+                f: A -> B ; g: A -> C ; h: A -> D ; k : A -> E
+                <para />
+                Let m(i, x, y, z) be a function with i e A, x e B, y e C,
+                z e D, and so m: (A, B, C, D) -> F
+                <para />
+                Then this method creates p(x), p : A -> F
+                such that p(x) = m(x, f(x), g(x), h(x)).
+            </summary>
+            <remarks>
+                Use the Select methods when your function needs access to
+                the original integer argument; use Project otherwise.
+            </remarks>
+            <typeparam name="A">
+                The <see cref="T:System.Type"/> of input.
+            </typeparam>
+            <typeparam name="B">
+                The <see cref="T:System.Type"/> of result returned by the
+                first projection.
+            </typeparam>
+            <typeparam name="C">
+                The <see cref="T:System.Type"/> of result returned by the
+                second projection.
+            </typeparam>
+            <typeparam name="D">
+                The <see cref="T:System.Type"/> of result returned by the
+                third projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the final projection.
+            </typeparam>
+            <param name="projection1">
+                The first projection.
+            </param>
+            <param name="projection2">
+                The second projection.
+            </param>
+            <param name="projection3">
+                The third projection.
+            </param>
+            <param name="selector">
+                The method defining how to project the results
+                of <paramref name="projection1"/>, <paramref name="projection2"/>,
+                and <paramref name="projection3"/>.
+            </param>
+            <returns>
+                A projection that projects the results of the given projections.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="projection1"/> is <c>null</c>.
+                - or -
+                <paramref name="projection2"/> is <c>null</c>.
+                - or -
+                <paramref name="projection3"/> is <c>null</c>.
+                - or -
+                <paramref name="selector"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.TimestampDeltaToDouble">
+            <summary>
+                Helper class containing useful methods for generating projections.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.TimestampDeltaToDouble.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimestampDelta})">
+            <summary>
+                Creates a projection that returns the TimestampDelta in nanoseconds as a <see cref="T:System.Double"/>.
+            </summary>
+            <param name="column">
+                Projection that returns a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </param>
+            <returns>
+                Projection that returns a nanosecond count as a double.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.UlongToDouble">
+            <summary>
+                Helper class containing useful methods for generating projections.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.UlongToDouble.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.UInt64})">
+            <summary>
+                This will create a projection that typecasts a <see cref="T:System.UInt64"/> value to a <see cref="T:System.Double"/>.
+            </summary>
+            <param name="column">
+                Projection that returns an integer.
+            </param>
+            <returns>
+                Projection that returns a double.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.Projection.VisibleDomainRelativePercent">
+            <summary>
+                Helper class containing useful methods for generating projections.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.VisibleDomainRelativePercent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,Microsoft.Performance.SDK.TimestampDelta})">
+            <summary>
+                Creates a projection that returns the percentage of the visible time consumed by this
+                <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+            <param name="timestampDeltaColumn">
+                Timestamp delta.
+            </param>
+            <returns>
+                Percent of time consumed by the given delta in a given visible domain.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.Projection.VisibleDomainRelativePercent.Create(Microsoft.Performance.SDK.Processing.IProjection{System.Int32,System.Double})">
+            <summary>
+                Creates a projection that maps a percentage relative to an entire domain to a percentage
+                relative to the current visible domain.
+            </summary>
+            <param name="percentColumn">
+                Percentage projection returning a double.
+            </param>
+            <returns>
+                Percentage relative to a given visible domain.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.RequiresCompositeCookerAttribute">
+            <summary>
+                This attribute is used on a class with static properties that return <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>
+                or on individual <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> static properties to indicate that a 
+                table described by the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> requires the identified composite data cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.RequiresCompositeCookerAttribute.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.RequiresCompositeCookerAttribute"/>
+                class.
+            </summary>
+            <param name="dataCookerId">
+                The ID of the composite data cooker.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="dataCookerId"/> is empty or composed only of whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataCookerId"/> is null.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.RequiresCompositeCookerAttribute.RequiredDataCookerPath">
+            <summary>
+                Gets the path to a required data cooker for the given table.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.RequiresSourceCookerAttribute">
+            <summary>
+                This attribute is used on a class with static properties that return <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>
+                or on individual <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> static properties to indicate that a 
+                table described by the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> requires the identified source data cooker.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.RequiresSourceCookerAttribute.#ctor(System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.RequiresSourceCookerAttribute"/>
+                class.
+            </summary>
+            <param name="sourceParserId">
+                The ID of the source parser.
+            </param>
+            <param name="dataCookerId">
+                The ID of the data cooker.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                One or more of the parameters is empty or composed only of whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                One or more of the parameters is null.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.RequiresSourceCookerAttribute.RequiredDataCookerPath">
+            <summary>
+                Gets the path to a required data cooker for the given table.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.SelectedTableRow">
+            <summary>
+                Represents a row selected by the user at the time a table command is invoked.
+                <para/>
+                A selected row is identified by its top-level <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex"/> in the table.
+                When the row belongs to (or expands into) an <see cref="T:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1"/>,
+                the specific expansion(s) selected within that row are described by
+                <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.SubRowIndices"/>. An empty <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.SubRowIndices"/> means the
+                top-level row itself is selected, with no sub-row expansion.
+            </summary>
+            <param name="RowIndex">
+                The zero-based index of the selected row in the table.
+            </param>
+            <param name="SubRowIndices">
+                The zero-based indices of the selected sub-rows within the expanded
+                hierarchical column of <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex"/>. May be empty if the top-level
+                row itself is selected. Never <c>null</c>; a <c>null</c> value passed to the
+                constructor is normalized to an empty list.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.SelectedTableRow.#ctor(System.Int32,System.Collections.Generic.IReadOnlyList{System.Int32})">
+            <summary>
+                Represents a row selected by the user at the time a table command is invoked.
+                <para/>
+                A selected row is identified by its top-level <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex"/> in the table.
+                When the row belongs to (or expands into) an <see cref="T:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1"/>,
+                the specific expansion(s) selected within that row are described by
+                <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.SubRowIndices"/>. An empty <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.SubRowIndices"/> means the
+                top-level row itself is selected, with no sub-row expansion.
+            </summary>
+            <param name="RowIndex">
+                The zero-based index of the selected row in the table.
+            </param>
+            <param name="SubRowIndices">
+                The zero-based indices of the selected sub-rows within the expanded
+                hierarchical column of <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex"/>. May be empty if the top-level
+                row itself is selected. Never <c>null</c>; a <c>null</c> value passed to the
+                constructor is normalized to an empty list.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex">
+            <summary>
+                The zero-based index of the selected row in the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.SubRowIndices">
+            <summary>
+                The zero-based indices of the selected sub-rows within the expanded
+                hierarchical column of <see cref="P:Microsoft.Performance.SDK.Processing.SelectedTableRow.RowIndex"/>. Never <c>null</c>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.SelectedTableRow.#ctor(System.Int32)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.SelectedTableRow"/> record
+                representing a selection of the top-level row only, with no sub-row expansion.
+            </summary>
+            <param name="rowIndex">
+                The zero-based index of the selected row in the table.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.SortOrder">
+            <summary>
+                Enumerates the different ways to sort a column.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SortOrder.None">
+            <summary>
+                Do not sort.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SortOrder.Ascending">
+            <summary>
+                Sort values in ascending order.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SortOrder.Descending">
+            <summary>
+                Sort values in descending order.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SortOrder.Ascending_Abs">
+            <summary>
+                Sort values in ascending order based on
+                the absolute values.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.SortOrder.Descending_Abs">
+            <summary>
+                Sort values in descending order based on
+                the absolute values.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.SortOrderExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.SortOrder"/> values.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.SortOrderExtensions.Reverse(Microsoft.Performance.SDK.Processing.SortOrder)">
+            <summary>
+                Given a sort order, returns the sort order that is the
+                logical reverse.
+            </summary>
+            <param name="sortOrder">
+                The sort order to examine.
+            </param>
+            <returns>
+                The logical reverse of the given sort order.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.SortOrderExtensions.SwitchAbs(Microsoft.Performance.SDK.Processing.SortOrder)">
+            <summary>
+                Toggles whether a given sort order is sensitive to absolute
+                value.
+            </summary>
+            <param name="sortOrder">
+                The sort order to interrogate.
+            </param>
+            <returns>
+                The new sort order.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.StreamingData`1">
+            <summary>
+            A helper class for streaming data cookers.
+            </summary>
+            <typeparam name="T">Type of data element produced by the data cooker.</typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.StreamingData`1.Subscribe(System.Action{`0})">
+            <summary>
+            Subscribe to the data cooker to receive callbacks for each data element produced.
+            </summary>
+            <param name="dataElementCallback">Callback to receive data elements.</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.StreamingData`1.Unsubscribe(System.Action{`0})">
+            <summary>
+            Unsubscribe to the data cooker to stop receiving callbacks for each data element produced.
+            </summary>
+            <param name="dataElementCallback">Previously subscribed callback.</param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.StreamingData`1.AddElement(`0)">
+            <summary>
+            Called to distribute the data element to any listeners.
+            </summary>
+            <param name="element">Data element</param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableAttribute">
+            <summary>
+                Denotes a class as implementing a data table.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableAttribute.DefaultTableDescriptorPropertyName">
+            <summary>
+                The default name of the static class property which returns the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableAttribute.DefaultTableBuilderMethodName">
+            <summary>
+                The default name of the static class method which builds a table.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableAttribute.DefaultIsDataAvailableMethodName">
+            <summary>
+                The default name of the static class method which checks if a table has data.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableAttribute.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableAttribute.#ctor(System.String,System.String,System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> class.
+            </summary>
+            <param name="tableDescriptorPropertyName">
+                Name of the static class property which returns the
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>
+            </param>
+            <param name="buildTableActionMethodName">
+                The name of the static class method which builds a table.
+                This method must have the following signature:
+                <code>
+                    void BuildTable(<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>)
+                </code>
+            </param>
+            <param name="isDataAvailableMethodName">
+                The name of the static class method which checks if the table has data.
+                This method must have the following signature:
+                <code>
+                    bool IsDataAvailable(<see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>)
+                </code>
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableAttribute.TableDescriptorPropertyName">
+            <summary>
+                The name of the static class property which returns the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableAttribute.BuildTableActionMethodName">
+            <summary>
+                The name of the static class method which builds a table.
+                BuildTable(Action&lt;ITableBuilder, IDataExtensionRetrieval&gt;)
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableAttribute.IsDataAvailableMethodName">
+            <summary>
+                The name of the static class method which checks if the table has data.
+                IsDataAvailable(IDataExtensionRetrieval)
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableBuilderExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/> and <see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.AddColumn``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Adds a new column to the builder with the given
+                configuration and projection.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being projected.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="column">
+                The column configuration the added column is to have.
+            </param>
+            <param name="projection">
+                The projection the added column is to have.
+            </param>
+            <returns>
+                The builder instance.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="column"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.AddColumnWithVariants``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a new column to the builder with the given
+                configuration and projection. The added column
+                can be configured with multiple variants using the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder"/> passed
+                to <paramref name="variantsBuilder"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being projected.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="column">
+                The column configuration the added column is to have.
+            </param>
+            <param name="projection">
+                The projection the added column is to have.
+            </param>
+            <param name="variantsBuilder">
+                The builder that can be used to add variants to the column.
+            </param>
+            <returns>
+                The builder instance.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="column"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.AddHierarchicalColumn``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{``0})">
+            <summary>
+                Adds a new hierarchical column to the builder with the given
+                configuration, projection, and info providers.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being projected.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="column">
+                The column configuration the added column is to have.
+            </param>
+            <param name="projection">
+                The projection the added column is to have.
+            </param>
+            <param name="collectionProvider">
+                The collection provider for the column.
+            </param>
+            <returns>
+                The builder instance.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="collectionProvider"/> is <c>null</c>.
+                - or -
+                <paramref name="column"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.AddHierarchicalColumnWithVariants``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,Microsoft.Performance.SDK.Processing.ColumnConfiguration,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0},Microsoft.Performance.SDK.Processing.ICollectionInfoProvider{``0},System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <summary>
+                Adds a new hierarchical column to the builder with the given
+                configuration, projection, and info providers. The added column
+                can be configured with multiple variants using the <see cref="T:Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder"/> passed
+                to <paramref name="variantsBuilder"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being projected.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="column">
+                The column configuration the added column is to have.
+            </param>
+            <param name="projection">
+                The projection the added column is to have.
+            </param>
+            <param name="collectionProvider">
+                The collection provider for the column.
+            </param>
+            <param name="variantsBuilder">
+                The builder that can be used to add variants to the column.
+            </param>
+            <returns>
+                The builder instance.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="collectionProvider"/> is <c>null</c>.
+                - or -
+                <paramref name="column"/> is <c>null</c>.
+                - or -
+                <paramref name="projection"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.GetColumnOrNull``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,System.String)">
+            <summary>
+                Tries to get the column with the given name from the builder,
+                if the builder has a column with the given name.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data projected by the column.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="columnName">
+                The name of the column to retrieve.
+            </param>
+            <returns>
+                The column, if it exists; <c>null</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.GetColumnOrNull``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,System.Guid)">
+            <summary>
+                Tries to get the column with the given <see cref="T:System.Guid"/> from the builder,
+                if the builder has a column with the given <see cref="T:System.Guid"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data projected by the column.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="columnGuid">
+                The <see cref="T:System.Guid"/> of the column to retrieve.
+            </param>
+            <returns>
+                The column, if it exists; <c>null</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.GetColumnOrNull``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,System.Func{Microsoft.Performance.SDK.Processing.IDataColumn{``0},System.Boolean})">
+            <summary>
+                Tries to get the column that satisfies the given predicate from the builder.
+                This method will return the first column found that matches the predicate.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data projected by the column.
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="predicate">
+                The predicate to use to search for columns.
+            </param>
+            <returns>
+                The column, if it exists; <c>null</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+                - or -
+                <paramref name="predicate"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableBuilderExtensions.ReplaceColumn``1(Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount,Microsoft.Performance.SDK.Processing.IDataColumn,Microsoft.Performance.SDK.Processing.IProjection{System.Int32,``0})">
+            <summary>
+                Replaces the column in the builder with a new column
+                using the given projection. The current columns configuration
+                is used on the new column. If the old column does not exist,
+                then a new column is simply added.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data in the column
+            </typeparam>
+            <param name="self">
+                The builder instance.
+            </param>
+            <param name="old">
+                The column to replace.
+            </param>
+            <param name="newProjection">
+                The projection that the replacement column should have.
+            </param>
+            <returns>
+                The builder instance.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="newProjection"/> is <c>null</c>.
+                - or -
+                <paramref name="old"/> is <c>null</c>.
+                - or -
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableCommandCallback">
+            <summary>
+                Represents a function to be called when the user executes a command
+                against a table. For example, in the UI, users can invoke table commands
+                by right clicking the table and selecting the command from the context
+                menu. See <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand(System.String,Microsoft.Performance.SDK.Processing.TableCommandCallback)"/>.
+            </summary>
+            <param name="selectedRows">
+                The rows that are selected by the user at the time the command is invoked.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableCommandCallback2">
+            <summary>
+                Represents an asynchronous function to be called when the user executes a
+                command against a table registered via
+                <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)"/>.
+            </summary>
+            <param name="context">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandContext2"/> describing the invocation, including the
+                selected rows and sub-rows.
+            </param>
+            <param name="cancellationToken">
+                A <see cref="T:System.Threading.CancellationToken"/> that the host may signal to request that
+                the command abort.
+            </param>
+            <returns>
+                A <see cref="T:System.Threading.Tasks.Task`1"/> that resolves to a <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandResult"/>
+                describing the outcome of the command. Callbacks that do not need to return a
+                value should return <see cref="P:Microsoft.Performance.SDK.Processing.VoidTableCommandResult.Instance"/>.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableCommandContext">
+            <summary>
+                Context for the execution of a table command.
+            </summary>
+            <param name="Column">
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </param>
+            <param name="Configuration">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time the command was invoked.
+                This value may be <c>null</c>.
+            </param>
+            <param name="SelectedRows">
+                The rows that are selected by the user at the time the command is invoked.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableCommandContext.#ctor(System.Nullable{System.Guid},Microsoft.Performance.SDK.Processing.TableConfiguration,System.Collections.Generic.IReadOnlyList{System.Int32})">
+            <summary>
+                Context for the execution of a table command.
+            </summary>
+            <param name="Column">
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </param>
+            <param name="Configuration">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time the command was invoked.
+                This value may be <c>null</c>.
+            </param>
+            <param name="SelectedRows">
+                The rows that are selected by the user at the time the command is invoked.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext.Column">
+            <summary>
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext.Configuration">
+            <summary>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time the command was invoked.
+                This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext.SelectedRows">
+            <summary>
+                The rows that are selected by the user at the time the command is invoked.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableCommandContext2">
+            <summary>
+                Context for the execution of a table command registered via
+                <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)"/>.
+                <para/>
+                Unlike <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandContext"/>, the selected rows are described by
+                <see cref="T:Microsoft.Performance.SDK.Processing.SelectedTableRow"/> values, which also carry any sub-row indices
+                selected within an expanded <see cref="T:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1"/>.
+            </summary>
+            <param name="Column">
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </param>
+            <param name="Configuration">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time
+                the command was invoked. This value may be <c>null</c>.
+            </param>
+            <param name="SelectedRows">
+                The rows that are selected by the user at the time the command is invoked.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableCommandContext2.#ctor(System.Nullable{System.Guid},Microsoft.Performance.SDK.Processing.TableConfiguration,System.Collections.Generic.IReadOnlyList{Microsoft.Performance.SDK.Processing.SelectedTableRow})">
+            <summary>
+                Context for the execution of a table command registered via
+                <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)"/>.
+                <para/>
+                Unlike <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandContext"/>, the selected rows are described by
+                <see cref="T:Microsoft.Performance.SDK.Processing.SelectedTableRow"/> values, which also carry any sub-row indices
+                selected within an expanded <see cref="T:Microsoft.Performance.SDK.Processing.IHierarchicalDataColumn`1"/>.
+            </summary>
+            <param name="Column">
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </param>
+            <param name="Configuration">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time
+                the command was invoked. This value may be <c>null</c>.
+            </param>
+            <param name="SelectedRows">
+                The rows that are selected by the user at the time the command is invoked.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext2.Column">
+            <summary>
+                The <see cref="T:System.Guid"/> of the column that the command was invoked on.
+                This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext2.Configuration">
+            <summary>
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/> of the table that was applied at the time
+                the command was invoked. This value may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableCommandContext2.SelectedRows">
+            <summary>
+                The rows that are selected by the user at the time the command is invoked.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.OpenUrisTableCommandResult">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandResult"/> that instructs the host to open one or
+                more <see cref="T:System.Uri"/>s on the plugin's behalf. The interpretation of each
+                <see cref="T:System.Uri"/> (for example, launching a web browser for <c>http(s)</c>
+                URIs, opening a file for <c>file</c> URIs, or handing off to a registered
+                custom scheme handler) is left to the host.
+            </summary>
+            <param name="Uris">
+                The <see cref="T:System.Uri"/>s to open. Must not be <c>null</c>.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.OpenUrisTableCommandResult.#ctor(System.Collections.Generic.IReadOnlyList{System.Uri})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.OpenUrisTableCommandResult"/>
+                record.
+            </summary>
+            <param name="Uris">
+                The <see cref="T:System.Uri"/>s to open. Must not be <c>null</c>.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="Uris"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.OpenUrisTableCommandResult.Uris">
+            <summary>
+                Gets the <see cref="T:System.Uri"/>s the host should open.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableCommandResult">
+            <summary>
+                Base type for the result of a table command executed via
+                <see cref="M:Microsoft.Performance.SDK.Processing.ITableBuilder.AddTableCommand3(System.String,System.Predicate{Microsoft.Performance.SDK.Processing.TableCommandContext2},Microsoft.Performance.SDK.Processing.TableCommandCallback2)"/>.
+                <para/>
+                Concrete result types are defined by the SDK (for example
+                <see cref="T:Microsoft.Performance.SDK.Processing.VoidTableCommandResult"/> and <see cref="T:Microsoft.Performance.SDK.Processing.OpenUrisTableCommandResult"/>).
+                Hosts inspect the returned <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandResult"/> to decide what
+                follow-up action, if any, to perform on the plugin's behalf.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.VoidTableCommandResult">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandResult"/> that carries no value. Use this when a
+                table command completes without needing to return any information to the host.
+                <para/>
+                Prefer the shared <see cref="P:Microsoft.Performance.SDK.Processing.VoidTableCommandResult.Instance"/> singleton to avoid allocations.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.VoidTableCommandResult.Instance">
+            <summary>
+                Gets the shared <see cref="T:Microsoft.Performance.SDK.Processing.VoidTableCommandResult"/> instance.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableConfiguration">
+            <summary>
+                Represents the configuration of table. The configuration is how the columns
+                should be arranged and other details in regards to the display / presentation
+                of the data in the table.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableConfiguration.PivotColumn">
+            <summary>
+                Columns to the left of this column will be pivoted.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphColumn">
+            <summary>
+                Columns to the right of this column will be graphed.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableConfiguration.LeftFreezeColumn">
+            <summary>
+                Columns to the left of this column will be frozen in place during horizontal scrolling.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableConfiguration.RightFreezeColumn">
+            <summary>
+                Columns to the right of this column will be frozen in place during horizontal scrolling.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableConfiguration.AllMetadataColumns">
+            <summary>
+                Gets all of the available metadata columns. See <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.PivotColumn"/>,
+                <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphColumn"/>, <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.LeftFreezeColumn"/>, and <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.RightFreezeColumn"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfiguration.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfiguration.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/>
+                class.
+            <param name="name">Identifies the table configuration.</param>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.Name">
+            <summary>
+                Gets or sets the name of this configuration.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.ChartType">
+            <summary>
+                Gets or sets the type of chart displayed for this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.AggregationOverTime">
+            <summary>
+                Gets or sets the aggregation over time mode for this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialFilterQuery">
+            <summary>
+                Gets or sets the query for initial filtering in this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialExpansionQuery">
+            <summary>
+                Gets or sets the query for initial expansion in this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialSelectionQuery">
+            <summary>
+                Gets or sets the query for initial selection in this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialFilterShouldKeep">
+            <summary>
+                Get or sets whether rows that satisfy <see cref="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialFilterQuery"/> should be
+                kept or removed from the table (i.e. whether <see cref="P:Microsoft.Performance.SDK.Processing.TableConfiguration.InitialFilterQuery"/> is a
+                "filter-in" or "filter-out" filter). Defaults to <c>true</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphFilterTopValue">
+            <summary>
+                Gets or sets the top value of the graph filter in this value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphFilterThresholdValue">
+            <summary>
+                Gets or sets the threshold value of the graph filter in this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphFilterColumnName">
+            <summary>
+                Gets or sets the name of the column for graph filtering.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.GraphFilterColumnGuid">
+            <summary>
+                Gets or sets the ID of the column for graph filtering.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.Description">
+            <summary>
+                Gets or sets an string that is used for information about the table configuration.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.HighlightEntries">
+            <summary>
+                Gets or sets the collection of query entries that are used to highlight in this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.Columns">
+            <summary>
+                Gets or sets the collection of columns, in the order in which
+                they should be logically displayed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfiguration.ColumnRoles">
+            <summary>
+                Gets the mapping of column roles to column guids, if any.
+                If there are no column roles, then this dictionary will
+                be empty.
+                Only the base projection of a column can be assigned a role; variants
+                of a column cannot be assigned a role.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfiguration.AddColumnRole(System.String,Microsoft.Performance.SDK.Processing.ColumnConfiguration)">
+            <summary>
+                Places the given column into the given column role. Only the base projection of
+                the column will be used; the <see cref="P:Microsoft.Performance.SDK.Processing.ColumnConfiguration.VariantGuid"/> set
+                on the configuration will be ignored.
+            </summary>
+            <param name="columnRole">
+                The case sensitive role into which to place the column.
+            </param>
+            <param name="column">
+                The column to place into the role.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="columnRole"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="column"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="column"/> is a metadata column (see <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.AllMetadataColumns"/>).
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfiguration.AddColumnRole(System.String,System.Guid)">
+            <summary>
+                Places the given column into the given column role. Only the base
+                projection of the specified column will be assigned to the role.
+            </summary>
+            <param name="columnRole">
+                The case sensitive role into which to place the column.
+            </param>
+            <param name="columnGuid">
+                The guid of column to place into the role.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="columnRole"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="columnGuid"/> is a metadata column (see <see cref="F:Microsoft.Performance.SDK.Processing.TableConfiguration.AllMetadataColumns"/>).
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfiguration.RemoveColumnRole(System.String)">
+            <summary>
+                Removes the column, if any, assigned to the given <see cref="T:Microsoft.Performance.SDK.Processing.ColumnRole"/>.
+            </summary>
+            <param name="columnRole">
+                The role to be removed.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableConfigurations">
+            <summary>
+                Contains a collection of <see cref="T:Microsoft.Performance.SDK.Processing.TableConfiguration"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfigurations.#ctor(System.Guid)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableConfigurations"/>
+                class.
+            </summary>
+            <param name="tableId">
+                The unique identifier of the table to which the configurations
+                apply.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfigurations.TableId">
+            <summary>
+                Gets the unique identifier of the table to which the configurations
+                apply.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfigurations.DefaultConfigurationName">
+            <summary>
+                Gets or sets the name of the default configuration.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableConfigurations.Configurations">
+            <summary>
+                Gets or sets the configurations in this instance.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfigurations.GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfigurations.System#Collections#IEnumerable#GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfigurations.GetPrebuiltTableConfigurations(System.Type,System.Guid,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer)">
+            <summary>
+                Checks the table Type for a <see cref="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsEmbeddedResourceAttribute"/> or a
+                <see cref="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsFilePathAttribute"/>, and deserializes the table configurations
+                if found.
+            </summary>
+            <param name="tableType">
+                Table type.
+            </param>
+            <param name="tableId">
+                Table id.
+            </param>
+            <param name="serializer">
+                Used to deserialize table data.
+            </param>
+            <returns>
+                TableConfigurations or null.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableConfigurations.GetPrebuiltTableConfigurations(System.Type,System.Guid,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Checks the table Type for a <see cref="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsEmbeddedResourceAttribute"/> or a
+                <see cref="T:Microsoft.Performance.SDK.Processing.PrebuiltConfigurationsFilePathAttribute"/>, and deserializes the table configurations
+                if found.
+            </summary>
+            <param name="tableType">
+                Table type.
+            </param>
+            <param name="tableId">
+                Table id.
+            </param>
+            <param name="serializer">
+                Used to deserialize table data.
+            </param>
+            <param name="logger">
+                Used to log relevant messages.
+            </param>
+            <returns>
+                TableConfigurations or null.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableDescriptor">
+            <summary>
+                Describes a table.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableDescriptor.DefaultCategory">
+            <summary>
+                The default table category name.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableDescriptor.DefaultLayoutStyle">
+            <summary>
+                Gets the default table layout style.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.#ctor(System.Guid,System.String,System.String,System.String,System.Boolean,Microsoft.Performance.SDK.Processing.TableLayoutStyle,System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Extensibility.DataCookerPath})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>
+                class.
+            </summary>
+            <param name="guid">
+                The unique identifier for this table. This MAY NOT be
+                the default (empty) <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Guid"/>.
+            </param>
+            <param name="name">
+                The name of this table.
+            </param>
+            <param name="description">
+                A user friendly description of this table.
+            </param>
+            <param name="category">
+                The category into which this table belongs. This parameter
+                may be null, at which point the table is assumed to be in
+                the default category.
+            </param>
+            <param name="isMetadataTable">
+                Whether the table is a metadata table.
+            </param>
+            <param name="defaultLayout">
+                The default layout style for the table.
+            </param>
+            <param name="requiredDataCookers">
+                Identifiers for data cookers required to instantiate this table.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="guid"/> is whitespace.
+                - or -
+                <paramref name="guid"/> parsed to a value
+                equal to <c>default(Guid)</c>.
+                - or -
+                <paramref name="name"/> is whitespace.
+                - or -
+                <paramref name="description"/> is whitespace.
+                - or -
+                <paramref name="category"/> is whitespace.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="guid"/> is <c>null</c>.
+                - or -
+                <paramref name="name"/> is <c>null</c>.
+                - or -
+                <paramref name="description"/> is <c>null</c>.
+                - or -
+                <paramref name="category"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Guid">
+            <summary>
+                Gets the unique identifier for the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Name">
+            <summary>
+                Gets the name of the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Description">
+            <summary>
+                Gets the description of the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Category">
+            <summary>
+                Gets the category of the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.DefaultLayout">
+            <summary>
+                Gets the default layout style of the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.IsMetadataTable">
+            <summary>
+                Gets a value indicating whether this instance describes a
+                metadata table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.ExtendedData">
+            <summary>
+                Provides a means of storing Data Source specific information
+                for a table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Type">
+            <summary>
+                Gets or sets the <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Type" /> associated with this <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor" />,
+                if any. This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.PrebuiltTableConfigurations">
+            <summary>
+                Gets or sets the pre-built configurations of this table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.ServiceInterface">
+            <summary>
+                Gets or sets the <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Type" /> representing the <see cref="T:Microsoft.Performance.SDK.Processing.ITableService"/>
+                used by this table, if any. This property may be <c>null</c>.
+                See <see cref="M:Microsoft.Performance.SDK.Processing.ICustomDataProcessor.CreateTableService(Microsoft.Performance.SDK.Processing.TableDescriptor)"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableDescriptor.RequiredDataCookers">
+            <summary>
+                Identifiers for data cookers necessary to create this table.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.Equals(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptor.AddRequiredDataCooker(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Add a data cooker path to the local <see cref="F:Microsoft.Performance.SDK.Processing.TableDescriptor.dataCookers"/>
+            </summary>
+            <param name="cookerPath"></param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer">
+            <summary>
+                Used to compare <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> instances for equality.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer.Default">
+            <summary>
+                Uses the <see cref="P:Microsoft.Performance.SDK.Processing.TableDescriptor.Guid"/> to compare for equality.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer.Equals(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorEqualityComparer.GetHashCode(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableDescriptorExtensions">
+            <summary>
+                Additional functionality for <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>s.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorExtensions.RequiresDataExtensions(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Determines whether a table requires data extensions (e.g. data cookers).
+            </summary>
+            <param name="self">
+                Identifies a table with a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </param>
+            <returns>
+                <c>true</c> if data extensions are required; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableDescriptorFactory">
+            <summary>
+                Provides a method of generating <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>s
+                from <see cref="T:System.Type"/>s that represent tables.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorFactory.TryCreate(System.Type,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer,Microsoft.Performance.SDK.Processing.TableDescriptor@)">
+            <summary>
+                If possible, creates a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> from the
+                given <see cref="T:System.Type"/>. A <see cref="T:System.Type"/> is considered to
+                represent a table if the following are true:
+                <para />
+                <list type="bullet">
+                    <item>
+                        The <see cref="T:System.Type"/> is concrete. That is, the
+                        <see cref="T:System.Type"/> is not abstract, is not static, and
+                        is not an interface.
+                    </item>
+                    <item>
+                        The <see cref="T:System.Type"/> is decorated with the
+                        <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> attribute.
+                    </item>       
+                </list>
+                <para/>
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> from which to extract a
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </param>
+            <param name="tableConfigSerializer">
+                The serializer object that is used to deserialize the 
+                pre-built table configuration JSON files.
+            </param>
+            <param name="tableDescriptor">
+                If <paramref name="type"/> is a valid table type, then this is
+                populated with the created <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+                Otherwise, this parameter will be set to <c>null</c>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> is a valid table,
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorFactory.TryCreate(System.Type,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer,Microsoft.Performance.SDK.Processing.TableDescriptor@,System.Action{Microsoft.Performance.SDK.Processing.ITableBuilder,Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval}@)">
+            <summary>
+                If possible, creates a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> from the
+                given <see cref="T:System.Type"/>. A <see cref="T:System.Type"/> is considered to
+                represent a table if the following are true:
+                <para />
+                <list type="bullet">
+                    <item>
+                        The <see cref="T:System.Type"/> is concrete. That is, the
+                        <see cref="T:System.Type"/> is not abstract, is not static, and
+                        is not an interface.
+                    </item>
+                    <item>
+                        The <see cref="T:System.Type"/> is decorated with the
+                        <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> attribute.
+                    </item>       
+                </list>
+                <para/>
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> from which to extract a
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </param>
+            <param name="tableConfigSerializer">
+                The serializer object that is used to deserialize the 
+                pre-built table configuration JSON files.
+            </param>
+            <param name="tableDescriptor">
+                If <paramref name="type"/> is a valid table type, then this is
+                populated with the created <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+                Otherwise, this parameter will be set to <c>null</c>.
+            </param>
+            <param name="buildTableAction">
+                If the type contains a build table action, it is returned here.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> is a valid table,
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorFactory.TryCreate(System.Type,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer,Microsoft.Performance.SDK.Processing.TableDescriptor@,System.Action{Microsoft.Performance.SDK.Processing.ITableBuilder,Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval}@,System.Func{Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval,System.Boolean}@)">
+            <summary>
+                If possible, creates a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> from the
+                given <see cref="T:System.Type"/>. A <see cref="T:System.Type"/> is considered to
+                represent a table if the following are true:
+                <para />
+                <list type="bullet">
+                    <item>
+                        The <see cref="T:System.Type"/> is concrete. That is, the
+                        <see cref="T:System.Type"/> is not abstract, is not static, and
+                        is not an interface.
+                    </item>
+                    <item>
+                        The <see cref="T:System.Type"/> is decorated with the
+                        <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> attribute.
+                    </item>       
+                </list>
+                <para/>
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> from which to extract a
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </param>
+            <param name="tableConfigSerializer">
+                The serializer object that is used to deserialize the 
+                pre-built table configuration JSON files.
+            </param>
+            <param name="tableDescriptor">
+                If <paramref name="type"/> is a valid table type, then this is
+                populated with the created <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+                Otherwise, this parameter will be set to <c>null</c>.
+            </param>
+            <param name="buildTableAction">
+                If the type contains a build table action, it is returned here.
+            </param>
+            <param name="isDataAvailableFunc">
+                If the type contains a has data func, it is returned here.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> is a valid table,
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDescriptorFactory.TryCreate(System.Type,Microsoft.Performance.SDK.Processing.ITableConfigurationsSerializer,Microsoft.Performance.SDK.Processing.ILogger,Microsoft.Performance.SDK.Processing.TableDescriptor@,System.Action{Microsoft.Performance.SDK.Processing.ITableBuilder,Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval}@,System.Func{Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval,System.Boolean}@)">
+            <summary>
+                If possible, creates a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> from the
+                given <see cref="T:System.Type"/>. A <see cref="T:System.Type"/> is considered to
+                represent a table if the following are true:
+                <para />
+                <list type="bullet">
+                    <item>
+                        The <see cref="T:System.Type"/> is concrete. That is, the
+                        <see cref="T:System.Type"/> is not abstract, is not static, and
+                        is not an interface.
+                    </item>
+                    <item>
+                        The <see cref="T:System.Type"/> is decorated with the
+                        <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> attribute.
+                    </item>       
+                </list>
+                <para/>
+            </summary>
+            <param name="type">
+                The <see cref="T:System.Type"/> from which to extract a
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </param>
+            <param name="tableConfigSerializer">
+                The serializer object that is used to deserialize the 
+                pre-built table configuration JSON files.
+            </param>
+            <param name="logger">
+                Used to log any relevant messages.
+            </param>
+            <param name="tableDescriptor">
+                If <paramref name="type"/> is a valid table type, then this is
+                populated with the created <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+                Otherwise, this parameter will be set to <c>null</c>.
+            </param>
+            <param name="buildTableAction">
+                If the type contains a build table action, it is returned here.
+            </param>
+            <param name="isDataAvailableFunc">
+                If the type contains a has data func, it is returned here.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> is a valid table,
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableDiscovery">
+            <summary>
+                Provides common <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> implementations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDiscovery.CreateForAssembly(Microsoft.Performance.SDK.Processing.IProcessingSource)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> instance that will
+                discover tables in the <see cref="T:System.Reflection.Assembly"/> containing the
+                given <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>. Tables are discovered in the
+                assembly by being a type decorated with the <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/>
+                attribute.
+                <para/>
+                No table that requires <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>s or implements a static
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>
+                will be returned from this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <param name="processingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> whose <see cref="T:System.Reflection.Assembly"/> is to
+                be searched for tables.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> that discovers tables in the
+                <see cref="T:System.Reflection.Assembly"/> containing the <paramref name="processingSource"/>
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="processingSource"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDiscovery.CreateForAssembly(System.Reflection.Assembly)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> instance that will
+                discover tables in the given <see cref="T:System.Reflection.Assembly"/>. Tables are
+                discovered in the assembly by being a type decorated with the
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableAttribute"/> attribute.
+                <para/>
+                No table that requires <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>s or implements a static
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>
+                will be returned from this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <param name="assembly">
+                The <see cref="T:System.Reflection.Assembly"/> to search for tables.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> that discovers tables in the
+                specified <paramref name="assembly"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDiscovery.CreateForNamespace(System.String,Microsoft.Performance.SDK.Processing.IProcessingSource)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> instance that will
+                discover tables in the given namespace in the <see cref="T:System.Reflection.Assembly"/>
+                containing the specified <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+                <para/>
+                No table that requires <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>s or implements a static
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>
+                will be returned from this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <param name="tableNamespace">
+                The namespace to search for tables. This parameter may be <c>null</c> to
+                specify the global namespace.
+            </param>
+            <param name="processingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> whose <see cref="T:System.Reflection.Assembly"/> is
+                to be searched for tables.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> that discovers tables in the
+                specified <paramref name="tableNamespace"/> in the <see cref="T:System.Reflection.Assembly"/>
+                containing <paramref name="processingSource"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="processingSource"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDiscovery.CreateForNamespace(System.String,System.Reflection.Assembly)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> instance that will
+                discover tables in the given namespace in the given assembly.
+                <para/>
+                No table that requires <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>s or implements a static
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>
+                will be returned from this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <param name="tableNamespace">
+                The namespace to search for tables. This parameter may be <c>null</c> to
+                specify the global namespace.
+            </param>
+            <param name="assembly">
+                The <see cref="T:System.Reflection.Assembly"/> to search for tables.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> that discovers tables in the
+                specified <paramref name="tableNamespace"/> in the specified <paramref name="assembly"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="assembly"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableDiscovery.CreateForNamespace(System.String,System.Reflection.Assembly[])">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> instance that will
+                discover tables in the given namespace in the given assemblies.
+                <para/>
+                No table that requires <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCooking.IDataCooker"/>s or implements a static
+                <c>BuildTable&lt;<see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/>, <see cref="T:Microsoft.Performance.SDK.Extensibility.IDataExtensionRetrieval"/>&gt;</c>
+                will be returned from this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/>.
+            </summary>
+            <param name="tableNamespace">
+                The namespace to search for tables. This parameter may be <c>null</c> to
+                specify the global namespace.
+            </param>
+            <param name="assemblies">
+                The <see cref="T:System.Reflection.Assembly"/> instances to search for tables. Any null elements in
+                this parameter are ignored. Any duplicate assemblies are ignored.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSourceTableProvider"/> that discovers tables in the
+                specified <paramref name="tableNamespace"/> in the specified <paramref name="assemblies"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="assemblies"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="assemblies"/> has no non-null elements.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableLayoutStyle">
+            <summary>
+                How a table should be presented in the UI.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableLayoutStyle.None">
+            <summary>
+                Do not draw a graph or table.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableLayoutStyle.Graph">
+            <summary>
+                Draw only a graph of the data.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableLayoutStyle.Table">
+            <summary>
+                Draw only a table of the data.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TableLayoutStyle.GraphAndTable">
+            <summary>
+                Draw a graph and a table of the data.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry">
+            <summary>
+                Represents a piece of detailed information about a table row.
+                It contains a top level property with optional children properties.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry" />
+            </summary>
+            <param name="name">
+                The name of the top level property of this entry.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="name"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                  <paramref name="name"/> is WhiteSpace.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.#ctor(System.String,System.String)">
+            <summary>
+                 Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry" />
+            </summary>
+            <param name="name">
+                 The name of the top level property of this entry.
+            </param>
+            <param name="value">
+                 The value of top level property.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="name"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                  <paramref name="name"/> is WhiteSpace.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.Name">
+            <summary>
+                Gets the name for the top level property of this entry.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.Value">
+            <summary>
+                Gets the value for the top level property of this entry.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.HasValue">
+            <summary>
+                Gets if the <see cref="P:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.Value" /> is <c>null</c> or empty.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.Childrens">
+            <summary>
+                Gets the children <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry" /> of this instance.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.TableRowDetailEntry.AddChildDetailsInfo(Microsoft.Performance.SDK.Processing.TableRowDetailEntry)">
+            <summary>
+                Add a child <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry"/> to this instance.
+            </summary>
+            <param name="child">
+                A <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry"/> that a piece of detailed information of the top level property. 
+            </param>
+            <returns>
+                This instance of the <see cref="T:Microsoft.Performance.SDK.Processing.TableRowDetailEntry"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="child"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.TextAlignment">
+            <summary>
+                Enumerates the different ways text can be aligned in a
+                data cell.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TextAlignment.Left">
+            <summary>
+                Default. Text is aligned to the left.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TextAlignment.Right">
+            <summary>
+                Text is aligned to the right.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TextAlignment.Center">
+            <summary>
+                Text is centered.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.Processing.TextAlignment.Justify">
+            <summary>
+                Text is justified.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.UIHints">
+            <summary>
+                Provides hints to the caller for rendering columns.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.UIHints.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.UIHints"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.UIHints.#ctor(Microsoft.Performance.SDK.Processing.UIHints)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Processing.UIHints"/>
+                class from an existing instance.
+            </summary>
+            <param name="other">
+                The instance of which to make a copy.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="other"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.Width">
+            <summary>
+                Gets or sets the width to use for rendering the column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.IsVisible">
+            <summary>
+                Gets or sets a value indicating whether the column should
+                be rendered at all.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.TextAlignment">
+            <summary>
+                Gets or sets the alignment that should be used for text in
+                the column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.CellFormat">
+            <summary>
+                Gets or sets a composite format string describing how
+                to format cell data. See <see cref="T:Microsoft.Performance.SDK.Processing.ColumnFormats"/> for
+                some examples. This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.SortOrder">
+            <summary>
+                Gets or sets the sorting rules to use when sorting data in
+                the column.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.SortPriority">
+            <summary>
+                Gets or sets the priority of this column when sorting
+                by multiple columns.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Processing.UIHints.AggregationMode">
+            <summary>
+                Gets or sets a value that determines how data from the
+                column will be aggregated in the table when multiple rows
+                are collapsed.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.UIHints.Default">
+            <summary>
+                Gets an instance of <see cref="T:Microsoft.Performance.SDK.Processing.UIHints"/> representing
+                default values.
+            </summary>
+            <returns>
+                A new instance of <see cref="T:Microsoft.Performance.SDK.Processing.UIHints"/> representing default
+                values.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.UIHints.Clone">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.UIHints.CloneT">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.VisibleDomainRegionContainer">
+            <summary>
+                This class provides a level of indirection that
+                our struct projectors can use to make sure that
+                modifications to copies still give the visible domain
+                to all instances.
+                If we set the visible domain on a copy, the mutation is
+                lost. If we set the visible domain on the container that
+                is on a copy, then the original instance will also
+                see the update.
+                <para/>
+                The projectors are structs because the table engine
+                strips away everything and lines them up in memory.
+                When the projectors were reference types, the Garbage Collector would
+                sometimes work too hard and we had terrible performance
+                problems.
+                <para/>
+                This class is internal as it is an implementation detail
+                of projections.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/> instances in
+                regards to interaction with the caller's visible domain.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection.DependsOnVisibleDomain``2(Microsoft.Performance.SDK.Processing.IProjection{``0,``1})">
+            <summary>
+                Determines if the <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/>
+                depends on a visible domain.
+            </summary>
+            <typeparam name="TSource">
+                The <see cref="T:System.Type"/> of argument to the projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the result of the projection.
+            </typeparam>
+            <param name="self">
+                The projection being queried.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/>
+                depends on a visible domain; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection.DependsOnVisibleDomain``1(``0)">
+            <summary>
+                Determines if the <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/>
+                depends on a visible domain in the application.
+            </summary>
+            <typeparam name="TProjection">
+                The <see cref="T:System.Type"/> being interrogated.
+            </typeparam>
+            <param name="self">
+                The projection being queried.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/>
+                depends on the current visible domain; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection.CloneIfVisibleDomainSensitive``2(Microsoft.Performance.SDK.Processing.IProjection{``0,``1})">
+            <summary>
+                Clones the given <see cref="T:Microsoft.Performance.SDK.Processing.IProjection`2"/>
+                if the projection is sensitive to a visible domain; otherwise, the 
+                projection itself is returned unmodified.
+            </summary>
+            <typeparam name="TSource">
+                The <see cref="T:System.Type"/> of argument to the projection.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the result of the projection.
+            </typeparam>
+            <param name="self">
+                The projection being cloned.
+            </param>
+            <returns>
+                A clone of the specified projection, if possible;
+                <paramref name="self"/> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection.CloneIfVisibleDomainSensitive``1(``0)">
+            <summary>
+                Clones the given <typeparamref name="TProjection"/>
+                if the projection is sensitive to a visible domain; otherwise, the 
+                projection itself is returned unmodified.
+            </summary>
+            <typeparam name="TProjection">
+                The <see cref="T:System.Type"/> being interrogated.
+            </typeparam>
+            <param name="self">
+                The projection being cloned.
+            </param>
+            <returns>
+                A clone of the specified projection, if possible;
+                <paramref name="self"/> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Processing.VisibleDomainSensitiveProjection.NotifyVisibleDomainChanged``1(``0,Microsoft.Performance.SDK.Processing.IVisibleDomainRegion)">
+            <summary>
+                Notifies the given projection of a visible domain change if the
+                projection depends on a visible domain.
+            </summary>
+            <typeparam name="TProjection">
+                The <see cref="T:System.Type"/> being interrogated.
+            </typeparam>
+            <param name="self">
+                The projection being notified.
+            </param>
+            <param name="newVisibleDomain">
+                The new visible domain.
+            </param>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IDiffConvertible">
+            <summary>
+                Marker interface for a column that is diffable.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IDiffConvertible`1">
+            <summary>
+                When column are being diffed, sometimes they need special handling to show the correct diffed values.
+                One example of this is diffing byte values, which are typically unsigned.  The diffed value can be negative,
+                which gets clamped to zero, if we don't convert the column to a signed bytes type.
+                This interface defines the target type for the conversion.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFormatForClipboard">
+            <summary>
+                Provides a means of formatting an instance of an
+                <see cref="T:System.Object"/> for the system clipboard.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFormatForClipboard.ToClipboardString(System.String,System.Boolean)">
+            <summary>
+                Converts this instance into a string suitable for
+                the system clipboard.
+            </summary>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="includeUnits">
+                Whether to include units in the string.
+            </param>
+            <returns>
+                The string representation of this instance, suitable for
+                use in the system clipboard.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFunc`1">
+            <summary>
+                Represents a function taking no parameters
+                and returning a result.
+            </summary>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFunc`1.Invoke">
+            <summary>
+                Invokes this function.
+            </summary>
+            <returns>
+                The return value.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFunc`2">
+            <summary>
+                Represents a function taking one parameter
+                and returning a result.
+            </summary>
+            <typeparam name="T">
+                The parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFunc`2.Invoke(`0)">
+            <summary>
+                Invokes the function.
+            </summary>
+            <param name="t1">
+                The first argument.
+            </param>
+            <returns>
+                The result.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFunc`3">
+            <summary>
+                Represents a function taking two parameters
+                and returning a result.
+            </summary>
+            <typeparam name="T1">
+                The first parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T2">
+               The second parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFunc`3.Invoke(`0,`1)">
+            <summary>
+                Invokes the given function.
+            </summary>
+            <param name="t1">
+                The first argument.
+            </param>
+            <param name="t2">
+                The second argument.
+            </param>
+            <returns>
+                The result.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFunc`4">
+            <summary>
+                Represents a function taking three parameters
+                and returning a result.
+            </summary>
+            <typeparam name="T1">
+                The first parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T2">
+               The second parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T3">
+                The third parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFunc`4.Invoke(`0,`1,`2)">
+            <summary>
+                Invokes the given function.
+            </summary>
+            <param name="t1">
+                The first argument.
+            </param>
+            <param name="t2">
+                The second argument.
+            </param>
+            <param name="t3">
+               The third argument.
+            </param>
+            <returns>
+                The result.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IFunc`5">
+            <summary>
+                Represents a function taking four parameters
+                and returning a result.
+            </summary>
+            <typeparam name="T1">
+                The first parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T2">
+               The second parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T3">
+                The third parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="T4">
+                The fourth parameter <see cref="T:System.Type"/>.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IFunc`5.Invoke(`0,`1,`2,`3)">
+            <summary>
+                Invokes the given function.
+            </summary>
+            <param name="t1">
+                The first argument.
+            </param>
+            <param name="t2">
+                The second argument.
+            </param>
+            <param name="t3">
+               The third argument.
+            </param>
+            <param name="t4">
+                The fourth argument.
+            </param>
+            <returns>
+                The result.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Int32Utils">
+            <summary>
+                Provides static (Shared in Visual basic) methods for interacting
+                with <see cref="T:System.Int32"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.GetBoxed(System.Int32)">
+            <summary>
+                Boxes the given <see cref="T:System.Int32" />
+            </summary>
+            <param name="value">
+                The <see cref="T:System.Int32"/> to box.
+            </param>
+            <returns>
+                The boxed <see cref="T:System.Int32"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.Clamp(System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Clamps the given value to the range [min, max].
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="min">
+                The minimum allowable value. The lower bound of the clamp.
+            </param>
+            <param name="max">
+                The maximum allowable value. The upper bound of the clamp.
+            </param>
+            <returns>
+                If value is less than min, then min. If value is between min
+                and max, then value. If value is greater than max, then max.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="max"/> is less than <paramref name="min"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.SafeClamp(System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Clamps the given value to the range [min, max], ensuring
+                that <paramref name="extreme1"/> is less than <paramref name="extreme2"/>
+                when calculating the clamp.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extreme1">
+                The first bound of the clamp.
+            </param>
+            <param name="extreme2">
+                The other bound of the clamp.
+            </param>
+            <returns>
+                The value, if value is in the range specified by <paramref name="extreme1"/>
+                and <paramref name="extreme2"/>. Otherwise, either <paramref name="extreme1"/>
+                or <paramref name="extreme2"/>, whichever is closer.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.IsClamped(System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="min">
+                The minimum value.
+            </param>
+            <param name="max">
+                The maximum value.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="min"/> and <paramref name="max"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.SafeIsClamped(System.Int32,System.Int32,System.Int32)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="extreme1">
+                The first extreme of the range.
+            </param>
+            <param name="extreme2">
+                The other extreme of the range.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="extreme1"/> and <paramref name="extreme2"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.IsIndexValid(System.Int32,System.Int32)">
+            <summary>
+                Determines whether the given index represents a valid index
+                into a collection with the given count.
+            </summary>
+            <param name="index">
+                The index to check.
+            </param>
+            <param name="count">
+                The size of the collection.
+            </param>
+            <returns>
+                <c>true</c> if index can safely be used in a collection of
+                size <paramref name="count"/>; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="count"/> is less than zero (0.)
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int32Utils.AbsMod(System.Int32,System.Int32)">
+            <summary>
+                Performs the operation "x mod y", correctly accounting
+                for negative values of x.
+                <remarks>
+                    The modulo function built into C# (%) does not handle negative numbers
+                    the way one might expect (i.e. (-x) % y = -(x % y)).
+                    This function returns the remainder when x is divided by y,
+                    whether x is positive or negative.
+                </remarks>
+            </summary>
+            <param name="x">
+                The value.
+            </param>
+            <param name="y">
+                The modulus.
+            </param>
+            <returns>
+                The result of "x mod y"
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Int64Range">
+            <summary>
+                Represents a range of values using <see cref="T:System.Int64"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.#ctor(System.Int64,System.Int64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Int64Range"/>
+                class.
+            </summary>
+            <param name="begin"></param>
+            <param name="end"></param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Int64Range.Begin">
+            <summary>
+                Gets the beginning of the range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Int64Range.End">
+            <summary>
+                Gets the end of the range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Int64Range.HasLength">
+            <summary>
+                Gets a value indicating whether this range has a
+                length.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Int64Range.Length">
+            <summary>
+                Gets the length of this range. The length
+                is the difference between <see cref="P:Microsoft.Performance.SDK.Int64Range.End"/> and
+                <see cref="P:Microsoft.Performance.SDK.Int64Range.Begin"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.op_Equality(Microsoft.Performance.SDK.Int64Range,Microsoft.Performance.SDK.Int64Range)">
+            <summary>
+                Determines whether the two <see cref="T:Microsoft.Performance.SDK.Int64Range"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first range.
+            </param>
+            <param name="second">
+                The second range.
+            </param>
+            <returns>
+                <c>true</c> if the ranges are considered to be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.op_Inequality(Microsoft.Performance.SDK.Int64Range,Microsoft.Performance.SDK.Int64Range)">
+            <summary>
+                Determines whether the two <see cref="T:Microsoft.Performance.SDK.Int64Range"/> instances
+                are not considered to be equal.
+            </summary>
+            <param name="first">
+                The first range.
+            </param>
+            <param name="second">
+                The second range.
+            </param>
+            <returns>
+                <c>true</c> if the ranges are not considered to be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.op_Implicit(Microsoft.Performance.SDK.Int64Range)~Microsoft.Performance.SDK.DoubleRange">
+            <summary>
+                Implicitly casts the given <see cref="T:Microsoft.Performance.SDK.Int64Range"/> to
+                a <see cref="T:Microsoft.Performance.SDK.DoubleRange"/>.
+            </summary>
+            <param name="range">
+                The range to cast.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.Overlaps(Microsoft.Performance.SDK.Int64Range)">
+            <summary>
+                Determines whether this range overlaps with the given range.
+                See <see cref="M:Microsoft.Performance.SDK.Int64Utils.DoRangesOverlap(System.Int64,System.Int64,System.Int64,System.Int64)"/> for more information.
+            </summary>
+            <param name="other">
+                The range to check.
+            </param>
+            <returns>
+                <c>true</c> if this instance overlaps with <paramref name="other"/>;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Range.Equals(Microsoft.Performance.SDK.Int64Range)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Int64Utils">
+            <summary>
+                Provides static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.Int64"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.DoRangesOverlap(System.Int64,System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Determines whether the two ranges overlap.
+            </summary>
+            <remarks>
+                The begin and end values for each range are implicitly swapped if begin is greater 
+                than end.
+                The range is treated as having an inclusive begin value, and exclusive end value.
+                In other words: [begin, end)
+            </remarks>
+            <param name="firstBegin">
+                The beginning of the first range.
+            </param>
+            <param name="firstEnd">
+                The end of the first range.
+            </param>
+            <param name="secondBegin">
+                The beginning of the second range.
+            </param>
+            <param name="secondEnd">
+                The end of the second range.
+            </param>
+            <returns>
+                <c>true</c> if the ranges overlap; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.DoInclusiveRangesOverlap(System.Int64,System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Determines whether the two ranges overlap.
+            </summary>
+            <remarks>
+                The begin and end values for each range are implicitly swapped if begin is greater 
+                than end.
+                This function behaves the same as the above function, except that the ranges 
+                are treated as having both inclusive begin values and inclusive end values
+                In other words: [begin, end]
+            </remarks>
+            <param name="firstBegin">
+                The beginning of the first range.
+            </param>
+            <param name="firstEnd">
+                The end of the first range.
+            </param>
+            <param name="secondBegin">
+                The beginning of the second range.
+            </param>
+            <param name="secondEnd">
+                The end of the second range.
+            </param>
+            <returns>
+                <c>true</c> if the ranges overlap; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.GetBoxed(System.Int64)">
+            <summary>
+                Boxes the given <see cref="T:System.Int64" />
+            </summary>
+            <param name="value">
+                The <see cref="T:System.Int64"/> to box.
+            </param>
+            <returns>
+                The boxed <see cref="T:System.Int64"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.Clamp(System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Clamps the given value to the range [min, max].
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="min">
+                The minimum allowable value. The lower bound of the clamp.
+            </param>
+            <param name="max">
+                The maximum allowable value. The upper bound of the clamp.
+            </param>
+            <returns>
+                If value is less than min, then min. If value is between min
+                and max, then value. If value is greater than max, then max.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="max"/> is less than <paramref name="min"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.SafeClamp(System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Clamps the given value to the range [min, max], ensuring
+                that <paramref name="extreme1"/> is less than <paramref name="extreme2"/>
+                when calculating the clamp.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extreme1">
+                The first bound of the clamp.
+            </param>
+            <param name="extreme2">
+                The other bound of the clamp.
+            </param>
+            <returns>
+                The value, if value is in the range specified by <paramref name="extreme1"/>
+                and <paramref name="extreme2"/>. Otherwise, either <paramref name="extreme1"/>
+                or <paramref name="extreme2"/>, whichever is closer.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.IsClamped(System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="min">
+                The minimum value.
+            </param>
+            <param name="max">
+                The maximum value.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="min"/> and <paramref name="max"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Int64Utils.SafeIsClamped(System.Int64,System.Int64,System.Int64)">
+            <summary>
+                Determines whether the given value is within the specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="extreme1">
+                The first extreme of the range.
+            </param>
+            <param name="extreme2">
+                The other extreme of the range.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="value"/> is between
+                <paramref name="extreme1"/> and <paramref name="extreme2"/> inclusive;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IPlottableGraphType">
+            <summary>
+                Provides a means of getting the value of an instance
+                that is able to be plotted on a graph.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IPlottableGraphType.GetGraphValue">
+            <summary>
+                Gets the value to plot for this instance.
+            </summary>
+            <returns>
+                A plottable value.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.IProvideColorTupleHash">
+            <summary>
+                Provides a hash value for a primary and secondary color.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.IProvideColorTupleHash.GetColorHash">
+            <summary>
+            Implemented on the type itself as a substitute for Object.GetHashCode() when 
+            we need a color index that derives from the value of some data. (you should 
+            not use pointer values to compute the color hash, for instance)
+            This interface is analogous in pattern to IEquatable
+            </summary>
+            <returns>
+            Returns color hash values (int, int?)
+            Values Item1 and Item2 represent a color primary and secondary (optional) index value
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.LargeSignedBytes">
+            <summary>
+                Represents a large signed quantity of bytes.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.#ctor(System.Decimal)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                struct.
+            </summary>
+            <param name="bytes">
+                The count of bytes.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.TotalBytes">
+            <summary>
+                Gets the total number of bytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.TotalKilobytes">
+            <summary>
+                Gets the total number of kilobytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.TotalMegabytes">
+            <summary>
+                Gets the total number of megabytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.TotalGigabytes">
+            <summary>
+                Gets the total number of gigabytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.Zero">
+            <summary>
+                Gets the value representing zero (0) bytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.MinValue">
+            <summary>
+                Gets the minimum number of bytes representable by this
+                struct.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.LargeSignedBytes.MaxValue">
+            <summary>
+                Gets the maximum number of bytes representable by this
+                struct.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.CompareTo(Microsoft.Performance.SDK.LargeSignedBytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.Equals(Microsoft.Performance.SDK.LargeSignedBytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_LessThan(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_GreaterThan(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_LessThanOrEqual(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_GreaterThanOrEqual(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_Equality(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_Inequality(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.ToString(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_Subtraction(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Subtracts two quantities of <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> from
+                each other.
+            </summary>
+            <param name="first">
+                The minuend.
+            </param>
+            <param name="second">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="second"/> from
+                <paramref name="first"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.op_Addition(Microsoft.Performance.SDK.LargeSignedBytes,Microsoft.Performance.SDK.LargeSignedBytes)">
+            <summary>
+                Adds two quantities of <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/> to
+                each other.
+            </summary>
+            <param name="first">
+                The first addend.
+            </param>
+            <param name="second">
+                The second addend.
+            </param>
+            <returns>
+                The result of the addition of <paramref name="first"/> with
+                <paramref name="second"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytes.GetGraphValue">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.LargeSignedBytesConverter">
+            <summary>
+                Converts instances into <see cref="T:Microsoft.Performance.SDK.LargeSignedBytes"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytesConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytesConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytesConverter.TryParse(System.String,System.Int64@,Microsoft.Performance.SDK.BytesUnits@,System.Int32@)">
+            <summary>
+                Attempts to parse the given string into a count of bytes.
+            </summary>
+            <param name="str">
+                The string to parse.
+            </param>
+            <param name="bytes">
+                The number of bytes.
+            </param>
+            <param name="units">
+                The units to use when interpreting the count of <paramref name="bytes"/>.
+            </param>
+            <param name="precision">
+                The precision.
+            </param>
+            <returns>
+                <c>true</c> if parsing was successful; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="str"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytesConverter.ConvertToBytesUnit(System.Decimal,Microsoft.Performance.SDK.BytesUnits)">
+            <summary>
+                Converts the given count of bytes to the given units.
+            </summary>
+            <param name="bytesValue">
+                The count of bytes.
+            </param>
+            <param name="units">
+                The units into which to convert the count.
+            </param>
+            <returns>
+                The number of bytes as expressed in <paramref name="units"/>.
+            </returns>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="units"/> is not a valid member of the <see cref="T:Microsoft.Performance.SDK.BytesUnits"/>
+                enumeration.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.LargeSignedBytesConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Definitions.BooleanOptionDefinition">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1"/> for a boolean value.
+            </summary>
+            <remarks>
+                This <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/> will have values exposed
+                by a <see cref="T:Microsoft.Performance.SDK.Options.Values.BooleanOptionValue"/>.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Definitions.FieldArrayOptionDefinition">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1"/> for an ordered collection of string fields.
+            </summary>
+            <remarks>
+                This <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/> will have values exposed
+                by a <see cref="T:Microsoft.Performance.SDK.Options.Values.FieldArrayOptionValue"/>.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Definitions.FieldOptionDefinition">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1"/> for a single string field.
+            </summary>
+            <remarks>
+                This <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/> will have values exposed
+                by a <see cref="T:Microsoft.Performance.SDK.Options.Values.FieldOptionValue"/>.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition">
+            <summary>
+                Base class for plugin option definitions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition"/> class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.Guid">
+            <summary>
+                Gets or initializes the <see cref="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.Guid"/> of the option. This value is required to be
+                initialized.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.Category">
+            <summary>
+                Gets or initializes the human-readable category of the option. This value is required to be initialized.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.Name">
+            <summary>
+                Gets or initializes the human-readable name of the option. This value is required to be initialized.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.Description">
+            <summary>
+                Gets or initializes the human-readable description of the option. This value is required to be initialized.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1">
+            <summary>
+                Base class for plugin option definitions.
+            </summary>
+            <typeparam name="T">
+                The type of the option value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1"/> class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1.DefaultValue">
+            <summary>
+                Gets or initializes the default value of the option. This value is required to be initialized.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Values.BooleanOptionValue">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1"/> for a boolean value.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Values.FieldArrayOptionValue">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1"/> for an ordered collection of string fields.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Values.FieldOptionValue">
+            <summary>
+                A <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1"/> for a single string field.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue">
+            <summary>
+                Base class for plugin option values.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Options.Values.PluginOptionValue.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue"/> class.
+            </summary>
+        </member>
+        <member name="E:Microsoft.Performance.SDK.Options.Values.PluginOptionValue.OptionChanged">
+            <summary>
+                Raised when this option's value changes.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1">
+            <summary>
+                Base class for plugin option values.
+            </summary>
+            <typeparam name="T">
+                The type of the option value.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue"/> class.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Options.Values.PluginOptionValue`1.CurrentValue">
+            <summary>
+                Gets the current value of the option.
+            </summary>
+            <remarks>
+                Note that this value may be equivalent to the <see cref="P:Microsoft.Performance.SDK.Options.Definitions.PluginOptionDefinition`1.DefaultValue"/> defined
+                for this plugin option regardless of whether the value has been modified/manually set. Do not use the value
+                of this property to determine whether the option is using its default value.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption">
+            <summary>
+                A plugin configuration option allows a plugin to change behavior based on requirements of an application
+                or runtime without coding directly to either one.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.#ctor(System.String,System.String)">
+            <summary>
+                Create an configuration option.
+            </summary>
+            <param name="name">
+                Option name.
+            </param>
+            <param name="description">
+                Option description.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Name">
+            <summary>
+                Gets the configuration option name.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Description">
+            <summary>
+                Gets a description of the configuration option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Applications">
+            <summary>
+            Gets the applications which opt-in to this option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Runtimes">
+            <summary>
+                The runtimes which opt-in to this option.
+            </summary>
+            <remarks>
+                Some runtimes exist as class libraries from which many application may derive. This area is provided for
+                options which are runtime specific.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.AddApplication(System.String)">
+            <summary>
+                Adds name of an application that elects to use this option.
+            </summary>
+            <param name="applicationName">
+                Application name.
+            </param>
+            <returns>
+                <c>true</c> if the name was added, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.AddApplications(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Adds names of applications that elect to use this option.
+            </summary>
+            <param name="applicationNames">
+                Application name.
+            </param>
+            <returns>
+                <c>true</c> if at least one name was added, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.DelApplication(System.String)">
+            <summary>
+                Deletes name of an application currently listed under this option.
+            </summary>
+            <param name="applicationName">
+                Application name.
+            </param>
+            <returns>
+                <c>true</c> if the name was removed, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.AddRuntime(System.String)">
+            <summary>
+                Adds name of a runtime that elects to use this option.
+            </summary>
+            <param name="runtimeName">
+                Runtime name.
+            </param>
+            <returns>
+                <c>true</c> if the name was added, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.AddRuntimes(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Adds names of runtimes that elect to use this option.
+            </summary>
+            <param name="runtimeNames">
+                Runtime names.
+            </param>
+            <returns>
+                <c>true</c> if at least one name was removed, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.DelRuntime(System.String)">
+            <summary>
+                Deletes name of an runtime currently listed under this option.
+            </summary>
+            <param name="runtimeName">
+                Runtime name.
+            </param>
+            <returns>
+                <c>true</c> if the name was removed, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Equals(Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOptionDTO.Name">
+            <summary>
+            The configuration option name.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOptionDTO.Description">
+            <summary>
+            A description of the configuration option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOptionDTO.Applications">
+            <summary>
+            The applications which opt-in to this option.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOptionDTO.Runtimes">
+            <summary>
+            The runtimes which opt-in to this option.
+            </summary>
+            <remarks>
+            Some runtimes exist as class libraries from which many application may derive. This area is provided for
+            options which are runtime specific.
+            </remarks>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration">
+            <summary>
+                A plugin configuration exposes a set of option and subscribers to those options.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.Comparer">
+            <summary>
+                The plugin configuration is English and case-sensitive.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.#ctor(System.String,NuGet.Versioning.SemanticVersion,System.Collections.Generic.ISet{Microsoft.Performance.SDK.PluginConfiguration.ConfigurationOption})">
+            <summary>
+                Create a plugin configuration.
+            </summary>
+            <param name="name">
+                Name of the plugin.
+            </param>
+            <param name="version">
+                Version of the configuration.
+            </param>
+            <param name="options">
+                A set of option to include in the configuration.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.PluginName">
+            <summary>
+                Gets the name of the plugin to which this configuration belongs.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.Version">
+            <summary>
+            Gets the configuration file version.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.Options">
+            <summary>
+                Gets a set of options to opt into.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.FindOption(System.String)">
+            <summary>
+                Find an option with the given name.
+            </summary>
+            <param name="name">
+                Option name.
+            </param>
+            <returns>
+                An option if found, or <c>null</c>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration.OptionEnabled(System.String,System.String,System.String)">
+            <summary>
+                Check if an option is enabled for an application or a runtime.
+            </summary>
+            <param name="optionName">
+                Name of the option.
+            </param>
+            <param name="applicationName">
+                Name of an application.
+            </param>
+            <param name="runtimeName">
+                Name of a runtime.
+            </param>
+            <returns>
+                true if the option is enabled; false otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationExtensions">
+            <summary>
+                Some extensions for <see cref="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration"/> objects.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationExtensions.OptionEnabled(Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration,System.String,Microsoft.Performance.SDK.Processing.IApplicationEnvironment)">
+            <summary>
+                Check if an option is enabled for an application or a runtime.
+            </summary>
+            <param name="configuration">
+                The plugin configuration.
+            </param>
+            <param name="optionName">
+                Name of the option.
+            </param>
+            <param name="environment">
+                The application environment contains the application and runtime names
+                for which to determine the options to apply (if any.)
+            </param>
+            <returns>
+                true if the option is enabled; false otherwise.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationDTO.PluginName">
+            <summary>
+            Name of the plugin to which this configuration belongs.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationDTO.Version">
+            <summary>
+            Configuration file version.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationDTO.Options">
+            <summary>
+            Provides a set of options to opt into.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer">
+            <summary>
+                Includes methods to de/serializing plugin configurations.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer.DefaultFileName">
+            <summary>
+                The default file name for a plugin configuration.
+            </summary>
+            <remarks>
+                This does not follow the standard lowercase "plugin" case-convention
+                in order to remain backwards compatible with previous plugin configurations.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer.ReadFromDefaultFile(System.Type,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Reads a configuration for the given <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="processingSourceType">
+                Type of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </param>
+            <param name="logger">
+                Used to log any messages.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration"/> on success; <c>null</c> on failure.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer.ReadFromDefaultFile(System.String,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Reads a configuration from a given directory.
+            </summary>
+            <param name="plugInDirectory">
+                The directory with the configuration file.
+            </param>
+            <param name="logger">
+                Used to log any errors.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration"/> on success; <c>null</c> on failure.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer.ReadFromStream(System.IO.Stream,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Reads a configuration from a given stream.
+            </summary>
+            <param name="configurationStream">
+                Source of the configuration data.
+            </param>
+            <param name="logger">
+                Used to log any errors.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration"/> on success; <c>null</c> on failure.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationSerializer.WriteToStream(Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration,System.IO.Stream,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Write a <see cref="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfiguration"/> to a stream.
+            </summary>
+            <param name="configuration">
+                Configuration to write.
+            </param>
+            <param name="configurationStream">
+                Stream to write to.
+            </param>
+            <param name="logger">
+                Used to log any errors.
+            </param>
+            <returns>
+                <c>true</c> when written successfully; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationValidation">
+            <summary>
+                Provides helper methods for configuration files.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationValidation.ValidCharactersMessage">
+            <summary>
+                A string that describes the allowable characters in a plugin configuration value.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.PluginConfiguration.PluginConfigurationValidation.ValidateElementName(System.String)">
+            <summary>
+                Check that the string value matches criteria of a plugin configuration.
+            </summary>
+            <param name="name">
+                A string value to store in a plugin configuration file.
+            </param>
+            <returns>
+                true if the value is valid; otherwise false.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ReadOnlyHashSet">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.SDK.ReadOnlyHashSet`1"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet.Empty``1">
+            <summary>
+                Gets the empty instance of <see cref="T:Microsoft.Performance.SDK.ReadOnlyHashSet`1"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of item contained in the collection.
+            </typeparam>
+            <returns>
+                The empty instance.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.ReadOnlyHashSet`1">
+            <summary>
+                Represents a readonly wrapper around a <see cref="T:System.Collections.Generic.HashSet`1"/>.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of item contained in the collection.
+            </typeparam>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.#ctor(System.Collections.Generic.HashSet{`0})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.ReadOnlyHashSet`1"/>
+                class, wrapping the given <see cref="T:System.Collections.Generic.HashSet`1"/>.
+            </summary>
+            <param name="source">
+                The <see cref="T:System.Collections.Generic.HashSet`1"/> to wrap.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="source"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Add(`0)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Clear">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Contains(`0)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.CopyTo(`0[],System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Count">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IsReadOnly">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Remove(`0)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.System#Collections#IEnumerable#GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.System#Collections#Generic#ISet{T}#Add(`0)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.UnionWith(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IntersectWith(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.ExceptWith(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.SymmetricExceptWith(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IsSubsetOf(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IsSupersetOf(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IsProperSupersetOf(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.IsProperSubsetOf(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.Overlaps(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.ReadOnlyHashSet`1.SetEquals(System.Collections.Generic.IEnumerable{`0})">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.SdkAssembly">
+            <summary>
+                This class exists to provide a hook for getting the
+                SDK assembly.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.SdkAssembly.Assembly">
+            <summary>
+                The Assembly containing this version of the SDK.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.SignedBytes">
+            <summary>
+                Represents a signed quantity of bytes.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.#ctor(System.Int64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                struct.
+            </summary>
+            <param name="bytes">
+                The count of bytes.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.TotalBytes">
+            <summary>
+                Gets the total number of bytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.TotalKilobytes">
+            <summary>
+                Gets the total number of kilobytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.TotalMegabytes">
+            <summary>
+                Gets the total number of megabytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.TotalGigabytes">
+            <summary>
+                Gets the total number of gigabytes represented
+                by this instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.Zero">
+            <summary>
+                Gets the value representing zero (0) bytes.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.MinValue">
+            <summary>
+                Gets the minimum number of bytes representable by this
+                struct.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.SignedBytes.MaxValue">
+            <summary>
+                Gets the maximum number of bytes representable by this
+                struct.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.CompareTo(Microsoft.Performance.SDK.SignedBytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.Equals(Microsoft.Performance.SDK.SignedBytes)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_LessThan(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_GreaterThan(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_LessThanOrEqual(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_GreaterThanOrEqual(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_Equality(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_Inequality(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.ToString(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_Subtraction(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Subtracts two quantities of <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> from
+                each other.
+            </summary>
+            <param name="first">
+                The minuend.
+            </param>
+            <param name="second">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="second"/> from
+                <paramref name="first"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.op_Addition(Microsoft.Performance.SDK.SignedBytes,Microsoft.Performance.SDK.SignedBytes)">
+            <summary>
+                Adds two quantities of <see cref="T:Microsoft.Performance.SDK.SignedBytes"/> to
+                each other.
+            </summary>
+            <param name="first">
+                The first addend.
+            </param>
+            <param name="second">
+                The second addend.
+            </param>
+            <returns>
+                The result of the addition of <paramref name="first"/> with
+                <paramref name="second"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToType(System.Type,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#GetTypeCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToBoolean(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToChar(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToDateTime(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToDecimal(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToDouble(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToSByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToSingle(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToString(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToUInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToUInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IConvertible#ToUInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytes.GetGraphValue">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.SignedBytesConverter">
+            <summary>
+                Converts instances to <see cref="T:Microsoft.Performance.SDK.SignedBytes"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytesConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytesConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytesConverter.TryParse(System.String,System.Int64@,Microsoft.Performance.SDK.BytesUnits@,System.Int32@)">
+            <summary>
+                Attempts to parse the given string into a count of bytes.
+            </summary>
+            <param name="str">
+                The string to parse.
+            </param>
+            <param name="bytes">
+                The number of bytes.
+            </param>
+            <param name="units">
+                The units to use when interpreting the count of <paramref name="bytes"/>.
+            </param>
+            <param name="precision">
+                The precision.
+            </param>
+            <returns>
+                <c>true</c> if parsing was successful; <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="str"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytesConverter.ConvertToBytesUnit(System.Int64,Microsoft.Performance.SDK.BytesUnits)">
+            <summary>
+                Converts the given count of bytes to the given units.
+            </summary>
+            <param name="bytesValue">
+                The count of bytes.
+            </param>
+            <param name="units">
+                The units into which to convert the count.
+            </param>
+            <returns>
+                The number of bytes as expressed in <paramref name="units"/>.
+            </returns>
+            <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+                <paramref name="units"/> is not a valid member of the <see cref="T:Microsoft.Performance.SDK.BytesUnits"/>
+                enumeration.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.SignedBytesConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StaticFunc`1">
+            <summary>
+                Encapsulates a method that has no parameters and returns a value of the <see cref="T:System.Type"/>
+                specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value of the method that this delegate encapsulates.
+            </typeparam>
+            <returns>
+                The return value of the method that this delegate encapsulates.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StaticFunc`2">
+            <summary>
+                Encapsulates a method that has one parameter and returns a value of the <see cref="T:System.Type"/>
+                specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of the parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value of the method that this delegate encapsulates.
+            </typeparam>
+            <param name="arg">
+                The parameter of the method that this delegate encapsulates.
+            </param>
+            <returns>
+                The return value of the method that this delegate encapsulates.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StaticFunc`3">
+            <summary>
+                Encapsulates a method that has two parameters and returns a value of the <see cref="T:System.Type"/>
+                specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value of the method that this delegate encapsulates.
+            </typeparam>
+            <param name="arg1">
+                The first parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg2">
+                The second parameter of the method that this delegate encapsulates.
+            </param>
+            <returns>
+                The return value of the method that this delegate encapsulates.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StaticFunc`4">
+            <summary>
+                Encapsulates a method that has three parameters and returns a value of the <see cref="T:System.Type"/>
+                specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter of the method that this delegate encapsulates.
+            </typeparam>
+            
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value of the method that this delegate encapsulates.
+            </typeparam>
+            <param name="arg1">
+                The first parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg2">
+                The second parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg3">
+                The third parameter of the method that this delegate encapsulates.
+            </param>
+            <returns>
+                The return value of the method that this delegate encapsulates.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StaticFunc`5">
+            <summary>
+                Encapsulates a method that has four parameters and returns a value of the <see cref="T:System.Type"/>
+                specified by the <typeparamref name="TResult"/> parameter.
+            </summary>
+            <typeparam name="T1">
+                The <see cref="T:System.Type"/> of the first parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T2">
+                The <see cref="T:System.Type"/> of the second parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T3">
+                The <see cref="T:System.Type"/> of the third parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="T4">
+                The <see cref="T:System.Type"/> of the fourth parameter of the method that this delegate encapsulates.
+            </typeparam>
+            <typeparam name="TResult">
+                The <see cref="T:System.Type"/> of the return value of the method that this delegate encapsulates.
+            </typeparam>
+            <param name="arg1">
+                The first parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg2">
+                The second parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg3">
+                The third parameter of the method that this delegate encapsulates.
+            </param>
+            <param name="arg4">
+                The fourth parameter of the method that this delegate encapsulates.
+            </param>
+            <returns>
+                The return value of the method that this delegate encapsulates.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison">
+            <summary>
+                Represents a string that compares without regards
+                to case sensitivity.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/>
+                class.
+            </summary>
+            <param name="source">
+                The underlying string value.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.CompareTo(Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.op_GreaterThan(Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison,Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.op_LessThan(Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison,Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithCaseInsensitiveComparison.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.StringWithLogicalComparison">
+            <summary>
+                Represents a string that is compared logically.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/>
+                class.
+            </summary>
+            <param name="source">
+                The underlying string value.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.CompareTo(Microsoft.Performance.SDK.StringWithLogicalComparison)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.System#IComparable#CompareTo(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.op_GreaterThan(Microsoft.Performance.SDK.StringWithLogicalComparison,Microsoft.Performance.SDK.StringWithLogicalComparison)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.op_LessThan(Microsoft.Performance.SDK.StringWithLogicalComparison,Microsoft.Performance.SDK.StringWithLogicalComparison)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.StringWithLogicalComparison"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.StringWithLogicalComparison.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Temporal">
+            <summary>
+                Represents a temporal interval.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.#ctor(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Temporal"/>
+                struct.
+            </summary>
+            <param name="startTime">
+                The start time.
+            </param>
+            <param name="endTime">
+                The end time.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.#ctor(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Temporal"/>
+                struct from the given time range.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Temporal.Default">
+            <summary>
+                Gets the default value of <see cref="T:Microsoft.Performance.SDK.Temporal"/>s.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Temporal.StartTime">
+            <summary>
+                Gets the start time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Temporal.EndTime">
+            <summary>
+                Gets the end time.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Temporal.TimeRange">
+            <summary>
+                Gets the range encompassed by this instance.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.Contains(Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether this instance encompasses
+                the given time.
+            </summary>
+            <param name="time">
+                The time.
+            </param>
+            <returns>
+                <c>true</c> if this instance contains <paramref name="time"/>;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.op_Explicit(Microsoft.Performance.SDK.TimeRange)~Microsoft.Performance.SDK.Temporal">
+            <summary>
+                Explicitly casts a <see cref="P:Microsoft.Performance.SDK.Temporal.TimeRange"/> to a <see cref="T:Microsoft.Performance.SDK.Temporal"/>.
+            </summary>
+            <param name="timeRange">
+                The range to cast.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.op_Implicit(Microsoft.Performance.SDK.Temporal)~Microsoft.Performance.SDK.TimeRange">
+            <summary>
+                Implicitly casts a <see cref="T:Microsoft.Performance.SDK.Temporal"/> to a <see cref="P:Microsoft.Performance.SDK.Temporal.TimeRange"/>.
+            </summary>
+            <param name="temporal">
+                The temporal to cast.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.op_Equality(Microsoft.Performance.SDK.Temporal,Microsoft.Performance.SDK.Temporal)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Temporal"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Temporal"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Temporal"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.op_Inequality(Microsoft.Performance.SDK.Temporal,Microsoft.Performance.SDK.Temporal)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Temporal"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Temporal"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Temporal"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Temporal.Equals(Microsoft.Performance.SDK.Temporal)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeFormatProvider">
+            <summary>
+            Abstract helper for Time based objects
+            <see cref="T:Microsoft.Performance.SDK.Timestamp"/>, <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>, <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeFormatProvider.GetFormat(System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeFormatProvider.Format(System.String,System.Object,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampDeltaFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeRangeFormatProvider">
+            <summary>
+            Format Provider for <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            <inheritdoc cref="T:System.IFormatProvider"/>
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeRange">
+            <summary>
+                Represents a range between two <see cref="T:Microsoft.Performance.SDK.Timestamp"/>s.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.StartTime">
+            <summary>
+                Gets or sets the start of the range.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.EndTime">
+            <summary>
+                Gets or sets the end of the range.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.op_Explicit(Microsoft.Performance.SDK.TimeRange)~Microsoft.Performance.SDK.Int64Range">
+            <summary>
+                Explicitly casts the given <see cref="T:Microsoft.Performance.SDK.TimeRange"/> to 
+                an <see cref="T:Microsoft.Performance.SDK.Int64Range"/> consisting of the nanosecond
+                representations of the times.
+            </summary>
+            <param name="range">
+                The range to convert.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.op_Explicit(Microsoft.Performance.SDK.Int64Range)~Microsoft.Performance.SDK.TimeRange">
+            <summary>
+                Explicitly casts the given <see cref="T:Microsoft.Performance.SDK.Int64Range"/>
+                consisting of the nanosecond representations of the times
+                to a <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="rangeNS">
+                The range to convert.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.op_Equality(Microsoft.Performance.SDK.TimeRange,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether the given instances are considered to be equal.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                <c>true</c> if the instances are considered to be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.op_Inequality(Microsoft.Performance.SDK.TimeRange,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether the given instances are not considered to be equal.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                <c>true</c> if the instances are not considered to be equal;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Equals(Microsoft.Performance.SDK.TimeRange)">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.Duration">
+            <summary>
+                Gets the duration represented by this <see cref="T:Microsoft.Performance.SDK.TimeRange"/>
+                as a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.#ctor(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimeRange"/>
+                struct.
+            </summary>
+            <param name="startTime">
+                The start time of the range.
+            </param>
+            <param name="endTime">
+                The end time for the range.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.#ctor(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimeRange"/>
+                struct.
+            </summary>
+            <param name="startTime">
+                The start time of the range.
+            </param>
+            <param name="duration">
+                The duration of the range.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Contains(Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether this instance contains the given <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </summary>
+            <param name="time">
+                The time to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="time"/> is contained within this range;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.IntersectsWith(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether this instance intersects with
+                the given instance.
+                <para/>
+                Does [this.startTime, this.endTime) intersect with [other.startTime, other.endTime)
+            </summary>
+            <param name="other">
+                The range to check against.
+            </param>
+            <returns>
+                <c>true</c> if the ranges intersect; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.IntersectsInclusivelyWith(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether this instance intersects inclusively with
+                the given instance.
+                <para/>
+                Does [this.startTime, this.endTime] intersect with [other.startTime, other.endTime]
+            </summary>
+            <param name="other">
+                The range to check against.
+            </param>
+            <returns>
+                <c>true</c> if the ranges intersect; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Intersect(Microsoft.Performance.SDK.TimeRange,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Gets the intersection of the two <see cref="T:Microsoft.Performance.SDK.TimeRange"/> instances.
+            </summary>
+            <param name="x">
+                The first time range.
+            </param>
+            <param name="y">
+                The second time range.
+            </param>
+            <returns>
+                The intersection, if one exists; <c>null</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Union(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.TimeRange})">
+            <summary>
+                Merges the set of <see cref="T:Microsoft.Performance.SDK.TimeRange"/> instances into the smallest
+                non-overlapping set.
+            </summary>
+            <param name="ranges">
+                The ranges.
+            </param>
+            <returns>
+                The smallest set of non-overlapping <see cref="T:Microsoft.Performance.SDK.TimeRange"/>s.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.Default">
+            <summary>
+                Gets the default <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.FullRange">
+            <summary>
+                Gets the largest possible <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimeRange.Zero">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.TimeRange"/> representing no time.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Parse(System.String)">
+            <summary>
+                Parses the given string into a <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.TimeRange" />
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="s"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.FormatException">
+                <paramref name="s"/> is not parseable into a <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.TryParse(System.String,Microsoft.Performance.SDK.TimeRange@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="result">
+                The parsed <see cref="T:Microsoft.Performance.SDK.TimeRange"/>; if successful.
+            </param>
+            <returns>
+                <c>true</c> if parsing was successful; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.Microsoft#Performance#SDK#IFormatForClipboard#ToClipboardString(System.String,System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToType(System.Type,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#GetTypeCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToBoolean(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToChar(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToDateTime(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToDecimal(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToDouble(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToSByte(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToSingle(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToString(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToUInt16(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToUInt32(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRange.System#IConvertible#ToUInt64(System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeRangeConverter">
+            <summary>
+                Converts instances to <see cref="T:Microsoft.Performance.SDK.TimeRange"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimeRange"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeRangeExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for dealing
+                with <see cref="T:Microsoft.Performance.SDK.TimeRange"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.TryGetSpanningRange(System.Collections.Generic.IList{Microsoft.Performance.SDK.TimeRange})">
+            <summary>
+                Attempts to get a range that spans all of the time ranges
+                in the given collection.
+            </summary>
+            <param name="sortedTimeRanges">
+                A sorted collection of timeranges to span.
+            </param>
+            <returns>
+                A spanning timerange, if one exists; <c>null</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.MinTime(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Gets the minimum time in the <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+            <returns>
+                The minimum value.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.MaxTime(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Gets the maximum time in the <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+            <returns>
+                The maximum value.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.AbsDuration(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Gets the absolute value of the duration of the given time range.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+            <returns>
+                The absolute value of the duration of the timerange.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.AsOrdered(Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Gets the given <see cref="T:Microsoft.Performance.SDK.TimeRange"/> as an ordered
+                <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+            <returns>
+                The ordered timerange.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimeRangeExtensions.AsOrdered(System.Nullable{Microsoft.Performance.SDK.TimeRange})">
+            <summary>
+                Gets the given <see cref="T:Microsoft.Performance.SDK.TimeRange"/> as an ordered
+                <see cref="T:Microsoft.Performance.SDK.TimeRange"/>.
+            </summary>
+            <param name="timeRange">
+                The time range.
+            </param>
+            <returns>
+                The ordered timerange.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.Timestamp">
+            <summary>
+                Represents a timestamp. A timestamp is a point in time
+                relative to zero (0) in a data analysis.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.#ctor(System.Int64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                class.
+            </summary>
+            <param name="nanoseconds">
+                The value of the timestamp in nanoseconds.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromNanoseconds(System.Int64)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of nanoseconds.
+            </summary>
+            <param name="nanoseconds">
+                The value in nanoseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromMicroseconds(System.Int64)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of microseconds.
+            </summary>
+            <param name="microseconds">
+                The value in microseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromMilliseconds(System.Int64)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of milliseconds.
+            </summary>
+            <param name="milliseconds">
+                The value in milliseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromSeconds(System.Int64)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of seconds.
+            </summary>
+            <param name="seconds">
+                The value in seconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromNanoseconds(System.Double)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of nanoseconds.
+            </summary>
+            <param name="nanoseconds">
+                The value in nanoseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromMicroseconds(System.Double)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of microseconds.
+            </summary>
+            <param name="microseconds">
+                The value in microseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromMilliseconds(System.Double)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of milliseconds.
+            </summary>
+            <param name="milliseconds">
+                The value in milliseconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.FromSeconds(System.Double)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from the given
+                quantity of seconds.
+            </summary>
+            <param name="seconds">
+                The value in seconds.
+            </param>
+            <returns>
+                The <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.ToNanoseconds">
+            <summary>
+                Gets the value of this instance in nanoseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.ToMicroseconds">
+            <summary>
+                Gets the value of this instance in microseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.ToMilliseconds">
+            <summary>
+                Gets the value of this instance in milliseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.ToSeconds">
+            <summary>
+                Gets the value of this instance in seconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.ToTimeSpan">
+            <summary>
+                Gets the value of this instance as a <see cref="T:System.TimeSpan"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Abs(Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> representing the absolute
+                value of the given <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+            <param name="value">
+                The value.
+            </param>
+            <returns>
+                The absolute value of <paramref name="value"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Min(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Gets the minimum of two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instances.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                The instance that is considered to be the minimum of the two.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Max(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Gets the maximum of two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instances.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                The instance that is considered to be the maximum of the two.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Clamp(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="min">
+                The minimum allowable value.
+            </param>
+            <param name="max">
+                The maximum allowable value.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="max"/> is less than <paramref name="min"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Clamp(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="minMax">
+                The range to clamp.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                The end time is less than the start time.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.SafeClamp(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extreme1">
+                One of the extremes of the range.
+            </param>
+            <param name="extreme2">
+                The other extreme of the range.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.SafeClamp(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extremes">
+                The range to clamp.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.IsClamped(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether the given value has been clamped into the
+                specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="min">
+                The minimum value of the clamp.
+            </param>
+            <param name="max">
+                The maximum value of the clamp.
+            </param>
+            <returns>
+                <c>true</c> if the value has been clamped; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.IsClamped(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether the given value has been clamped into the
+                specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="minMax">
+                The range of the clamp.
+            </param>
+            <returns>
+                <c>true</c> if the value has been clamped; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.SafeIsClamped(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether the given value has been clamped into the
+                specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="extreme1">
+                One extreme of the clamp.
+            </param>
+            <param name="extreme2">
+                The other extreme of the clamp.
+            </param>
+            <returns>
+                <c>true</c> if the value has been clamped; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.SafeIsClamped(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimeRange)">
+            <summary>
+                Determines whether the given value has been clamped into the
+                specified range.
+            </summary>
+            <param name="value">
+                The value to check.
+            </param>
+            <param name="extremes">
+                The extremes of the clamp.
+            </param>
+            <returns>
+                <c>true</c> if the value has been clamped; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.Zero">
+            <summary>
+                Gets the instance that represents a timestamp of zero (0) nanoseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.MinValue">
+            <summary>
+                Gets the instance representing the minimum representable
+                value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.MaxValue">
+            <summary>
+                Gets the instance representing the maximum representable
+                value.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.LegacyMin">
+            <summary>
+                Gets the instance representing the minimum representable
+                value. This is exists for backwards compatibility and
+                is not to be used.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.LegacyMax">
+            <summary>
+                Gets the instance representing the maximum representable
+                value. This is exists for backwards compatibility and
+                is not to be used.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.LegacyEnd">
+            <summary>
+                Represents the largest possible timestamp valid for
+                the end of a data stream. This is exists for backwards
+                compatibility and is not to be used.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.Timestamp.BoxedZero">
+            <summary>
+                Gets the instance that represents a delta of zero (0) nanoseconds,
+                already boxed.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.CompareTo(Microsoft.Performance.SDK.Timestamp)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Equals(Microsoft.Performance.SDK.Timestamp)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_LessThan(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_GreaterThan(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_LessThanOrEqual(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_GreaterThanOrEqual(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_Equality(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Timestamp"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_Inequality(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.Timestamp"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.Timestamp"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_Subtraction(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.Timestamp)">
+            <summary>
+                Subtracts two quantities of <see cref="T:Microsoft.Performance.SDK.Timestamp"/> from
+                each other.
+            </summary>
+            <param name="first">
+                The minuend.
+            </param>
+            <param name="second">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="second"/> from
+                <paramref name="first"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_Addition(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Adds the given delta to the given timestamp.
+            </summary>
+            <param name="time">
+                The first addend.
+            </param>
+            <param name="duration">
+                The second addend.
+            </param>
+            <returns>
+                The result of the addition of <paramref name="time"/> with
+                <paramref name="duration"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.op_Subtraction(Microsoft.Performance.SDK.Timestamp,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Subtracts the given delta from the given timestamp.
+            </summary>
+            <param name="time">
+                The minuend.
+            </param>
+            <param name="duration">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="duration"/>
+                from <paramref name="time"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.ToString(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.ToClipboardString(System.String,System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.ToString2(Microsoft.Performance.SDK.TimeUnit)">
+            <summary>
+                Gets the string representation of this
+                instance using the specified units.
+            </summary>
+            <param name="units">
+                The units.
+            </param>
+            <returns>
+                The string representation.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Parse(System.String)">
+            <summary>
+                Parses the given string into a <see cref="T:Microsoft.Performance.SDK.Timestamp" />,
+                assuming nanoseconds if no units are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+            </returns>
+            <exception cref="T:System.FormatException">
+                The given string is not parseable into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.Parse(System.String,Microsoft.Performance.SDK.TimeUnit)">
+            <summary>
+                Parses the given string into a <see cref="T:Microsoft.Performance.SDK.Timestamp" />,
+                assuming the given units if no units are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if no units are present in <paramref name="s"/>.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+            </returns>
+            <exception cref="T:System.FormatException">
+                The given string is not parseable into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </exception>
+            <exception cref="T:System.OverflowException">
+                The string represents a value not representable by a
+                <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.TryParse(System.String,Microsoft.Performance.SDK.Timestamp@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,Microsoft.Performance.SDK.Timestamp@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>,
+                assuming the given units if none are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in <paramref name="s"/>.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.Timestamp.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,Microsoft.Performance.SDK.Timestamp@,Microsoft.Performance.SDK.TimeUnit@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>,
+                assuming the given units if none are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in <paramref name="s"/>.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <param name="parsedUnits">
+                The units parsed.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampConverter">
+            <summary>
+                Converts instances to <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimestampConverter"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampDelta">
+            <summary>
+                Represents a delta between two <see cref="T:Microsoft.Performance.SDK.Timestamp"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.#ctor(System.Int64)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                class.
+            </summary>
+            <param name="nanoseconds">
+                The difference in nanoseconds between the timestamps.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromNanoseconds(System.Int64)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of nanoseconds.
+            </summary>
+            <param name="nanoseconds">
+                The number of nanoseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromMicroseconds(System.Int64)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of microseconds.
+            </summary>
+            <param name="microseconds">
+                The number of microseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromMilliseconds(System.Int64)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of milliseconds.
+            </summary>
+            <param name="milliseconds">
+                The number of milliseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromSeconds(System.Int64)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of seconds.
+            </summary>
+            <param name="seconds">
+                The number of seconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromNanoseconds(System.Double)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of nanoseconds.
+            </summary>
+            <param name="nanoseconds">
+                The number of nanoseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromMicroseconds(System.Double)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of microseconds.
+            </summary>
+            <param name="microseconds">
+                The number of microseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromMilliseconds(System.Double)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of milliseconds.
+            </summary>
+            <param name="milliseconds">
+                The number of milliseconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.FromSeconds(System.Double)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from the given
+                count of seconds.
+            </summary>
+            <param name="seconds">
+                The number of seconds.
+            </param>
+            <returns>
+                A new <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.ToNanoseconds">
+            <summary>
+                Gets the value of this instance in nanoseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.ToMicroseconds">
+            <summary>
+                Gets the value of this instance in microseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.ToMilliseconds">
+            <summary>
+                Gets the value of this instance in milliseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.ToSeconds">
+            <summary>
+                Gets the value of this instance in seconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.ToTimeSpan">
+            <summary>
+                Gets the value of this instance as a <see cref="T:System.TimeSpan"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Abs(Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Gets a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> representing the absolute
+                value of the given <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+            <param name="value">
+                The value.
+            </param>
+            <returns>
+                The absolute value of <paramref name="value"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Min(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Gets the minimum of two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instances.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                The instance that is considered to be the minimum of the two.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Max(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Gets the maximum of two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instances.
+            </summary>
+            <param name="first">
+                The first instance.
+            </param>
+            <param name="second">
+                The second instance.
+            </param>
+            <returns>
+                The instance that is considered to be the maximum of the two.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Clamp(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="min">
+                The minimum allowable value.
+            </param>
+            <param name="max">
+                The maximum allowable value.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="max"/> is less than <paramref name="min"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.SafeClamp(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Clamps the given instance to a value in the range specified.
+            </summary>
+            <param name="value">
+                The value to clamp.
+            </param>
+            <param name="extreme1">
+                One of the extremes of the range.
+            </param>
+            <param name="extreme2">
+                The other extreme of the range.
+            </param>
+            <returns>
+                The value clamped to an acceptable value within the specified range.
+            </returns>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.Zero">
+            <summary>
+                Gets the instance that represents a delta of zero (0) nanoseconds.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.MinValue">
+            <summary>
+                Gets the instance representing the minimum representable
+                delta.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.MaxValue">
+            <summary>
+                Gets the instance representing the maximum representable
+                delta.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.SDK.TimestampDelta.BoxedZero">
+            <summary>
+                Gets the instance that represents a delta of zero (0) nanoseconds,
+                already boxed.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.CompareTo(Microsoft.Performance.SDK.TimeRange)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.CompareTo(Microsoft.Performance.SDK.TimestampDelta)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Equals(Microsoft.Performance.SDK.TimeRange)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Equals(Microsoft.Performance.SDK.TimestampDelta)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_LessThan(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                is strictly less than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly less than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_GreaterThan(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                is strictly greater than another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be strictly greater than <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_LessThanOrEqual(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                is less than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be less than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_GreaterThanOrEqual(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether one instance of an <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                is greater than or equal to another instance.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be greater than or equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Equality(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> instances
+                are considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Inequality(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Determines whether two <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> instances
+                are *not* considered to be equal.
+            </summary>
+            <param name="first">
+                The first <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <param name="second">
+                The second <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to compare.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="first"/> is not considered
+                to be equal to <paramref name="second"/>; <c>false</c>
+                otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Subtraction(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Subtracts two quantities of <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> from
+                each other.
+            </summary>
+            <param name="first">
+                The minuend.
+            </param>
+            <param name="second">
+                The subtrahend.
+            </param>
+            <returns>
+                The result of the subtraction of <paramref name="second"/> from
+                <paramref name="first"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Addition(Microsoft.Performance.SDK.TimestampDelta,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Adds two quantities of <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> to
+                each other.
+            </summary>
+            <param name="first">
+                The first addend.
+            </param>
+            <param name="second">
+                The second addend.
+            </param>
+            <returns>
+                The result of the addition of <paramref name="first"/> with
+                <paramref name="second"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Multiply(Microsoft.Performance.SDK.TimestampDelta,System.Double)">
+            <summary>
+                Multiplies the given <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> by the given
+                quantity.
+            </summary>
+            <param name="value">
+                The multiplicand.
+            </param>
+            <param name="factor">
+                The multiplier.
+            </param>
+            <returns>
+                The product of <paramref name="value"/> multiplied by the <paramref name="factor"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_Multiply(System.Double,Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Multiplies the given <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/> by the given
+                quantity.
+            </summary>
+            <param name="factor">
+                The multiplicand.
+            </param>
+            <param name="value">
+                The multiplier.
+            </param>
+            <returns>
+                The product of <paramref name="value"/> multiplied by the <paramref name="factor"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.op_UnaryNegation(Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Gets the unary negation of the given <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+            <param name="value">
+                The value to negate.
+            </param>
+            <returns>
+                The negation of <paramref name="value"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.DivideRoundUp(Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Divides this instance by another instance, rounding the result
+                of the division up.
+            </summary>
+            <param name="other">
+                The divisor.
+            </param>
+            <returns>
+                The quotient as a <see cref="T:System.Int64"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.DivideRoundUpAsDouble(Microsoft.Performance.SDK.TimestampDelta)">
+            <summary>
+                Divides this instance by another instance, rounding the result
+                of the division up.
+            </summary>
+            <param name="other">
+                The divisor.
+            </param>
+            <returns>
+                The quotient as a <see cref="T:System.Double"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.ToString(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.ToString(System.String,System.IFormatProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.ToClipboardString(System.String,System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Parse(System.String)">
+            <summary>
+                Parses the given string into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta" />,
+                assuming nanoseconds if no units are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+            </returns>
+            <exception cref="T:System.FormatException">
+                The given string is not parseable into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.Parse(System.String,Microsoft.Performance.SDK.TimeUnit)">
+            <summary>
+                Parses the given string into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta" />,
+                assuming the given units if no units are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if no units are present in <paramref name="s"/>.
+            </param>
+            <returns>
+                The parsed <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+            </returns>
+            <exception cref="T:System.FormatException">
+                The given string is not parseable into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </exception>
+            <exception cref="T:System.OverflowException">
+                The string represents a value not representable by a
+                <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.TryParse(System.String,Microsoft.Performance.SDK.TimestampDelta@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,Microsoft.Performance.SDK.TimestampDelta@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>,
+                assuming the given units if none are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in <paramref name="s"/>.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDelta.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,Microsoft.Performance.SDK.TimestampDelta@,Microsoft.Performance.SDK.TimeUnit@)">
+            <summary>
+                Attempts to parse the given string into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>,
+                assuming the given units if none are specified in the string.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in <paramref name="s"/>.
+            </param>
+            <param name="result">
+                The result of parsing, if successful.
+            </param>
+            <param name="parsedUnits">
+                The units parsed.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="s"/> can be parsed into a <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instance; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampDeltaConverter">
+            <summary>
+                Converts instances to <see cref="T:Microsoft.Performance.SDK.TimestampDelta"/>
+                instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.#ctor">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.SDK.TimestampDeltaConverter"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampDeltaConverter.GetOutputType">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimestampFormatter">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for formatting
+                <see cref="T:Microsoft.Performance.SDK.Timestamp"/> instances.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatGrouped">
+            <summary>
+                Format the timestamp in a grouped way.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatWithUnits">
+            <summary>
+                Place units in the formatted string.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatSeconds">
+            <summary>
+                Format as seconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatMilliseconds">
+            <summary>
+                Format as milliseconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatMicroseconds">
+            <summary>
+                Format as microseconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatNanoseconds">
+            <summary>
+                Format as nanoseconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatSecondsGrouped">
+            <summary>
+                Format as seconds grouped.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatMillisecondsGrouped">
+            <summary>
+                Format as milliseconds grouped.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatMicrosecondsGrouped">
+            <summary>
+                Format as microseconds grouped.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimestampFormatter.FormatNanosecondsGrouped">
+            <summary>
+                Format as nanoseconds grouped.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.ToString(System.Int64,System.String,System.IFormatProvider)">
+            <summary>
+                Converts the given count of nanoseconds to a string.
+            </summary>
+            <param name="nanoseconds">
+                The nanoseconds to convert.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="formatProvider">
+                The format provider.
+            </param>
+            <returns>
+                The string representation of the nanoseconds.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.ToClipboardString(System.Int64,System.String,System.IFormatProvider,System.Boolean)">
+            <summary>
+                Converts the given count of nanoseconds to a string suitable for the system
+                clipboard.
+            </summary>
+            <param name="nanoseconds">
+                The nanoseconds to convert.
+            </param>
+            <param name="format">
+                A composite format string.
+            </param>
+            <param name="formatProvider">
+                The format provider.
+            </param>
+            <param name="includeUnits">
+                Whether to include units in the generated string.
+            </param>
+            <returns>
+                The string representation of the nanoseconds.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.ToString(System.Int64,System.IFormatProvider,Microsoft.Performance.SDK.TimeUnit,System.Boolean,System.Boolean)">
+            <summary>
+                Converts the given count of nanoseconds to a string.
+            </summary>
+            <param name="nanoseconds">
+                The nanoseconds to convert.
+            </param>
+            <param name="formatProvider">
+                The format provider.
+            </param>
+            <param name="timeUnits">
+                The units to use.
+            </param>
+            <param name="includeUnits">
+                Whether to include units in the generated string.
+            </param>
+            <param name="includeThousandsSeparator">
+                Whether to include the thousands separator in the generates string.
+            </param>
+            <returns>
+                The string representation of the nanoseconds.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.ParseToNanoseconds(System.String)">
+            <summary>
+                Parses the given string to nanoseconds.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <returns>
+                The parsed nanoseconds.
+            </returns>
+            <exception cref="T:System.FormatException">
+                The string cannot be parsed.
+            </exception>
+            <exception cref="T:System.OverflowException">
+                The string represents a value not representable by a
+                <see cref="T:System.Int64"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.ParseToNanoseconds(System.String,Microsoft.Performance.SDK.TimeUnit)">
+            <summary>
+                Parses the given string to nanoseconds.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in the string.
+            </param>
+            <returns>
+                The parsed nanoseconds.
+            </returns>
+            <exception cref="T:System.FormatException">
+                The string cannot be parsed.
+            </exception>
+            <exception cref="T:System.OverflowException">
+                The string represents a value not representable by a
+                <see cref="T:System.Int64"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.TryParse(System.String,System.Int64@)">
+            <summary>
+                Parses the string as a timestamp.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="resultNS">
+                The parsed timestamp, in units of nanoseconds.
+            </param>
+            <returns>
+                <c>true</c> if the string was parsed successfully; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,System.Int64@)">
+            <summary>
+                Parses the string as a timestamp.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in the string.
+            </param>
+            <param name="resultNS">
+                The parsed timestamp, in units of nanoseconds.
+            </param>
+            <returns>
+                <c>true</c> if the string was parsed successfully; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TimestampFormatter.TryParse(System.String,Microsoft.Performance.SDK.TimeUnit,System.Int64@,Microsoft.Performance.SDK.TimeUnit@)">
+            <summary>
+                Parses the string as a timestamp which may include a specification for the units of time.
+            </summary>
+            <param name="s">
+                The string to parse.
+            </param>
+            <param name="defaultUnits">
+                The units to assume if none are specified in the string.
+            </param>
+            <param name="resultNS">
+                The parsed timestamp, in units of nanoseconds.
+            </param>
+            <param name="parsedUnits">
+                The units that were parsed from the string, or defaultUnits if none were found.
+            </param>
+            <returns>
+                <c>true</c> if the string was parsed successfully; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TimeUnit">
+            <summary>
+                Represents units of time.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimeUnit.Seconds">
+            <summary>
+                Represents seconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimeUnit.Milliseconds">
+            <summary>
+                Represents milliseconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimeUnit.Microseconds">
+            <summary>
+                Represents microseconds.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Performance.SDK.TimeUnit.Nanoseconds">
+            <summary>
+                Represents nanoseconds.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.SDK.TypeExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:System.Type"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsAssignableTo(System.Type,System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is
+                assignable to an instance of the specified <see cref="T:System.Type"/>.
+            </summary>
+            <param name="type">
+                The current type.
+            </param>
+            <param name="baseType">
+                The target type.
+            </param>
+            <returns>
+                <c>true</c> if an instance of <see cref="T:System.Type"/> <paramref name="type"/>
+                is assignable to an instance of <see cref="T:System.Type"/> <paramref name="baseType"/>;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="type"/> is <c>null</c>.
+                - or -
+                <paramref name="baseType"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsNullableType(System.Type)">
+            <summary>
+                Determines whether the current type is <see cref="T:System.Nullable"/>.
+            </summary>
+            <param name="type">
+                The type to check.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> represents a nullable
+                type; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.WhereAssignableFrom``1(System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+                Gets the collection of <see cref="T:System.Type"/> from the given collection that are
+                assignable to <see cref="T:System.Type"/> <typeparamref name="TBase"/>.
+            </summary>
+            <typeparam name="TBase">
+                The target <see cref="T:System.Type"/>.
+            </typeparam>
+            <param name="items">
+                The <see cref="T:System.Type"/>s to check.
+            </param>
+            <returns>
+                All <see cref="T:System.Type"/> from <paramref name="items"/> that are assignable to
+                <typeparamref name="TBase"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="items"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.WhereAssignableFrom(System.Collections.Generic.IEnumerable{System.Type},System.Type)">
+            <summary>
+                Gets the collection of <see cref="T:System.Type"/> from the given collection that are
+                assignable to <see cref="T:System.Type"/> <paramref name="baseType"/>.
+            </summary>
+            <param name="items">
+                The <see cref="T:System.Type"/>s to check.
+            </param>
+            <param name="baseType">
+                The target <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                All <see cref="T:System.Type"/> from <paramref name="items"/> that are assignable to
+                <paramref name="baseType"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="items"/> is <c>null</c>.
+                - or -
+                <paramref name="baseType"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsAssignableToGenericType(System.Type,System.Type)">
+            <summary>
+                Determines if the current <see cref="T:System.Type"/> is assignable to the
+                given generic <see cref="T:System.Type"/>.
+            </summary>
+            <param name="type">
+                The current type.
+            </param>
+            <param name="generic">
+                The generic type.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> is assignable to <paramref name="generic"/>;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.Is(System.Type,System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is
+                assignable to an instance of the specified <see cref="T:System.Type"/>.
+            </summary>
+            <param name="self">
+                The current type.
+            </param>
+            <param name="other">
+                The target type.
+            </param>
+            <returns>
+                <c>true</c> if an instance of <see cref="T:System.Type"/> <paramref name="self"/>
+                is assignable to an instance of <see cref="T:System.Type"/> <paramref name="other"/>;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+                - or -
+                <paramref name="other"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.Is``1(System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is
+                assignable to an instance of the specified <see cref="T:System.Type"/>.
+            </summary>
+            <typeparam name="T">
+                The target type.
+            </typeparam>
+            <param name="self">
+                The current type.
+            </param>
+            <returns>
+                <c>true</c> if an instance of <see cref="T:System.Type"/> <paramref name="self"/>
+                is assignable to an instance of <see cref="T:System.Type"/> <typeparamref name="T"/>.
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="self"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.Implements``1(System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> implements
+                the given interface <see cref="T:System.Type"/>.
+            </summary>
+            <typeparam name="TInterface">
+                The interface <see cref="T:System.Type"/>.
+            </typeparam>
+            <param name="type">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> implements the given interface <see cref="T:System.Type"/>;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="type"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <typeparamref name="TInterface"/> does not represent an interface <see cref="T:System.Type"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.Implements(System.Type,System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> implements
+                the given interface <see cref="T:System.Type"/>.
+            </summary>
+            <param name="type">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <param name="interfaceType">
+                The interface <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="type"/> implements the given interface;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="type"/> is <c>null</c>.
+                - or -
+                <paramref name="interfaceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="interfaceType"/> does not represent an interface <see cref="T:System.Type"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsStatic(System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is static.
+            </summary>
+            <param name="self">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is static;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsInstantiatable(System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is instantiable.
+                Instantiable <see cref="T:System.Type"/>s are concrete.
+            </summary>
+            <param name="self">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is instantiable;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsConcrete(System.Type)">
+            <summary>
+                Determines whether the current <see cref="T:System.Type"/> is concrete.
+                Concrete <see cref="T:System.Type"/>s can be instantiated.
+            </summary>
+            <param name="self">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is concrete;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsPublic(System.Type)">
+            <summary>
+                Determines whether the given <see cref="T:System.Type"/> is considered to be
+                public or nested public.
+            </summary>
+            <param name="self">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                <c>true</c> if <paramref name="self"/> is public or
+                nested public; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.Default(System.Type)">
+            <summary>
+                Gets the default value for the given <see cref="T:System.Type"/>.
+            </summary>
+            <param name="self">
+                The current <see cref="T:System.Type"/>.
+            </param>
+            <returns>
+                The default value for instances of the <see cref="T:System.Type"/>
+                referred to by <paramref name="self"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.SDK.TypeExtensions.IsNumeric(System.Type)">
+            <summary>
+             Determines whether the given <see cref="T:System.Type"/> is a numeric type
+            </summary>
+            <param name="self"></param>
+            <returns></returns>
+        </member>
+    </members>
+</doc>

--- a/src/Microsoft.Performance.SDK/Processing/ITableBuilder.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ITableBuilder.cs
@@ -88,6 +88,47 @@ namespace Microsoft.Performance.SDK.Processing
             Action<TableCommandContext> onExecute);
 
         /// <summary>
+        ///     Registers a command that users can execute against this table.
+        ///     <para/>
+        ///     Compared to <see cref="AddTableCommand2(string, Predicate{TableCommandContext}, Action{TableCommandContext})"/>,
+        ///     this overload uses <see cref="TableCommandContext2"/>, whose selected rows
+        ///     also carry sub-row indices for hierarchical columns, and expects the callback
+        ///     to return a <see cref="TableCommandResult"/> asynchronously.
+        /// </summary>
+        /// <param name="commandName">
+        ///     The human-readable name to associate with the command.
+        /// </param>
+        /// <param name="canExecute">
+        ///     The callback to execute to determine if the user can choose this command.
+        /// </param>
+        /// <param name="onExecute">
+        ///     The asynchronous callback to execute when the user chooses this command.
+        ///     Callbacks that do not need to return a value should return
+        ///     <see cref="VoidTableCommandResult.Instance"/>.
+        /// </param>
+        /// <returns>
+        ///     This instance of the builder.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">
+        ///     <paramref name="commandName"/> is <c>null</c>.
+        ///     - or -
+        ///     <paramref name="canExecute"/> is <c>null</c>.
+        ///     - or -
+        ///     <paramref name="onExecute"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        ///     <paramref name="commandName"/> is whitespace.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        ///     A command with <paramref name="commandName"/> has already been added
+        ///     to this instance via <see cref="AddTableCommand3"/>, irrespective of casing.
+        /// </exception>
+        ITableBuilder AddTableCommand3(
+            string commandName,
+            Predicate<TableCommandContext2> canExecute,
+            TableCommandCallback2 onExecute);
+
+        /// <summary>
         ///     Adds a configuration for this table to the builder.
         /// </summary>
         /// <param name="configuration">

--- a/src/Microsoft.Performance.SDK/Processing/SelectedTableRow.cs
+++ b/src/Microsoft.Performance.SDK/Processing/SelectedTableRow.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     Represents a row selected by the user at the time a table command is invoked.
+///     <para/>
+///     A selected row is identified by its top-level <see cref="RowIndex"/> in the table.
+///     When the row belongs to (or expands into) an <see cref="IHierarchicalDataColumn{T}"/>,
+///     the specific expansion(s) selected within that row are described by
+///     <see cref="SubRowIndices"/>. An empty <see cref="SubRowIndices"/> means the
+///     top-level row itself is selected, with no sub-row expansion.
+/// </summary>
+/// <param name="RowIndex">
+///     The zero-based index of the selected row in the table.
+/// </param>
+/// <param name="SubRowIndices">
+///     The zero-based indices of the selected sub-rows within the expanded
+///     hierarchical column of <see cref="RowIndex"/>. May be empty if the top-level
+///     row itself is selected. Never <c>null</c>; a <c>null</c> value passed to the
+///     constructor is normalized to an empty list.
+/// </param>
+public record SelectedTableRow(int RowIndex, IReadOnlyList<int> SubRowIndices)
+{
+    /// <summary>
+    ///     The zero-based indices of the selected sub-rows within the expanded
+    ///     hierarchical column of <see cref="RowIndex"/>. Never <c>null</c>.
+    /// </summary>
+    public IReadOnlyList<int> SubRowIndices { get; init; } = SubRowIndices ?? Array.Empty<int>();
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SelectedTableRow"/> record
+    ///     representing a selection of the top-level row only, with no sub-row expansion.
+    /// </summary>
+    /// <param name="rowIndex">
+    ///     The zero-based index of the selected row in the table.
+    /// </param>
+    public SelectedTableRow(int rowIndex)
+        : this(rowIndex, Array.Empty<int>())
+    {
+    }
+}

--- a/src/Microsoft.Performance.SDK/Processing/TableCommandCallback2.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableCommandCallback2.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     Represents an asynchronous function to be called when the user executes a
+///     command against a table registered via
+///     <see cref="ITableBuilder.AddTableCommand3(string, System.Predicate{TableCommandContext2}, TableCommandCallback2)"/>.
+/// </summary>
+/// <param name="context">
+///     The <see cref="TableCommandContext2"/> describing the invocation, including the
+///     selected rows and sub-rows.
+/// </param>
+/// <param name="cancellationToken">
+///     A <see cref="CancellationToken"/> that the host may signal to request that
+///     the command abort.
+/// </param>
+/// <returns>
+///     A <see cref="Task{TResult}"/> that resolves to a <see cref="TableCommandResult"/>
+///     describing the outcome of the command. Callbacks that do not need to return a
+///     value should return <see cref="VoidTableCommandResult.Instance"/>.
+/// </returns>
+public delegate Task<TableCommandResult> TableCommandCallback2(
+    TableCommandContext2 context,
+    CancellationToken cancellationToken);

--- a/src/Microsoft.Performance.SDK/Processing/TableCommandContext2.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableCommandContext2.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     Context for the execution of a table command registered via
+///     <see cref="ITableBuilder.AddTableCommand3(string, Predicate{TableCommandContext2}, TableCommandCallback2)"/>.
+///     <para/>
+///     Unlike <see cref="TableCommandContext"/>, the selected rows are described by
+///     <see cref="SelectedTableRow"/> values, which also carry any sub-row indices
+///     selected within an expanded <see cref="IHierarchicalDataColumn{T}"/>.
+/// </summary>
+/// <param name="Column">
+///     The <see cref="Guid"/> of the column that the command was invoked on.
+///     This value may be <c>null</c>.
+/// </param>
+/// <param name="Configuration">
+///     The <see cref="TableConfiguration"/> of the table that was applied at the time
+///     the command was invoked. This value may be <c>null</c>.
+/// </param>
+/// <param name="SelectedRows">
+///     The rows that are selected by the user at the time the command is invoked.
+/// </param>
+public record TableCommandContext2(
+    Guid? Column,
+    TableConfiguration Configuration,
+    IReadOnlyList<SelectedTableRow> SelectedRows);

--- a/src/Microsoft.Performance.SDK/Processing/TableCommandResults/OpenUrisTableCommandResult.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableCommandResults/OpenUrisTableCommandResult.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     A <see cref="TableCommandResult"/> that instructs the host to open one or
+///     more <see cref="Uri"/>s on the plugin's behalf. The interpretation of each
+///     <see cref="Uri"/> (for example, launching a web browser for <c>http(s)</c>
+///     URIs, opening a file for <c>file</c> URIs, or handing off to a registered
+///     custom scheme handler) is left to the host.
+/// </summary>
+/// <param name="Uris">
+///     The <see cref="Uri"/>s to open. Must not be <c>null</c>.
+/// </param>
+public sealed record OpenUrisTableCommandResult : TableCommandResult
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="OpenUrisTableCommandResult"/>
+    ///     record.
+    /// </summary>
+    /// <param name="Uris">
+    ///     The <see cref="Uri"/>s to open. Must not be <c>null</c>.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="Uris"/> is <c>null</c>.
+    /// </exception>
+    public OpenUrisTableCommandResult(IReadOnlyList<Uri> Uris)
+    {
+        Guard.NotNull(Uris, nameof(Uris));
+        this.Uris = Uris;
+    }
+
+    /// <summary>
+    ///     Gets the <see cref="Uri"/>s the host should open.
+    /// </summary>
+    public IReadOnlyList<Uri> Uris { get; init; }
+}

--- a/src/Microsoft.Performance.SDK/Processing/TableCommandResults/TableCommandResult.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableCommandResults/TableCommandResult.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     Base type for the result of a table command executed via
+///     <see cref="ITableBuilder.AddTableCommand3(string, System.Predicate{TableCommandContext2}, TableCommandCallback2)"/>.
+///     <para/>
+///     Concrete result types are defined by the SDK (for example
+///     <see cref="VoidTableCommandResult"/> and <see cref="OpenUrisTableCommandResult"/>).
+///     Hosts inspect the returned <see cref="TableCommandResult"/> to decide what
+///     follow-up action, if any, to perform on the plugin's behalf.
+/// </summary>
+public abstract record TableCommandResult;

--- a/src/Microsoft.Performance.SDK/Processing/TableCommandResults/VoidTableCommandResult.cs
+++ b/src/Microsoft.Performance.SDK/Processing/TableCommandResults/VoidTableCommandResult.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Performance.SDK.Processing;
+
+/// <summary>
+///     A <see cref="TableCommandResult"/> that carries no value. Use this when a
+///     table command completes without needing to return any information to the host.
+///     <para/>
+///     Prefer the shared <see cref="Instance"/> singleton to avoid allocations.
+/// </summary>
+public sealed record VoidTableCommandResult : TableCommandResult
+{
+    /// <summary>
+    ///     Gets the shared <see cref="VoidTableCommandResult"/> instance.
+    /// </summary>
+    public static VoidTableCommandResult Instance { get; } = new VoidTableCommandResult();
+}

--- a/src/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.xml
+++ b/src/Microsoft.Performance.Toolkit.Engine/Microsoft.Performance.Toolkit.Engine.xml
@@ -1,0 +1,2158 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Performance.Toolkit.Engine</name>
+    </assembly>
+    <members>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.CookerOutput">
+            <summary>
+                Retrieves data from a single cooker instance.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerOutput.QueryOutput``1(System.String)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="name">
+                The name of the data output.
+            </param>
+            <returns>
+                The uniquely identified data.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="name"/> references data that does not exist.
+            </exception>
+            <exception cref="T:System.InvalidCastException">
+                The value at <paramref name="name"/> cannot be cast to <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerOutput.QueryOutput(System.String)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="name">
+                Unique name of the data to retrieve.
+            </param>
+            <returns>
+                The uniquely identified data, as an <see cref="T:System.Object"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="name"/> references data that does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerOutput.TryQueryOutput``1(System.String,``0@)">
+            <summary>
+                Retrieves data by name, typecast to the given type.
+                The caller is coupled to the data extension and expected to know the
+                data type.
+            </summary>
+            <typeparam name="T">
+                Type of the data to retrieve.
+            </typeparam>
+            <param name="name">
+                Unique name of the data to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerOutput.TryQueryOutput(System.String,System.Object@)">
+            <summary>
+                Retrieves data by name.
+            </summary>
+            <param name="name">
+                Unique name of the data to retrieve.
+            </param>
+            <param name="result">
+                The uniquely identified data, as an object.
+            </param>
+            <returns>
+                <c>true</c> if the value was successfully retrieved; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet">
+            <summary>
+                Represents a collection of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s to process.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.#ctor(Microsoft.Performance.Toolkit.Engine.PluginSet,System.Boolean)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/>
+                class, referencing the given <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>.
+            </summary>
+            <param name="plugins">
+                The plugins that are available to process data sources.
+            </param>
+            <param name="ownsPlugins">
+                <c>true</c> to take ownership and dispose <paramref name="plugins"/>
+                when this instance is disposed; <c>false</c> to leave
+                <paramref name="plugins"/> undisposed.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="plugins"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AssignedDataSourcesToProcess">
+            <summary>
+                Gets the collection of Data Sources grouped by their <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.DataSourceSet.FreeDataSourcesToProcess">
+            <summary>
+                Gets the collection of Data Sources to process. These Data Sources will be processed in whatever
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/> are able to handle the Data Source.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Plugins">
+            <summary>
+                Gets the plugins backing this set of data sources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Create">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/>
+                class, using plugins loaded from the current working
+                directory.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Create(Microsoft.Performance.Toolkit.Engine.PluginSet)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/>
+                class, referencing the given <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>.
+            </summary>
+            <remarks>
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/> created by this method will
+                take ownership of <see cref="F:Microsoft.Performance.Toolkit.Engine.DataSourceSet.plugins"/>. If you do not want
+                this behavior, use <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Create(Microsoft.Performance.Toolkit.Engine.PluginSet,System.Boolean)"/>.
+            </remarks>
+            <param name="plugins">
+                The plugins that are available to process data sources.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="plugins"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Create(Microsoft.Performance.Toolkit.Engine.PluginSet,System.Boolean)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/>
+                class, referencing the given <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>.
+            </summary>
+            <param name="plugins">
+                The plugins that are available to process data sources.
+            </param>
+            <param name="ownsPlugins">
+                <c>true</c> to take ownership and dispose <paramref name="plugins"/>
+                when this instance is disposed; <c>false</c> to leave
+                <paramref name="plugins"/> undisposed.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="plugins"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.NotSupportedException">
+                <paramref name="ownsPlugins"/> is <c>false</c>. This feature will
+                be enabled in a future update.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.Dispose">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSource(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Adds the given file to this instance for processing.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <returns>
+               A reference to this instance after the operation has completed.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                This instance is sealed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                <paramref name="dataSource"/> cannot be processed by any
+                discovered extensions.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.TryAddDataSource(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Attempts to add the given Data Source to this instance for processing.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <returns>
+                <c>true</c> if the Data Source has been added for processing;
+                <c>false</c> if the Data Source is not valid, cannot be processed,
+                or the instance has already been processed.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSource(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)">
+            <summary>
+                Adds the given Data Source to this instance for processing by
+                the specific <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process the file.
+            </param>
+            <returns>
+               A reference to this instance after the operation has completed.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/> is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given Data Source.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.TryAddDataSource(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)">
+            <summary>
+                Attempts to add the given Data Source to this instance for processing by
+                the specific <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process <paramref name="dataSource"/>.
+            </param>
+            <returns>
+                <c>true</c> if the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/> has been added for processing by the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSources(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Type)">
+            <summary>
+                Adds the given data sources to this instance for processing by
+                the specific <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>. All of the files will be processed
+                by the same instance of the Custom Data Processor. Use <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSource(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)"/>
+                to ensure each Data Source is processed by a different instance, or
+                use multiple calls to <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSources(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Type)"/>.
+            </summary>
+            <param name="dataSources">
+                The Data Sources to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process the <paramref name="dataSources"/>.
+            </param>
+            <returns>
+               A reference to this instance after the operation has completed.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSources"/> is <c>null</c>.
+                - or -
+                One or more elements of <paramref name="dataSources"/>
+                is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                This instance is sealed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given Data Source.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.TryAddDataSources(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Type)">
+            <summary>
+                Attempts to add the given data sources to this instance for processing by
+                the specific <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>. All of the files will be processed
+                by the same instance of the Custom Data Processor. Use <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSource(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)"/>
+                to ensure each Data Source is processed by a different instance, or
+                use multiple calls to <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AddDataSources(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Type)"/>.
+            </summary>
+            <param name="dataSources">
+                The Data Sources to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process the <paramref name="dataSources"/>.
+            </param>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSet.AsReadOnly">
+            <summary>
+                Returns a readonly deep-copy of this instance.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions">
+            <summary>
+                Contains static (Shared in Visual Basic) methods for interacting
+                with <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/> instances.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String)">
+            <summary>
+                Adds the given file to this instance for processing.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePath">
+                The path to the file to process.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="filePath"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="filePath"/> is whitespace.
+            </exception>
+            <exception cref="T:System.IO.FileNotFoundException">
+                The path specified by <paramref name="filePath"/> does not exist.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                <paramref name="filePath"/> cannot be processed by any
+                discovered extensions.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String,System.Type)">
+            <summary>
+                Adds the given file to this instance for processing by
+                the specific source.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePath">
+                The path to the file to process.
+            </param>
+            <param name="processingSourceType">
+                The processing source to use to process the file.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="filePath"/> is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="filePath"/> is whitespace.
+            </exception>
+            <exception cref="T:System.IO.FileNotFoundException">
+                The path specified by <paramref name="filePath"/> does not exist.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given file.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.TryAddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String)">
+            <summary>
+                Attempts to add the given file to this instance for processing.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePath">
+                The path to the file to process.
+            </param>
+            <returns>
+                <c>true</c> if the file has been added for processing;
+                <c>false</c> if the file is not valid, cannot be processed,
+                or the instance has already been processed.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.TryAddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String,System.Type)">
+            <summary>
+                Attempts to add the given file to this instance for processing by
+                the specific source.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePath">
+                The path to the file to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process the file.
+            </param>
+            <returns>
+                <c>true</c> if the file has been added for processing by this <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFiles(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.Collections.Generic.IEnumerable{System.String},System.Type)">
+            <summary>
+                Adds the given files to this instance for processing by
+                the specific source. All of the files will be processed
+                by the same instance of data processor. Use <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String,System.Type)"/>
+                to ensure each file is processed by a different instance, or
+                use multiple calls to <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFiles(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.Collections.Generic.IEnumerable{System.String},System.Type)"/>.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePaths">
+                The path to the files to process.
+            </param>
+            <param name="processingSourceType">
+                The data source to use to process the file.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                One or more paths specified by <paramref name="filePaths"/> is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                One or more paths specified by <paramref name="filePaths"/> is whitespace.
+            </exception>
+            <exception cref="T:System.IO.FileNotFoundException">
+                One or more paths specified by <paramref name="filePaths"/> does not exist.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given file.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.TryAddFiles(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.Collections.Generic.IEnumerable{System.String},System.Type)">
+            <summary>
+                Attempts to add the given files to this instance. All of
+                the files will be processed by the same instance of 
+                data processor. Use <see cref="M:Microsoft.Performance.Toolkit.Engine.DataSourceSetExtensions.AddFile(Microsoft.Performance.Toolkit.Engine.DataSourceSet,System.String,System.Type)"/> to ensure
+                each file is processed by a different instance.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> instance.
+            </param>
+            <param name="filePaths">
+                The paths to the files to add.
+            </param>
+            <param name="processingSourceType">
+                The data source to use to process the file.
+            </param>
+            <returns>
+                <c>true</c> if the files are added;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.Engine">
+            <summary>
+                Provides the entry point for programmatically manipulating, cooking,
+                and accessing data.
+            </summary>
+            <remarks>
+                This class is not thread safe.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.IsProcessed">
+            <summary>
+                Gets a value indicating whether this instance has completed processing.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.DataSourcesToProcess">
+            <summary>
+                Gets the collection of all data sources to process in this
+                engine instance.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.Plugins">
+            <summary>
+                Gets the collection of all plugins loaded into this engine instance.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.EnabledCookers">
+            <summary>
+                Gets the collection of all enabled cookers.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.EnabledTables">
+            <summary>
+                Gets the collection of all enabled tables
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception> 
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.AvailableTables">
+            <summary>
+                Gets the collection of available tables
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.Engine.CreateInfo">
+            <summary>
+                Gets the parameters used to create this instance.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Create(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine" /> class.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <returns>
+                The created engine environment.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+                A fatal error occurred while creating the engine.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                <paramref name="dataSource"/> cannot be processed by any
+                discovered extensions.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Create(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine" /> class.
+            </summary>
+            <param name="dataSource">
+                The Data Source to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process <paramref name="dataSource"/>.
+            </param>
+            <returns>
+                The created engine environment.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSource"/> is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+                A fatal error occurred while creating the engine.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given Data Source.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Create(System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Type)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine" /> class.
+            </summary>
+            <param name="dataSources">
+                The Data Sources to process.
+            </param>
+            <param name="processingSourceType">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> to use to process <paramref name="dataSources"/>.
+            </param>
+            <returns>
+                The created engine environment.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSources"/> is <c>null</c>.
+                - or -
+                <paramref name="processingSourceType"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+                The specified <paramref name="processingSourceType"/> cannot handle
+                the given Data Source.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+                The specified <paramref name="processingSourceType"/> is unknown.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+                A fatal error occurred while creating the engine.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Create(Microsoft.Performance.Toolkit.Engine.EngineCreateInfo)">
+            <summary>
+                Creates a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine" /> class.
+            </summary>
+            <param name="createInfo">
+                Provides details on how to create the engine as well as what 
+                the engine should process.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="createInfo"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+                A fatal error occurred while creating the engine.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.EnableCooker(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Enables the given cooker for processing when <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/>
+                is called.
+            </summary>
+            <param name="dataCookerPath">
+                The cooker to enable.
+            </param>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException">
+                <paramref name="dataCookerPath"/> is not known by this instance.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.NoDataSourceException">
+                There are inadequate data sources in <see cref="P:Microsoft.Performance.Toolkit.Engine.Engine.DataSourcesToProcess"/>
+                in order for the specified cooker to participate in processing.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.TryEnableCooker(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Attempts to enable the given cooker for processing when <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/>
+                is called.
+            </summary>
+            <param name="dataCookerPath">
+                The cooker to enable.
+            </param>
+            <returns>
+                <c>true</c> if the cooker exists and can be enabled;
+                <c>false</c> otherwise. Note that <c>false</c> is
+                always returned when <see cref="P:Microsoft.Performance.Toolkit.Engine.Engine.IsProcessed"/> is <c>true</c>.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.EnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Enables the given table for processing when <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/>
+                is called.
+            </summary>
+            <param name="descriptor">
+                The table to enable.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="descriptor"/> cannot be null.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                The processing sources referenced by the table could
+                not be found.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already been processed.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.TableException">
+                A table is not available for the given <paramref name="descriptor"/>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.TableNotFoundException">
+                A table cannot be found for the given <paramref name="descriptor"/>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.TryEnableTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Attempts to enable the given cooker for processing when <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/>
+                is called.
+            </summary>
+            <param name="descriptor">
+                The table to enable.
+            </param>
+            <returns>
+                <c>true</c> if the table exists and can be enabled;
+                <c>false</c> otherwise. Note that <c>false</c> is
+                always returned when <see cref="P:Microsoft.Performance.Toolkit.Engine.Engine.IsProcessed"/> is <c>true</c>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="descriptor"/> cannot be null.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Process">
+            <summary>
+                Processes all of the files given to this instance using all
+                of the enabled cookers.
+            </summary>
+            <returns>
+                The results of processing.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+              <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/> has already been called on this instance.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+                An unexpected error occurred.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.GetSourceParserRetrieval">
+            <summary>
+                Enables retrieval of cooker data associated with source parsers.
+            </summary>
+            <remarks>
+                In most cases it is better to retrieve cooked data through the <see cref="T:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults"/>
+                returned from <see cref="M:Microsoft.Performance.Toolkit.Engine.Engine.Process"/>. In rare circumstances, there is some data made available
+                prior to processing <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s; this provides a mechanism for retrieval in such cases.
+            </remarks>
+            <returns>
+                Custom data retrieval interfaces from custom data processors created by the engine that derive from
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Dispose">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.Dispose(System.Boolean)">
+            <summary>
+                Disoses all resources held by this class.
+            </summary>
+            <param name="disposing">
+                <c>true</c> to dispose both managed and unmanaged
+                resources; <c>false</c> to dispose only unmanaged
+                resources.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.ThrowIfDisposed">
+            <summary>
+                Throws an exception if this instance has been disposed.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.ThrowIfProcessed">
+            <summary>
+                Throws an exception if this instance has already processed.
+            </summary>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+                This instance has already processed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.CreateLogger(System.Type)">
+            <summary>
+                Creates a logger for the given type.
+            </summary>
+            <param name="type">
+                The <c>Type</c> for which the logger is created.
+            </param>
+            <returns>
+                An instance of <see cref="T:Microsoft.Performance.SDK.Processing.ILogger"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.Engine.GetExtensibleProcessors">
+            <summary>
+                Returns custom data processors that derive from <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/>.
+            </summary>
+            <returns>
+                Custom data processors created by the engine that derive from
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/>.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineApplicationEnvironment.TryGetAuthProvider``2(Microsoft.Performance.SDK.Auth.IAuthProvider{``0,``1}@)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo">
+            <summary>
+                Specifies a set of values that are used when
+                you create a <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.#cctor">
+            <summary>
+                Initializes the statc members of the <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>
+                class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.#ctor(Microsoft.Performance.Toolkit.Engine.ReadOnlyDataSourceSet)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/> class.
+            </summary>
+            <param name="dataSources">
+                The data sources to be processed in the engine.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="dataSources"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorOptions(Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Specifies the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to use when processing data sources.
+            </summary>
+            <param name="options"> <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to use for all processors that will process the data sources. </param>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="options"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorOptions(System.Collections.Generic.IDictionary{System.Guid,Microsoft.Performance.SDK.Processing.ProcessorOptions})">
+            <summary>
+                Specifies the <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to use when processing data sources.
+            </summary>
+            <param name="optionsMap">A dictionary which maps <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> for a given processor which will process the data sources. </param>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="optionsMap"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorOptions(Microsoft.Performance.SDK.Processing.IProcessingOptionsResolver)">
+            <summary>
+                Specifies an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingOptionsResolver"/> to provide <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to use when processing data sources.
+            </summary>
+            <remarks>
+                To set processor options for all processing sources use <see cref="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorOptions(Microsoft.Performance.SDK.Processing.ProcessorOptions)"/>.
+                To set processor options per processing source use <seealso cref="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorOptions(System.Collections.Generic.IDictionary{System.Guid,Microsoft.Performance.SDK.Processing.ProcessorOptions})"/>.
+            </remarks>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="processingOptionsResolver"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithAuthProvider``2(Microsoft.Performance.SDK.Auth.IAuthProvider{``0,``1})">
+            <summary>
+                Registers an <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> of type <typeparamref name="TAuth"/> to be available to plugins
+                via <see cref="!:IApplicationEnvironment.TryGetAuthProvider&lt;TAuth, TResult&gt;"/>.
+            </summary>
+            <param name="provider">
+                The <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> to register.
+            </param>
+            <typeparam name="TAuth">
+                The type of <see cref="T:Microsoft.Performance.SDK.Auth.IAuthMethod`1"/> for which the <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> is being registered.
+            </typeparam>
+            <typeparam name="TResult">
+                The type of the result of successful authentication requests for <typeparamref name="TAuth"/>.
+            </typeparam>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                An <see cref="T:Microsoft.Performance.SDK.Auth.IAuthProvider`2"/> for the specified type <typeparamref name="TAuth"/> already exists.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithProcessorEnvironmentFactory(Microsoft.Performance.Toolkit.Engine.ProcessorEnvironmentFactory)">
+            <summary>
+                Registers a <see cref="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.ProcessEnvironmentFactory"/> to use for generating a custom processor 
+                environment.
+            </summary>
+            <param name="factory">
+                Factory for generating a <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorEnvironment"/>.
+            </param>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="factory"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.WithPluginOptionValue``2(System.Guid,``1)">
+            <summary>
+                Specifies that the <see cref="T:Microsoft.Performance.SDK.Runtime.Options.PluginOption"/> whose <see cref="P:Microsoft.Performance.SDK.Runtime.Options.PluginOption.Guid" /> corresponds to
+                the specified <paramref name="optionGuid"/> should have the specified <paramref name="value" />.
+            </summary>
+            <param name="optionGuid">
+                The <see cref="P:Microsoft.Performance.SDK.Runtime.Options.PluginOption.Guid" /> of the <see cref="T:Microsoft.Performance.SDK.Runtime.Options.PluginOption"/> to set the value for.
+            </param>
+            <param name="value">
+                The value to set for the <see cref="T:Microsoft.Performance.SDK.Runtime.Options.PluginOption"/>.
+            </param>
+            <typeparam name="T">
+                The concrete type of the <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue"/> whose value should be set (e.g. <see cref="T:Microsoft.Performance.SDK.Options.Values.BooleanOptionValue"/>
+                or <see cref="T:Microsoft.Performance.SDK.Options.Values.FieldOptionValue"/>).
+            </typeparam>
+            <typeparam name="TValue">
+                The type of the value of the <see cref="T:Microsoft.Performance.SDK.Runtime.Options.PluginOption"/>.
+            </typeparam>
+            <returns>
+                The instance of <see cref="T:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="value"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.RuntimeName">
+            <summary>
+                Gets or sets the name of the runtime on which the application is built.
+            </summary>
+            <remarks>
+                Defaults to the engine assembly name.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.ApplicationName">
+            <summary>
+                Gets or sets the application name.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.LoggerFactory">
+            <summary>
+                Gets or sets a logger factory.
+            </summary>
+            <remarks>
+                The logger factory should be able to provide each processing source a logger specific to its type.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.DataSources">
+            <summary>
+                Gets the data sources that are to be processed by an <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/>
+                instance.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.OptionsResolver">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingOptionsResolver"/> which can be used to provide <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.IsInteractive">
+            <summary>
+                Gets or sets a value indicating whether the Engine instance will
+                allow for user interaction. If this property is set to <c>false</c>,
+                then any attempts made by plugins to get interaction from a user
+                will fail. By default, this property is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.EngineCreateInfo.RegisteredPluginOptions">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.Toolkit.Engine.Options.EnginePluginOptionValuesRegistry"/> that tracks which <see cref="T:Microsoft.Performance.SDK.Options.Values.PluginOptionValue"/>
+                instances have been registered.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.EngineException">
+            <summary>
+                Represents errors that occur when interacting with the WPT runtime.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.EngineException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException">
+            <summary>
+                Represents the error that occurs when an attempt is made to access a cooker
+                that is not known.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException"/>
+                class with the given cooker path.
+            </summary>
+            <param name="dataCookerPath">
+                The path to the cooker that was not found.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException"/>
+                class with the given cooker path, and the error that is the cause of this error.
+            </summary>
+            <param name="dataCookerPath">
+                The path to the cooker that was not found.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.DataCookerPath">
+            <summary>
+                Gets the requested cooker path that is the cause of this error.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException">
+            <summary>
+                Represents the error that occurs when an attempt is made to access a
+                data output that is not known.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.#ctor(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException"/>
+                class with the given output path.
+            </summary>
+            <param name="dataOutputPath">
+                The path to the data that was not found.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.#ctor(Microsoft.Performance.SDK.Extensibility.DataOutputPath,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException"/>
+                class with the given output path, and the error that is the cause of this error.
+            </summary>
+            <param name="dataOutputPath">
+                The path to the data that was not found.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.DataOutputPath">
+            <summary>
+                Gets the requested data output path that is the cause of this error.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.TableNotFoundException">
+            <summary>
+                Represents the error that occurs when an attempt is made to access a
+                <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that is not known.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.#ctor(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.TableNotFoundException"/>
+                class with the given <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </summary>
+            <param name="tableDescriptor">
+                The path to the data that was not found.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.#ctor(Microsoft.Performance.SDK.Processing.TableDescriptor,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.TableNotFoundException"/>
+                class with the given <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>, and the error that is the cause of this error.
+            </summary>
+            <param name="tableDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that was not found.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.Descriptor">
+            <summary>
+                Gets the requested <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that is the cause of this error.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotFoundException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.TableException">
+            <summary>
+                Represents the error that occurs when an attempt is made to build a
+                <see cref="T:Microsoft.Performance.Toolkit.Engine.ITableResult"/> that with a specified <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.#ctor(System.String,Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.TableException"/>
+                class with the given <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>.
+            </summary>
+            <param name="message">
+                The message that describes the error.
+            </param>
+            <param name="tableDescriptor">
+                The path to the data that was not found.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.#ctor(System.String,Microsoft.Performance.SDK.Processing.TableDescriptor,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.TableException"/>
+                class with the given <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/>, and the error that is the cause of this error.
+            </summary>
+            <param name="message">
+                The message that describes the error.
+            </param>
+            <param name="tableDescriptor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that was not found.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.TableException.Descriptor">
+            <summary>
+                Gets the requested <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> that is the cause of this error.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException">
+            <summary>
+                Represents the error that occurs when an attempt is made
+                to add a Data Source for processing that no processor can handle.
+                This can also happen if the user requests a processor to
+                process a Data Source that the processor cannot process.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor(Microsoft.Performance.SDK.Processing.IDataSource)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException" />
+                class for the given Data Source.
+            </summary>
+            <param name="dataSource">
+                The unsupported Data Source.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor(Microsoft.Performance.SDK.Processing.IDataSource,System.Type)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException" />
+                class for the given Data Source and requested <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="dataSource">
+                The unsupported Data Source.
+            </param>
+            <param name="requestedProcessingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that was requested for the file.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.#ctor(Microsoft.Performance.SDK.Processing.IDataSource,System.Type,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException" />
+                class for the given <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>, requested <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>,
+                and the error that is the cause of this error.
+            </summary>
+            <param name="dataSource">
+                The unsupported Data Source.
+            </param>
+            <param name="requestedProcessingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that was requested for the Data Source.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.DataSource">
+            <summary>
+                Gets the URI of the requested Data Source.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.RequestedProcessingSource">
+            <summary>
+                Gets the fully qualified type name of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> requested for
+                the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>. This property may be null if no <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> was requested
+                for the <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>. See <see cref="P:System.Type.FullName"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException">
+            <summary>
+                Represents the error that occurs when an attempt is made
+                to use an <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that is unknown by the runtime.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.#ctor(System.Type)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException" />
+                class for the requested <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <param name="requestedProcessingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that was requested.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.#ctor(System.Type,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException" />
+                class for the requested data source and the error that is the
+                cause of this error.
+            </summary>
+            <param name="requestedProcessingSource">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that was requested.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.RequestedProcessingSource">
+            <summary>
+                Gets the fully qualified type name of the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> requested for
+                the file. This property may be null if no <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> was requested
+                for the file. See <see cref="P:System.Type.FullName"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.UnsupportedProcessingSourceException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException">
+            <summary>
+                Represents the error that occurs when an attempt is made
+                to use a path that is not valid as a directory for extensions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException.#ctor(System.String)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException" />
+                class for the given path.
+            </summary>
+            <param name="path">
+                The path that is invalid.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException.#ctor(System.String,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.UnsupportedDataSourceException" />
+                class for the given file and the error that is the cause of this error.
+            </summary>
+            <param name="filePath">
+                The path to the unsupported file.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException.Path">
+            <summary>
+                Gets the invalid path.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException">
+            <summary>
+                Represents errors that occur when attempting to mutate
+                the runtime after it has already been processed.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.InstanceAlreadyProcessedException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.NoDataSourceException">
+            <summary>
+                Represents the error that occurs when an attempt is made to enable a
+                source cooker on the engine when the data sources do not provide the
+                data required for said cooker.
+                <para />
+                An example of this condition would be when you attempt to add a cooker
+                that cooks events from an ETL file (Event Tracing for Windows trace file),
+                but no ETL files are present in the set of files to process.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.NoDataSourceException"/>
+                class with the specified <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/>.
+            </summary>
+            <param name="cookerPath">
+                The path to the cooker which will not be able to participate in data
+                processing due to there being inadequate data in the data source set.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.#ctor(Microsoft.Performance.SDK.Extensibility.DataCookerPath,System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.NoDataSourceException"/>
+                class with the specified <see cref="T:Microsoft.Performance.SDK.Extensibility.DataCookerPath"/> and the error
+                that is the cause of this error, if any.
+            </summary>
+            <param name="cookerPath">
+                The path to the cooker which will not be able to participate in data
+                processing due to there being inadequate data in the data source set.
+            </param>
+            <param name="inner">
+                The error that is the cause of this error.
+            </param>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.NoDataSourceException.CookerPath">
+            <summary>
+                Gets the path to the cooker that will not have any input.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException">
+            <summary>
+                Represents errors that occur when attempting to build a table that was not enabled.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException.#ctor(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException"/>
+                class for the given table.
+            </summary>
+            <param name="descriptor">
+                The descriptor of the table that was requested to be built, but was not
+                enabled for processing.
+            </param>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.GlobalProcessingOptionsResolver.#ctor(Microsoft.Performance.SDK.Processing.ProcessorOptions)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.GlobalProcessingOptionsResolver"/> class.
+            </summary>
+            <param name="options"> 
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> to return from all calls to <see cref="M:Microsoft.Performance.Toolkit.Engine.GlobalProcessingOptionsResolver.GetProcessorOptions(System.Guid,Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup)"/>, 
+                regardless of the specified <see cref="T:System.Guid"/> and <see cref="T:Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup"/>. 
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="options"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.GlobalProcessingOptionsResolver.GetProcessorOptions(System.Guid,Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.ITableResult">
+            <summary>
+                Enables access to table data generated by
+                <see cref="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor)"/> or
+                <see cref="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TryBuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.Toolkit.Engine.ITableResult@)"/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.BuiltInTableConfigurations">
+            <inheritdoc cref="P:Microsoft.Performance.SDK.Processing.ITableBuilder.BuiltInTableConfigurations"/>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.DefaultConfiguration">
+            <inheritdoc cref="P:Microsoft.Performance.SDK.Processing.ITableBuilder.DefaultConfiguration"/>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.RowCount">
+            <inheritdoc cref="P:Microsoft.Performance.SDK.Processing.ITableBuilderWithRowCount.RowCount"/>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.Columns">
+            <summary>
+                Gets the collection of columns that have been added to the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.ColumnVariants">
+            <summary>
+                Gets the mapping from columns with variants to those variants.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.TableCommands">
+            <summary>
+                Gets the dictionary of table command name and <see cref="T:Microsoft.Performance.SDK.Processing.TableCommandCallback"/> that have been assigned to the table.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ITableResult.TableRowDetailsGenerator">
+            <summary>
+                Gets the function to be used to generate details for a given row in the table.
+                <para/>
+                The function will take the row number being examined by the user, and should
+                return a collection of one or more entries given details for that row. This can
+                be used to support information on a row by row basis that does not make
+                sense in a columnar format.
+                <para/>
+                This method is not required to be set; it is perfectly acceptable
+                to not support details. This method may be called only zero (0) or one (1)
+                time(s) per instance.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.ITableResultExtensions">
+            <summary>
+                Extensions for <see cref="T:Microsoft.Performance.Toolkit.Engine.ITableResult"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ITableResultExtensions.TryGetColumnVariants(Microsoft.Performance.Toolkit.Engine.ITableResult,Microsoft.Performance.SDK.Processing.IDataColumn,System.Collections.Generic.IReadOnlyDictionary{Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnVariantDescriptor,Microsoft.Performance.SDK.Processing.IDataColumn}@)">
+            <summary>
+                Attempts to get the column variants for the given column.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.ITableResult"/> to search.
+            </param>
+            <param name="baseColumn">
+                The column for which to get the variants.
+            </param>
+            <param name="foundColumns">
+                The column variants for the given column, if found.
+            </param>
+            <returns>
+                <c>true</c> if the column variants were found; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ITableResultExtensions.TryGetColumnVariant(Microsoft.Performance.Toolkit.Engine.ITableResult,System.Guid,System.Guid,Microsoft.Performance.SDK.Processing.IDataColumn@)">
+            <summary>
+                Attempts to get the column variant for the given column and variant identifier.
+            </summary>
+            <param name="self">
+                The <see cref="T:Microsoft.Performance.Toolkit.Engine.ITableResult"/> to search.
+            </param>
+            <param name="columnGuid">
+                The guid of the column for which to get the variant.
+            </param>
+            <param name="variantGuid">
+                The guid of the variant to get.
+            </param>
+            <param name="columnVariant">
+                The variant of the given column with the given identifier, if found.
+            </param>
+            <returns>
+                <c>true</c> if the variant was found; <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.PluginSet">
+            <summary>
+                Represents a collection of plugins.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.ArePluginsIsolated">
+            <summary>
+                Gets a value indicating whether plugins are isolated into their
+                own isolated assembly contexts.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.CreationErrors">
+            <summary>
+                Gets any non-fatal errors that occured during data set
+                creation. Because these errors are not fatal, they are
+                reported here rather than raising an exception.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.ExtensionDirectories">
+            <summary>
+                Gets the directories from which the plugins in this set were loaded.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.ProcessingSourceReferences">
+            <summary>
+                Gets all of the loaded Processing Sources.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.SourceDataCookers">
+            <summary>
+                Gets the paths of all loaded Source Cookers.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.CompositeDataCookers">
+            <summary>
+                Gets the paths of all loaded Composite Cookers.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.AllCookers">
+            <summary>
+                Gets the paths of all loaded cookers.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.PluginSet.TablesById">
+            <summary>
+                Gets the mapping of all loaded Table Ids to the corresponding loaded Table.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Load">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>, loading all plugins found
+                in the current working directory.
+            </summary>
+            <returns>
+                A new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/> class containing all
+                of the successfully discovered plugins.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Load(System.String)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>, loading all plugins found
+                in the given directory.
+            </summary>
+            <param name="extensionDirectory">
+                The path to the directory search for extensions.
+            </param>
+            <returns>
+                A new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/> class containing all
+                of the successfully discovered plugins.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException">
+                <paramref name="extensionDirectory"/> is invalid or does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Load(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>, loading all plugins found
+                in the given directories.
+            </summary>
+            <param name="extensionDirectories">
+                The directories to search for plugins.
+            </param>
+            <returns>
+                A new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/> class containing all
+                of the successfully discovered plugins.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="extensionDirectories"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="extensionDirectories"/> is empty.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException">
+                One or more directory paths in <paramref name="extensionDirectories"/>
+                is invalid or does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Load(System.Collections.Generic.IEnumerable{System.String},Microsoft.Performance.SDK.IAssemblyLoader)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>, loading all plugins found
+                in the given directories, using the given loading function.
+            </summary>
+            <param name="extensionDirectories">
+                The directories to search for plugins.
+            </param>
+            <param name="assemblyLoader">
+                The loader to use to load plugin assemblies. This parameter may be
+                <c>null</c>. If this parameter is <c>null</c>, then the default
+                loader will be used.
+                <remarks>
+                    The default loader provides no isolation.
+                </remarks>
+            </param>
+            <returns>
+                A new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/> class containing all
+                of the successfully discovered plugins. The returned instance will
+                also contain a collection of non-fatal errors that occurred when
+                creating this data set (e.g. a plugin failed to load.)
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="extensionDirectories"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="extensionDirectories"/> is empty.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException">
+                One or more directory paths in <paramref name="extensionDirectories"/>
+                is invalid or does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Load(System.Collections.Generic.IEnumerable{System.String},Microsoft.Performance.SDK.IAssemblyLoader,Microsoft.Performance.SDK.Processing.ILogger)">
+            <summary>
+                Creates a new <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/>, loading all plugins found
+                in the given directories, using the given loading function.
+            </summary>
+            <param name="extensionDirectories">
+                The directories to search for plugins.
+            </param>
+            <param name="assemblyLoader">
+                The loader to use to load plugin assemblies. This parameter may be
+                <c>null</c>. If this parameter is <c>null</c>, then the default
+                loader will be used.
+                <remarks>
+                    The default loader provides no isolation.
+                </remarks>
+            </param>
+            <param name="logger">
+                Used to log any messages.
+                May be <c>null</c>.
+            </param>
+            <returns>
+                A new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.PluginSet"/> class containing all
+                of the successfully discovered plugins. The returned instance will
+                also contain a collection of non-fatal errors that occurred when
+                creating this data set (e.g. a plugin failed to load.)
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="extensionDirectories"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="extensionDirectories"/> is empty.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.InvalidExtensionDirectoryException">
+                One or more directory paths in <paramref name="extensionDirectories"/>
+                is invalid or does not exist.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.PluginSet.Dispose">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.ProcessingError">
+            <summary>
+                Encapsulates information about an unexpected error in a <see cref="T:Microsoft.Performance.SDK.Processing.CustomDataProcessor"/>
+                or extension that occurred while the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/> was processing data.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ProcessingError.#ctor(System.Guid,Microsoft.Performance.SDK.Processing.ICustomDataProcessor,System.Collections.Generic.IEnumerable{Microsoft.Performance.SDK.Processing.IDataSource},System.Exception)">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.ProcessingError"/>
+                class.
+            </summary>
+            <param name="processingSourceGuid">
+                The GUID identifying the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/> that is
+                the source of the given <paramref name="processor"/>.
+            </param>
+            <param name="processor">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> that threw the error.
+            </param>
+            <param name="dataSources">
+                The <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that were being processed by
+                <paramref name="processor"/> when the error occurred.
+            </param>
+            <param name="processFault">
+                The error that was thrown.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="processor"/> is <c>null</c>.
+                - or -
+                <paramref name="dataSources"/> is <c>null</c>.
+                - or -
+                <paramref name="processFault"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="processingSourceGuid"/> is equivalent to the default Guid
+                (<see cref="F:System.Guid.Empty"/>).
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.ProcessingSourceGuid">
+            <summary>
+                Gets the GUID that identifies the <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>
+                that is the source of the referenced <see cref="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.Processor"/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.Processor">
+            <summary>
+                Gets the <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> that threw the error.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.DataSources">
+            <summary>
+                Gets the collection of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that were being processed
+                by <see cref="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.Processor"/> when the error occurred.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.DataSourceInfoFault">
+            <summary>
+                Gets the error that occurred while retreiving data source information, 
+                if any occurred. This property may be <c>null</c>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.EnableTableFaults">
+            <summary>
+                Gets the error(s) that occurred while enabling tables, if any occurred.
+                This property may be empty.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.ProcessFault">
+            <summary>
+                Gets the error that was thrown by <see cref="P:Microsoft.Performance.Toolkit.Engine.ProcessingError.Processor"/> while processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ProcessingSourceOptionsResolver.#ctor(System.Collections.Generic.IDictionary{System.Guid,Microsoft.Performance.SDK.Processing.ProcessorOptions})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.ProcessingSourceOptionsResolver"/> class.
+            </summary>
+            <param name="optionsMap"> A dictionary which maps <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> for a given processor which will process the data sources. </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="optionsMap"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ProcessingSourceOptionsResolver.GetProcessorOptions(System.Guid,Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup)">
+            <summary>
+                Return <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorOptions"/> for a ProcessingSource.
+            </summary>
+            <remarks> 
+                If a <paramref name="processingSourceGuid"/> wasn't specified, we return the <see cref="F:Microsoft.Performance.SDK.Processing.ProcessorOptions.Default"/>. 
+            </remarks>
+            <param name="processingSourceGuid"> A Guid for a  processing source to find processor options.</param>
+            <param name="dataSourceGroup">A DataSourceGroup. This is ignored in this implementation. </param>
+            <returns>Options for a given ProcessingSource.</returns>
+            <exception cref="T:System.ArgumentNullException">
+                The specified <paramref name="processingSourceGuid"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ProcessingSourceOptionsResolver.GetProcessorOptions(System.Guid)">
+            <summary>
+                Return options for processing for a ProcessingSource.
+            </summary>
+            <remarks> 
+                If a <paramref name="processingSourceGuid"/> wasn't specified, we return the <see cref="F:Microsoft.Performance.SDK.Processing.ProcessorOptions.Default"/>. 
+            </remarks>
+            <param name="processingSourceGuid"> A Guid for a  processing source to find processor options.</param>
+            <returns>Options for a given ProcessingSource.</returns>
+            <exception cref="T:System.ArgumentNullException">
+                The specified <paramref name="processingSourceGuid"/> is <c>null</c>.
+            </exception>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.ProcessorEnvironmentFactory">
+            <summary>
+                This is used to generate processor environments.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.ProcessorEnvironmentFactory.CreateProcessorEnvironment(System.Guid,Microsoft.Performance.SDK.Processing.DataSourceGrouping.IDataSourceGroup)">
+            <summary>
+                Creates a <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorEnvironment"/> for a processor.
+            </summary>
+            <param name="processingSourceIdentifier">
+                Identifies the source processor used to generate the data processor.
+            </param>
+            <param name="dataSourceGroup">
+                A collection of <see cref="T:Microsoft.Performance.SDK.Processing.IDataSource"/>s that a <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> can process together
+                in a specified <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingMode"/>.
+            </param>
+            <returns>
+                A <see cref="T:Microsoft.Performance.SDK.Processing.ProcessorEnvironment"/> or <c>null</c>. When <c>null</c> is returned, a default processor 
+                environment will be used.
+            </returns>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.ReadOnlyDataSourceSet">
+            <summary>
+                Presents a readonly view of a <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/>.
+            </summary>
+            <remarks>
+                Instances of this class are only valid for as long as the creating
+                <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/> is valid. Instances of this class are
+                invalidated when the creating <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/> is disposed.
+                The behavior of instances of this class after the creating 
+                <see cref="T:Microsoft.Performance.Toolkit.Engine.DataSourceSet"/> is disposed is undefined.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ReadOnlyDataSourceSet.DataSourcesToProcess">
+            <summary>
+                Gets the collection of Data Sources that are to be processed by a specific <see cref="T:Microsoft.Performance.SDK.Processing.IProcessingSource"/>.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ReadOnlyDataSourceSet.FreeDataSourcesToProcess">
+            <summary>
+                Gets the collection of Data Sources to process. These Data Sources will be processed in whatever
+                <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessorWithSourceParser"/> are able to handle the Data Source.
+            </summary>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.ReadOnlyDataSourceSet.Plugins">
+            <summary>
+                Gets the plugins backing this set of data sources.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults">
+            <summary>
+                Represents the results of processing data using the <see cref="T:Microsoft.Performance.Toolkit.Engine.Engine"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.#ctor(Microsoft.Performance.SDK.Extensibility.DataCooking.ICookedDataRetrieval,Microsoft.Performance.SDK.Runtime.Extensibility.ICompositeCookerRepository,Microsoft.Performance.SDK.Runtime.Extensibility.IDataExtensionRetrievalFactory,Microsoft.Performance.SDK.Runtime.Extensibility.DataExtensions.Repository.IDataExtensionRepository,System.Collections.Generic.IDictionary{Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.SDK.Processing.ICustomDataProcessor},System.Collections.Generic.IEnumerable{Microsoft.Performance.Toolkit.Engine.ProcessingError})">
+            <summary>
+                Initializes a new instance of the <see cref="T:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults"/>
+                class.
+            </summary>
+            <param name="sourceCookerData">
+                The retrieval interface for getting to source cooker data.
+            </param>
+            <param name="compositeCookerData">
+                The retrieval interface for getting to composite cooker data.
+            </param>
+            <param name="retrievalFactory">
+                The factory for creating retrievals for composite cookers.
+            </param>
+            <param name="repository">
+                The repository that was used to process the data.
+            </param>
+            <param name="tableToProcessorMap">
+                The map of a <see cref="T:Microsoft.Performance.SDK.Processing.TableDescriptor"/> to the <see cref="T:Microsoft.Performance.SDK.Processing.ICustomDataProcessor"/> that produces
+                that table.
+            </param>
+            <param name="errors">
+                The collection of errors, if any, that were encountered during processing.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="sourceCookerData"/> is <c>null</c>.
+                - or -
+                <paramref name="compositeCookerData"/> is <c>null</c>.
+                - or -
+                <paramref name="retrievalFactory"/> is <c>null</c>.
+                - or -
+                <paramref name="repository"/> is <c>null</c>.
+                - or -
+                <paramref name="tableToProcessorMap"/> is <c>null</c>.
+                - or -
+                <paramref name="errors"/> is <c>null</c>.
+            </exception>
+            TODO: Going to move RuntimeExecutionResults to internal and expose calls via new interface
+                  1 - 1 with the Engine when calling Process
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.ProcessingErrors">
+            <summary>
+                Gets the collection of errors, if any, that occurred during processing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.GetCookedData(Microsoft.Performance.SDK.Extensibility.DataCookerPath)">
+            <summary>
+                Gets the direct cooker retrieval for the specified
+                cooker.
+            </summary>
+            <param name="cookerPath">
+                The path to the cooker to retrieve.
+            </param>
+            <returns>
+                The object to query for cooked data from the specified cooker.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.CookerNotFoundException">
+                <paramref name="cookerPath"/> does not represent a known cooker.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TryGetCookedData(Microsoft.Performance.SDK.Extensibility.DataCookerPath,Microsoft.Performance.Toolkit.Engine.CookerOutput@)">
+            <summary>
+                Attempts to get the data retrieval for the specified cooker.
+            </summary>
+            <param name="cookerPath">
+                The path to the cooker to retrieve.
+            </param>
+            <param name="retrieval">
+                The object to query for cooked data, if any.
+            </param>
+            <returns>
+                <c>true</c> if the cooker can be queried;
+                <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.QueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <summary>
+                Queries for processed data from the given path.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being queried.
+            </typeparam>
+            <param name="dataOutputPath">
+                The fully qualified output path to the data to retrieve.
+            </param>
+            <returns>
+                The cooked data.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException">
+                No processed data could be found for the given <paramref name="dataOutputPath"/>.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.QueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath)">
+            <summary>
+                Queries for processed data from the given path.
+            </summary>
+            <param name="dataOutputPath">
+                The fully qualified output path to the data to retrieve.
+            </param>
+            <returns>
+                The cooked data.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.DataOutputNotFoundException">
+                No processed data could be found for the given <paramref name="dataOutputPath"/>.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TryQueryOutput(Microsoft.Performance.SDK.Extensibility.DataOutputPath,System.Object@)">
+            <summary>
+                Attempts to query for processed data from the given path.
+            </summary>
+            <param name="dataOutputPath">
+                The fully qualified output path to the data to retrieve.
+            </param>
+            <param name="data">
+                The retrieved data, if any.
+            </param>
+            <returns>
+                <c>true</c> if data at the given path was found;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TryQueryOutput``1(Microsoft.Performance.SDK.Extensibility.DataOutputPath,``0@)">
+            <summary>
+                Attempts to query for processed data from the given path.
+            </summary>
+            <typeparam name="T">
+                The <see cref="T:System.Type"/> of data being queried.
+            </typeparam>
+            <param name="dataOutputPath">
+                The fully qualified output path to the data to retrieve.
+            </param>
+            <param name="data">
+                The retrieved data, if any.
+            </param>
+            <returns>
+                <c>true</c> if data at the given path was found;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.IsTableDataAvailable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Checks if the given <paramref name="tableDescriptor"/> has data available.
+            </summary>
+            <param name="tableDescriptor">
+                The table to check.
+            </param>
+            <returns>
+                <c>true</c> the table has data available;
+                <c>false</c> otherwise.
+                <c>null</c> the table does not support checking if data is available.
+            </returns>
+            <remarks>
+                If this method returns <c>null</c> and you must check if the given 
+                descriptor has data, you can check if the <see cref="T:Microsoft.Performance.SDK.Processing.ITableBuilder"/> 
+                returned from <see cref="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor)"/> 
+                has a row count greater than 0."
+            </remarks>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.TableException">
+                A exception occured when calling IsDataAvailable on the specified <paramref name="tableDescriptor"/>.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.BuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor)">
+            <summary>
+                Builds a table with the given <paramref name="tableDescriptor"/>.
+            </summary>
+            <param name="tableDescriptor">
+                The table to build.
+            </param>
+            <returns>
+                The built table.
+            </returns>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.TableException">
+                A table cannot be built for the given <paramref name="tableDescriptor"/>.
+            </exception>
+            <exception cref="T:Microsoft.Performance.Toolkit.Engine.TableNotEnabledException">
+                A table for the given <paramref name="tableDescriptor"/> was not enabled.
+            </exception>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TryBuildTable(Microsoft.Performance.SDK.Processing.TableDescriptor,Microsoft.Performance.Toolkit.Engine.ITableResult@)">
+            <summary>
+                Attempts to build a table with the given <paramref name="tableDescriptor"/>.
+            </summary>
+            <param name="tableDescriptor">
+                The table to build.
+            </param>
+            <param name="filledTableBulder">
+                The built table, if any.
+            </param>
+            <returns>
+                <c>true</c> if the table for the given <paramref name="tableDescriptor"/> was built;
+                <c>false</c> otherwise.
+            </returns>
+            <exception cref="T:System.ObjectDisposedException">
+                This instance is disposed.
+            </exception>
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.Dispose">
+            <inheritdoc/>
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TableBuilder.ColumnVariants">
+            <inheritdoc />
+        </member>
+        <member name="P:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TableBuilder.Columns">
+            <inheritdoc />
+        </member>
+        <member name="M:Microsoft.Performance.Toolkit.Engine.RuntimeExecutionResults.TableBuilder.AddColumnWithVariants(Microsoft.Performance.SDK.Processing.IDataColumn,System.Func{Microsoft.Performance.SDK.Processing.ColumnBuilding.RootColumnBuilder,Microsoft.Performance.SDK.Processing.ColumnBuilding.ColumnBuilder})">
+            <inheritdoc />
+        </member>
+    </members>
+</doc>

--- a/src/Microsoft.Performance.Toolkit.Engine/RuntimeExecutionResults.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine/RuntimeExecutionResults.cs
@@ -534,6 +534,8 @@ namespace Microsoft.Performance.Toolkit.Engine
 
             private readonly List<TableCommand2> tableCommands2;
 
+            private readonly List<TableCommand3> tableCommands3;
+
             internal TableBuilder()
             {
                 this.columns = new List<IDataColumn>();
@@ -547,6 +549,9 @@ namespace Microsoft.Performance.Toolkit.Engine
 
                 this.tableCommands2 = new List<TableCommand2>();
                 this.TableCommands2 = new ReadOnlyCollection<TableCommand2>(this.tableCommands2);
+
+                this.tableCommands3 = new List<TableCommand3>();
+                this.TableCommands3 = new ReadOnlyCollection<TableCommand3>(this.tableCommands3);
 
                 this.variantsRegistrar = new ColumnVariantsRegistrar();
             }
@@ -572,6 +577,8 @@ namespace Microsoft.Performance.Toolkit.Engine
             public IReadOnlyDictionary<string, TableCommandCallback> TableCommands => this.tableCommandsRO;
 
             public IReadOnlyCollection<TableCommand2> TableCommands2 { get; }
+
+            public IReadOnlyCollection<TableCommand3> TableCommands3 { get; }
 
             public Func<int, IEnumerable<TableRowDetailEntry>> TableRowDetailsGenerator { get; private set; }
 
@@ -599,6 +606,25 @@ namespace Microsoft.Performance.Toolkit.Engine
 
                 this.tableCommands.TryAdd(commandName, (rows) => onExecute(new TableCommandContext(null, null, rows ?? ArraySegment<int>.Empty)));
                 this.tableCommands2.Add(new TableCommand2(commandName, canExecute, onExecute));
+                return this;
+            }
+
+            public ITableBuilder AddTableCommand3(
+                string commandName,
+                Predicate<TableCommandContext2> canExecute,
+                TableCommandCallback2 onExecute)
+            {
+                Guard.NotNull(commandName, nameof(commandName));
+                Guard.NotNull(canExecute, nameof(canExecute));
+                Guard.NotNull(onExecute, nameof(onExecute));
+
+                var canonicalName = commandName.Trim();
+                if (this.tableCommands3.Any(x => StringComparer.CurrentCultureIgnoreCase.Equals(x.CommandName, canonicalName)))
+                {
+                    throw new InvalidOperationException($"Duplicate command names are not allowed. Duplicate: {canonicalName}");
+                }
+
+                this.tableCommands3.Add(new TableCommand3(canonicalName, canExecute, onExecute));
                 return this;
             }
 


### PR DESCRIPTION
Adds ITableBuilder.AddTableCommand3 to remove limitations for:
1. HierarchicalColumns (sub-rows)
2. Allow for return values.