### PR TITLE
Upgrade to MSTest4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Build solution
       run: dotnet build "${{ github.workspace }}/src/SDK.sln" --no-restore -c Release
     - name: Run tests
-      run: dotnet test "${{ github.workspace }}/src/SDK.sln" -c Release --filter "TestCategory~Unit|TestCategory~Integration|TestCategory~Functional" --no-build --verbosity normal
+      run: dotnet test "${{ github.workspace }}/src/SDK.sln" -c Release --no-build --verbosity normal
     - name: Build samples
       run: ls "${{ github.workspace }}/samples/**/*.sln" | % { dotnet build $_.FullName -c Release }

--- a/.github/workflows/main_tests_status.yml
+++ b/.github/workflows/main_tests_status.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Build solution
       run: dotnet build "${{ github.workspace }}/src/SDK.sln" --no-restore -c Release
     - name: Run tests
-      run: dotnet test "${{ github.workspace }}/src/SDK.sln" -c Release --filter "TestCategory~Unit|TestCategory~Integration|TestCategory~Functional" --no-build --verbosity normal
+      run: dotnet test "${{ github.workspace }}/src/SDK.sln" -c Release --no-build --verbosity normal

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-	  <PackageReference Update="MSTest.TestAdapter" Version="2.2.7" />
-	  <PackageReference Update="MSTest.TestFramework" Version="2.2.7" />
+	  <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+	  <PackageReference Update="MSTest.TestAdapter" Version="4.2.2" />
+	  <PackageReference Update="MSTest.TestFramework" Version="4.2.2" />
 	  <PackageReference Update="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Plugins/PluginsLoaderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.NetCoreApp.Tests/Plugins/PluginsLoaderTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
 
                         // If this Assert is hit, the SDK was likely updated to break
                         // the processing source definitions used to test this class
-                        Assert.Fail("ProcessingSource {0} failed to compile", plugin);
+                        Assert.Fail($"ProcessingSource {plugin} failed to compile");
                     }
                     else
                     {
@@ -130,7 +130,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public void NullDirectoryThrows()
         {
             (var loader, _) = Setup(true);
-            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugin(null, out _));
+            Assert.ThrowsExactly<ArgumentNullException>(() => loader.TryLoadPlugin(null, out _));
         }
         
         [TestMethod]
@@ -138,7 +138,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public async Task NullDirectoryThrowsAsync()
         {
             (var loader, _) = Setup(true);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => loader.TryLoadPluginAsync(null));
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => loader.TryLoadPluginAsync(null));
         }
 
         [TestMethod]
@@ -146,7 +146,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public void NullDirectoriesThrows()
         {
             (var loader, _) = Setup(true);
-            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugins(null, out _));
+            Assert.ThrowsExactly<ArgumentNullException>(() => loader.TryLoadPlugins(null, out _));
         }
         
         [TestMethod]
@@ -154,7 +154,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public async Task NullDirectoriesThrowsAsync()
         {
             (var loader, _) = Setup(true);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => loader.TryLoadPluginsAsync(null));
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => loader.TryLoadPluginsAsync(null));
         }
         
         [TestMethod]
@@ -162,7 +162,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public void NullDirectoryInDirectoriesThrows()
         {
             (var loader, _) = Setup(true);
-            Assert.ThrowsException<ArgumentNullException>(() => loader.TryLoadPlugins(new List<string>() { "foo", null }, out _));
+            Assert.ThrowsExactly<ArgumentNullException>(() => loader.TryLoadPlugins(new List<string>() { "foo", null }, out _));
         }
         
         [TestMethod]
@@ -170,7 +170,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         public async Task NullDirectoryInDirectoriesThrowsAsync()
         {
             (var loader, _) = Setup(true);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => loader.TryLoadPluginsAsync(new List<string>() { "foo", null }));
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => loader.TryLoadPluginsAsync(new List<string>() { "foo", null }));
         }
         
         [TestMethod]
@@ -635,9 +635,7 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
             // Assert blocking observed first plugin
             Assert.AreEqual(expected0.Length,
                 blockingConsumer.ObservedDataSources.Count,
-                "Blocking consumer observed {0} data sources but should have observed {1}",
-                blockingConsumer.ObservedDataSources.Count,
-                expected0.Length);
+                $"Blocking consumer observed {blockingConsumer.ObservedDataSources.Count} data sources but should have observed {expected0.Length}");
             AssertObservedCDSs(expected0, blockingConsumer);
 
             // Allow InvalidB to be processed
@@ -660,16 +658,16 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
             {
                 sut.Dispose();
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.LoadedProcessingSources);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.LoadedProcessingSources);
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Subscribe(new MockPluginsConsumer()));
-                await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => sut.SubscribeAsync(new MockPluginsConsumer()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryLoadPlugin(Any.FilePath(), out _));
-                await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => sut.TryLoadPluginAsync(Any.FilePath()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryLoadPlugins(new[] { Any.FilePath(), }, out _));
-                await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => sut.TryLoadPluginsAsync(new[] { Any.FilePath(), }));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Unsubscribe(new MockPluginsConsumer()));
-                await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => sut.UnsubscribeAsync(new MockPluginsConsumer()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Subscribe(new MockPluginsConsumer()));
+                await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => sut.SubscribeAsync(new MockPluginsConsumer()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryLoadPlugin(Any.FilePath(), out _));
+                await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => sut.TryLoadPluginAsync(Any.FilePath()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryLoadPlugins(new[] { Any.FilePath(), }, out _));
+                await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => sut.TryLoadPluginsAsync(new[] { Any.FilePath(), }));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Unsubscribe(new MockPluginsConsumer()));
+                await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => sut.UnsubscribeAsync(new MockPluginsConsumer()));
             }
         }
 
@@ -741,17 +739,12 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
         {
             Assert.AreEqual(expected,
                 loader.LoadedProcessingSources.Count(),
-                "The plugins loader reports having loaded {0} instead of {1} processing sources",
-                loader.LoadedProcessingSources.Count(),
-                expected);
+                $"The plugins loader reports having loaded {loader.LoadedProcessingSources.Count()} instead of {expected} processing sources");
             foreach (var consumer in consumers)
             {
                 Assert.AreEqual(expected,
                     consumer.ObservedDataSources.Count,
-                    "Consumer {0} observed {1} instead of {2} processing sources",
-                    consumer,
-                    consumer.ObservedDataSources.Count,
-                    expected);
+                    $"Consumer {consumer} observed {consumer.ObservedDataSources.Count} instead of {expected} processing sources");
             }
         }
 
@@ -794,22 +787,13 @@ namespace Microsoft.Performance.SDK.Runtime.NetCoreApp.Plugins.Tests
 
                 Assert.AreEqual(expected.Guid,
                     actual.Guid,
-                    "The loaded ProcessingSource at index {0} had the GUID {1} instead of {2}",
-                    i,
-                    actual.Guid,
-                    expected.Guid);
+                    $"The loaded ProcessingSource at index {i} had the GUID {actual.Guid} instead of {expected.Guid}");
                 Assert.AreEqual(expected.Name,
                     actual.Name,
-                    "ProcessingSource {0} was loaded with the name {1} instead of {2}",
-                    actual.Guid,
-                    actual.Name,
-                    expected.Name);
+                    $"ProcessingSource {actual.Guid} was loaded with the name {actual.Name} instead of {expected.Name}");
                 Assert.AreEqual(expected.Description,
                     actual.Description,
-                    "ProcessingSource {0} was loaded with the description {1} instead of {2}",
-                    actual.Guid,
-                    actual.Description,
-                    expected.Description);
+                    $"ProcessingSource {actual.Guid} was loaded with the description {actual.Description} instead of {expected.Description}");
             }
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/EmptyColumnBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/EmptyColumnBuilderTests.cs
@@ -23,7 +23,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithToggle(null, Projection.Constant(1f));
         });
@@ -34,7 +34,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithToggle<int>(new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }), null);
         });
@@ -45,7 +45,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 null,
@@ -59,7 +59,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }),
@@ -73,7 +73,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }),
@@ -87,7 +87,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() => { builder.WithToggledModes(null, builder => builder); });
+        Assert.ThrowsExactly<ArgumentNullException>(() => { builder.WithToggledModes(null, builder => builder); });
     }
 
     [TestMethod]
@@ -103,7 +103,7 @@ public class EmptyColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() => { builder.WithModes(null, builder => builder); });
+        Assert.ThrowsExactly<ArgumentNullException>(() => { builder.WithModes(null, builder => builder); });
     }
 
     [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/ModalColumnBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/ModalColumnBuilderTests.cs
@@ -27,7 +27,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithMode(null, Projection.Constant(1f));
         });
@@ -38,7 +38,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithMode<int>(modeDescriptor, null);
         });
@@ -57,7 +57,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalMode(
                 null,
@@ -71,7 +71,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalMode<float>(
                 modeDescriptor,
@@ -85,7 +85,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalMode<float>(
                 modeDescriptor,
@@ -111,7 +111,7 @@ public class ModalColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentException>(() =>
         {
             builder.WithDefaultMode(Guid.NewGuid());
         });

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/ToggledColumnBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ColumnBuilding/ToggledColumnBuilderTests.cs
@@ -23,7 +23,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithToggle(null, Projection.Constant(1f));
         });
@@ -34,7 +34,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithToggle<int>(new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }), null);
         });
@@ -45,7 +45,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 null,
@@ -59,7 +59,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }),
@@ -73,7 +73,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             builder.WithHierarchicalToggle(
                 new ColumnVariantDescriptor(Guid.NewGuid(), new ColumnVariantProperties { Label = "Foo" }),
@@ -87,7 +87,7 @@ public class ToggledColumnBuilderTests
     {
         var builder = CreateSut();
 
-        Assert.ThrowsException<ArgumentNullException>(() => { builder.WithToggledModes(null, modesBuilder => modesBuilder); });
+        Assert.ThrowsExactly<ArgumentNullException>(() => { builder.WithToggledModes(null, modesBuilder => modesBuilder); });
     }
 
     [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/CookedDataReflectorTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/CookedDataReflectorTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void QueryAsWrongTypeThrows()
         {
-            Assert.ThrowsException<InvalidCastException>(
+            Assert.ThrowsExactly<InvalidCastException>(
                 () => testReflector.QueryOutput<bool>(
                     new DataOutputPath(TestCookedDataReflector.DefaultCookerPath, nameof(TestCookedDataReflector.AddFunc))));
         }
@@ -133,7 +133,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void QueryNonExistentPathThrows()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => testReflector.QueryOutput<bool>(
                     new DataOutputPath(TestCookedDataReflector.DefaultCookerPath, "DoesNotExist")));
         }

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/DataSourceResolverTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/DataSourceResolverTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void Assign_NullDataSourcesThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => DataSourceResolver.Assign(null, Array.Empty<ProcessingSourceReference>()));
         }
 
@@ -32,7 +32,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void Assign_NullProcessingSourcesThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => DataSourceResolver.Assign(Array.Empty<IDataSource>(), null));
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
                 var ecds = kvp.Key;
                 var eds = kvp.Value.ToList();
 
-                Assert.IsTrue(actual.ContainsKey(ecds), "'{0}' is not found in the assignment.", ecds);
+                Assert.IsTrue(actual.ContainsKey(ecds), $"'{ecds}' is not found in the assignment.");
                 var ads = actual[ecds].ToList();
 
                 CollectionAssert.AreEquivalent(eds, ads);

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Discovery/AssemblyExtensionDiscoveryTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Discovery
         [UnitTest]
         public void ProcessAssemblies_NullDirectoryPath()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Discovery.ProcessAssemblies((string)null, out _));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Discovery.ProcessAssemblies((string)null, out _));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CompositeCookerRepositoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CompositeCookerRepositoryTests.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void Constructor_NullParam_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => new ProcessingSystemCompositeCookers(null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new ProcessingSystemCompositeCookers(null));
         }
 
         [TestMethod]
         [UnitTest]
         public void Initialize_NullParam_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.Initialize(null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.Initialize(null));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CompositeDataCookerReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/CompositeDataCookerReferenceTests.cs
@@ -34,20 +34,20 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
                 sut.Dispose();
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Availability);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.DependencyReferences);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Description);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.InitialAvailability);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Name);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Path);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataCookers);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Availability);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DependencyReferences);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Description);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.InitialAvailability);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Name);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Path);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataCookers);
                 // TODO: __SDK_DP__
                 // Redesign Data Processor API
-                // Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataProcessors);
+                // Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataProcessors);
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.CreateInstance(new FakeRetrieval()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CreateInstance(new FakeRetrieval()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
             }
             finally
             {

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookerSchedulingNodeTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataCookerSchedulingNodeTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void ConstructorThrowsWithoutDependencySupportInDataCooker()
         {
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => DataCookerSchedulingNode.CreateSchedulingNode(new DataCookerWithoutDependencies()));
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             scheduler.AddNode(cookerWithCircularDependency2Node);
             scheduler.AddNode(cookerWithCircularDependency3Node);
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => cookerWithCircularDependency1Node.Schedule(scheduler, null));
         }
 
@@ -1287,7 +1287,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             scheduler.AddNode(node);
             scheduler.AddNode(asRequiredNode);
 
-            Assert.ThrowsException<InvalidOperationException>(() => node.Schedule(scheduler, null));
+            Assert.ThrowsExactly<InvalidOperationException>(() => node.Schedule(scheduler, null));
         }
 
         [TestMethod]
@@ -1321,7 +1321,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             scheduler.AddNode(node2);
             scheduler.AddNode(asRequiredNode);
 
-            Assert.ThrowsException<InvalidOperationException>(() => node1.Schedule(scheduler, null));
+            Assert.ThrowsExactly<InvalidOperationException>(() => node1.Schedule(scheduler, null));
         }
     }
 }

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionDependencyTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void ConstructorThrowsForNullDependencyTarget()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new DataExtensionDependencyState((IDataExtensionDependencyTarget)null));
         }
 
@@ -28,7 +28,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void ConstructorThrowsForNullOther()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new DataExtensionDependencyState((DataExtensionDependencyState)null));
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRepositoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRepositoryTests.cs
@@ -33,19 +33,19 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             this.Sut.Dispose();
 
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.CompositeDataCookers);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.CompositeDataCookers);
             // TODO: __SDK_DP__
             // Redesign Data Processor API
-            ////Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.DataProcessors);
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.SourceDataCookers);
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.TablesById);
+            ////Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.DataProcessors);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.SourceDataCookers);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.TablesById);
 
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.GetCompositeDataCookerReference(new DataCookerPath()));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.GetCompositeDataCookerReference(new DataCookerPath()));
             // TODO: __SDK_DP__
             // Redesign Data Processor API
-            ////Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.GetDataProcessorReference(new DataProcessorId()));
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.GetSourceDataCookerFactory(new DataCookerPath()));
-            Assert.ThrowsException<ObjectDisposedException>(() => this.Sut.GetSourceDataCookerReference(new DataCookerPath()));
+            ////Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.GetDataProcessorReference(new DataProcessorId()));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.GetSourceDataCookerFactory(new DataCookerPath()));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => this.Sut.GetSourceDataCookerReference(new DataCookerPath()));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRetrievalFactoryTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataExtensionRetrievalFactoryTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var sourceCookerData = CreateSourceCookerData();
             var compositeCookerData = CreateCompositeCookerData(dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
                 new DataExtensionRetrievalFactory(sourceCookerData, compositeCookerData, null));
         }
 
@@ -45,7 +45,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRepository = new TestDataExtensionRepository();
             var compositeCookerData = CreateCompositeCookerData(dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
                 new DataExtensionRetrievalFactory(null, compositeCookerData, dataExtensionRepository));
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRepository = new TestDataExtensionRepository();
             var sourceCookerData = CreateSourceCookerData();
 
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
                 new DataExtensionRetrievalFactory(sourceCookerData, null, dataExtensionRepository));
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRetrievalFactory =
                 new DataExtensionRetrievalFactory(sourceCookerData, compositeCookerData, dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.ThrowsExactly<ArgumentException>(() =>
                 dataExtensionRetrievalFactory.CreateDataRetrievalForCompositeDataCooker(cookerPath));
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRetrievalFactory =
                 new DataExtensionRetrievalFactory(sourceCookerData, compositeCookerData, dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.ThrowsExactly<ArgumentException>(() =>
                 dataExtensionRetrievalFactory.CreateDataRetrievalForCompositeDataCooker(dataCookerReference.Path));
         }
 
@@ -199,7 +199,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRetrievalFactory =
                 new DataExtensionRetrievalFactory(sourceCookerData, compositeCookerData, dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.ThrowsExactly<ArgumentException>(() =>
                 dataExtensionRetrievalFactory.CreateDataRetrievalForTable(tableId));
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var dataExtensionRetrievalFactory =
                 new DataExtensionRetrievalFactory(sourceCookerData, compositeCookerData, dataExtensionRepository);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.ThrowsExactly<ArgumentException>(() =>
                 dataExtensionRetrievalFactory.CreateDataRetrievalForTable(tableReference.TableDescriptor.Guid));
         }
     }

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataProcessorReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DataProcessorReferenceTests.cs
@@ -34,19 +34,19 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
     ////            sut.Dispose();
 
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.Availability);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.DependencyReferences);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.DependencyState);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.Description);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.Id);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.InitialAvailability);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.Name);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataCookers);
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataProcessors);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Availability);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DependencyReferences);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DependencyState);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Description);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Id);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.InitialAvailability);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Name);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataCookers);
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataProcessors);
 
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.GetOrCreateInstance(new FakeRetrieval()));
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
-    ////            Assert.ThrowsException<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.GetOrCreateInstance(new FakeRetrieval()));
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
+    ////            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
     ////        }
     ////        finally
     ////        {

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagExtensionsTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagExtensionsTests.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
             var dag = DependencyDag.Create(catalog, repo);
 
-            Assert.ThrowsException<ArgumentNullException>(() => DependencyDagExtensions.DependentWalk(null, x => { }));
-            Assert.ThrowsException<ArgumentNullException>(() => dag.DependentWalk(null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => DependencyDagExtensions.DependentWalk(null, x => { }));
+            Assert.ThrowsExactly<ArgumentNullException>(() => dag.DependentWalk(null));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/DependencyDagTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void Create_NullParameters_Throw()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => DependencyDag.Create(null, new TestDataExtensionRepository()));
-            Assert.ThrowsException<ArgumentNullException>(() => DependencyDag.Create(new TestProcessingSourceCatalog(), null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => DependencyDag.Create(null, new TestDataExtensionRepository()));
+            Assert.ThrowsExactly<ArgumentNullException>(() => DependencyDag.Create(new TestProcessingSourceCatalog(), null));
         }
 
         [TestMethod]
@@ -36,7 +36,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var repo = new DataExtensionRepository();
             repo.FinalizeDataExtensions();
 
-            Assert.ThrowsException<ArgumentException>(() => DependencyDag.Create(catalog, repo));
+            Assert.ThrowsExactly<ArgumentException>(() => DependencyDag.Create(catalog, repo));
         }
 
         [TestMethod]
@@ -543,7 +543,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             repo.TryAddReference(r0d3);
             repo.FinalizeDataExtensions();
 
-            var e = Assert.ThrowsException<InvalidOperationException>(() => DependencyDag.Create(catalog, repo));
+            var e = Assert.ThrowsExactly<InvalidOperationException>(() => DependencyDag.Create(catalog, repo));
 
             var expectedCycleString = string.Format(
                 "Cycle: {0} -> {1} -> {2} -> {0}",
@@ -586,7 +586,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             repo.TryAddReference(r0d3);
             repo.FinalizeDataExtensions();
 
-            var e = Assert.ThrowsException<InvalidOperationException>(() => DependencyDag.Create(catalog, repo));
+            var e = Assert.ThrowsExactly<InvalidOperationException>(() => DependencyDag.Create(catalog, repo));
 
             var expectedCycleString = string.Format(
                 "Cycle: {0} -> {1} -> {2} -> {0}",

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceDataCookerReferenceTests.cs
@@ -154,21 +154,21 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
                 sut.Dispose();
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Availability);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.DependencyReferences);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Description);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.InitialAvailability);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Name);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Path);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Availability);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DependencyReferences);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Description);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.InitialAvailability);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Name);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Path);
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.CreateInstance());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataCookers);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CreateInstance());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.PerformAdditionalDataExtensionValidation(new FakeSupport(), new FakeReference()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataCookers);
 
                 // TODO: __SDK_DP__
                 // Redesign Data Processor API
-                // Assert.ThrowsException<ObjectDisposedException>(() => sut.RequiredDataProcessors);
+                // Assert.ThrowsExactly<ObjectDisposedException>(() => sut.RequiredDataProcessors);
             }
             finally
             {

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceSessionTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/SourceSessionTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         [UnitTest]
         public void Constructor_NullSourceParser_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new SourceProcessingSession<TestRecord, TestParserContext, int>(null));
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
         {
             var sourceParser = new TestSourceParser();
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new SourceProcessingSession<TestRecord, TestParserContext, int>(sourceParser));
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
             var sourceParser = new TestSourceParser() { Id = "TestSourceParser" };
             var sourceSession = new SourceProcessingSession<TestRecord, TestParserContext, int>(sourceParser);
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => sourceSession.RegisterSourceDataCooker(null));
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Extensibility/TableExtensionReferenceTests.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Performance.SDK.Runtime.Tests.Extensibility
 
                 sut.Dispose();
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Availability);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.BuildTableAction);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.DependencyReferences);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.IsDataAvailableFunc);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TableDescriptor);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Availability);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.BuildTableAction);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DependencyReferences);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.IsDataAvailableFunc);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TableDescriptor);
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.ProcessDependencies(new TestDataExtensionRepository()));
             }
             finally
             {

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
@@ -102,7 +102,7 @@ public class PluginOptionsSystemTests
     [DataRow(@"C:\Foo\:bar.json")]
     public void BadFilePath_ThrowsArgumentException(string filePath)
     {
-        Assert.ThrowsException<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentException>(() =>
         {
             PluginOptionsSystem.CreateForFile(null, (_) => new NullLogger());
         });
@@ -111,7 +111,7 @@ public class PluginOptionsSystemTests
     [TestMethod]
     public void LongFilePath_ThrowsPathTooLongException()
     {
-        Assert.ThrowsException<PathTooLongException>(() =>
+        Assert.ThrowsExactly<PathTooLongException>(() =>
         {
             PluginOptionsSystem.CreateForFile(Path.Combine(@"C:\", new string('a', 50000), "foo.json"), (_) => new NullLogger());
         });
@@ -120,7 +120,7 @@ public class PluginOptionsSystemTests
     [TestMethod]
     public void UnknownNetworkPath_ThrowsDirectoryNotFoundException()
     {
-        Assert.ThrowsException<DirectoryNotFoundException>(() =>
+        Assert.ThrowsExactly<DirectoryNotFoundException>(() =>
         {
             PluginOptionsSystem.CreateForFile(@"\\randomServer\C$\foo.json", (_) => new NullLogger());
         });

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/PluginOptionsSystemTests.cs
@@ -104,7 +104,7 @@ public class PluginOptionsSystemTests
     {
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            PluginOptionsSystem.CreateForFile(null, (_) => new NullLogger());
+            PluginOptionsSystem.CreateForFile(filePath, (_) => new NullLogger());
         });
     }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsLoaderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsLoaderTests.cs
@@ -63,7 +63,7 @@ public class StreamPluginOptionsLoaderTests
 
         await sut.TryLoadAsync();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => stream.Position);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => stream.Position);
         Assert.IsFalse(stream.CanRead);
         Assert.IsFalse(stream.CanSeek);
         Assert.IsFalse(stream.CanWrite);

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsSaverTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/Options/StreamPluginOptionsSaverTests.cs
@@ -57,7 +57,7 @@ public class StreamPluginOptionsSaverTests
         var success = await sut.TrySaveAsync(TestPluginOptionDto.PluginOptionsDto());
 
         Assert.IsTrue(success);
-        Assert.ThrowsException<ObjectDisposedException>(() => stream.Position);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => stream.Position);
         Assert.IsFalse(stream.CanRead);
         Assert.IsFalse(stream.CanSeek);
         Assert.IsFalse(stream.CanWrite);

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceExecutorTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceExecutorTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void ExecuteWithNullExecutionContextThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => this.Sut.InitializeCustomDataProcessor(null));
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
                 Any.ProcessorEnvironment(),
                 ProcessorOptions.Default);
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => this.Sut.InitializeCustomDataProcessor(executionContext));
         }
 

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceReferenceTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/ProcessingSourceReferenceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void TryCreateReferenceForNullTypeThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => ProcessingSourceReference.TryCreateReference(
                     null,
                     out ProcessingSourceReference _));
@@ -139,29 +139,29 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
 
                 sut.Dispose();
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.AssemblyPath);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.AvailableTables);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.CommandLineOptions);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TrackedProcessors);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.DataSources);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Description);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Guid);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Instance);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Name);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Type);
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Version);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.AssemblyPath);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.AvailableTables);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CommandLineOptions);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TrackedProcessors);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DataSources);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Description);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Guid);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Instance);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Name);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Type);
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Version);
 
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.AreDirectoriesSupported());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.AreExtensionlessFilesSupported());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Clone());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.CloneT());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.CreateProcessor((IDataSourceGroup)null, null, null));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.Supports(Any.DataSource()));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryGetCanonicalFileExtensions());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryGetDirectoryDescription());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryGetExtensionlessFileDescription());
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryGetFileDescription(".txt"));
-                Assert.ThrowsException<ObjectDisposedException>(() => sut.TryGetFileExtensions());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.AreDirectoriesSupported());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.AreExtensionlessFilesSupported());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Clone());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CloneT());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CreateProcessor((IDataSourceGroup)null, null, null));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Supports(Any.DataSource()));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryGetCanonicalFileExtensions());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryGetDirectoryDescription());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryGetExtensionlessFileDescription());
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryGetFileDescription(".txt"));
+                Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryGetFileExtensions());
             }
             finally
             {

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/TableBuilderTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void SetRowCountDoesNotAllowNegativeNumber()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
                 () => this.Sut.SetRowCount(-1));
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddColumnDoesNotAllowNulls()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => this.Sut.AddColumn(null));
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => this.Sut.ReplaceColumn(null, column));
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
               new UIHints { Width = 200, },
               Projection.CreateUsingFuncAdaptor(i => "test"));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => this.Sut.ReplaceColumn(column, null));
         }
 
@@ -194,12 +194,12 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         [UnitTest]
         public void AddTableCommandInvalidArgumentsThrow()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand(null, _ => { }));
-            Assert.ThrowsException<ArgumentException>(() => this.Sut.AddTableCommand(string.Empty, _ => { }));
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand("test", null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddTableCommand(null, _ => { }));
+            Assert.ThrowsExactly<ArgumentException>(() => this.Sut.AddTableCommand(string.Empty, _ => { }));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddTableCommand("test", null));
 
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand2("test", null, (context) => { }));
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddTableCommand2("test", (context) => true, null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddTableCommand2("test", null, (context) => { }));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddTableCommand2("test", (context) => true, null));
         }
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         public void AddTableCommandDuplicateNameThrows()
         {
             this.Sut.AddTableCommand("test", _ => { });
-            Assert.ThrowsException<InvalidOperationException>(() => this.Sut.AddTableCommand("test", _ => { }));
+            Assert.ThrowsExactly<InvalidOperationException>(() => this.Sut.AddTableCommand("test", _ => { }));
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         public void AddTableCommandDuplicateNameThrowsIrrespectiveOfCase()
         {
             this.Sut.AddTableCommand("test", _ => { });
-            Assert.ThrowsException<InvalidOperationException>(() => this.Sut.AddTableCommand("tEsT", _ => { }));
+            Assert.ThrowsExactly<InvalidOperationException>(() => this.Sut.AddTableCommand("tEsT", _ => { }));
         }
 
         [TestMethod]
@@ -223,7 +223,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
         public void AddTableCommandDuplicateNameThrowsIrrespectiveOfPadding()
         {
             this.Sut.AddTableCommand("test", _ => { });
-            Assert.ThrowsException<InvalidOperationException>(() => this.Sut.AddTableCommand(" test\t  ", _ => { }));
+            Assert.ThrowsExactly<InvalidOperationException>(() => this.Sut.AddTableCommand(" test\t  ", _ => { }));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Runtime.Tests/VersionCheckerTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/VersionCheckerTests.cs
@@ -75,10 +75,7 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
             Assert.AreEqual(
                 expected,
                 result,
-                "{0} SHOULD{1} HAVE BEEN SUPPORTED BY {2}",
-                candidateSemVer,
-                expected ? string.Empty : " NOT",
-                sdkSemVer);
+                $"{candidateSemVer} SHOULD{(expected ? string.Empty : " NOT")} HAVE BEEN SUPPORTED BY {sdkSemVer}");
         }
 
         private static VersionChecker CreateSut(

--- a/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsSystem.cs
+++ b/src/Microsoft.Performance.SDK.Runtime/Options/PluginOptionsSystem.cs
@@ -64,6 +64,8 @@ public sealed class PluginOptionsSystem
         string filePath,
         Func<Type, ILogger> loggerFactory)
     {
+        ValidateFilePath(filePath);
+
         var directory = Path.GetDirectoryName(filePath);
 
         if (string.IsNullOrEmpty(directory))
@@ -78,6 +80,43 @@ public sealed class PluginOptionsSystem
         var registry = new PluginOptionsRegistry(loggerFactory(typeof(PluginOptionsRegistry)));
 
         return new PluginOptionsSystem(loader, saver, registry);
+    }
+
+    /// <summary>
+    ///     Validates that <paramref name="filePath"/> is well-formed, throwing an
+    ///     <see cref="ArgumentException"/> if it contains invalid characters or is
+    ///     otherwise malformed. This check is performed up-front so that malformed
+    ///     paths consistently result in an <see cref="ArgumentException"/> instead of
+    ///     leaking lower-level exceptions (e.g. <see cref="IOException"/>) or, worse,
+    ///     silently succeeding.
+    /// </summary>
+    private static void ValidateFilePath(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException("File path cannot be null, empty, or consist only of white-space characters.", nameof(filePath));
+        }
+
+        if (filePath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+        {
+            throw new ArgumentException("The file path contains invalid characters.", nameof(filePath));
+        }
+
+        string fileName = Path.GetFileName(filePath);
+        if (!string.IsNullOrEmpty(fileName) && fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("The file name portion of the file path contains invalid characters.", nameof(filePath));
+        }
+
+        // A ':' is only valid as the drive-letter separator (e.g. "C:\..."). Anywhere
+        // else it produces a malformed path (e.g. ":C:\foo" or "C:\foo\:bar.json"),
+        // which some file system APIs surface as an IOException rather than an
+        // ArgumentException.
+        int colonIndex = filePath.IndexOf(':');
+        if (colonIndex >= 0 && colonIndex != 1)
+        {
+            throw new ArgumentException("The file path contains a ':' character in a position other than a drive letter separator.", nameof(filePath));
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Performance.SDK.Tests/CollectionExtensionsTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/CollectionExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void AsReadOnlyArrayThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => CollectionExtensions.AsReadOnly<object>((object[])null));
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void AsReadOnlyIListThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => CollectionExtensions.AsReadOnly<object>((IList<object>)null));
         }
 

--- a/src/Microsoft.Performance.SDK.Tests/ColumnVariantsTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ColumnVariantsTests.cs
@@ -265,7 +265,7 @@ public class ColumnVariantsTests
         var tableBuilder = new TableBuilder();
         tableBuilder.SetRowCount(1);
 
-        Assert.ThrowsException<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
         {
             tableBuilder.AddColumnWithVariants(baseConfig, utcProj, builder =>
             {
@@ -281,7 +281,7 @@ public class ColumnVariantsTests
     {
         var tableBuilder = new TableBuilder().SetRowCount(1);
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             tableBuilder.AddColumnWithVariants(null, (builder) => builder);
         });
@@ -314,7 +314,7 @@ public class ColumnVariantsTests
         var tableBuilder = new TableBuilder();
         tableBuilder.SetRowCount(1);
 
-        Assert.ThrowsException<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
         {
             tableBuilder.AddColumnWithVariants(baseConfig, utcProj, builder =>
             {

--- a/src/Microsoft.Performance.SDK.Tests/DataSourceInfoTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/DataSourceInfoTests.cs
@@ -15,24 +15,24 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void NegativeStartThrows()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(-1, 0, DateTime.UnixEpoch));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(-1, 0, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(-1, 0, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(-1, 0, DateTime.UnixEpoch));
         }
 
         [TestMethod]
         [UnitTest]
         public void NegativeEndThrows()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(0, -1, DateTime.UnixEpoch));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(0, -1, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(0, -1, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(0, -1, DateTime.UnixEpoch));
         }
 
         [TestMethod]
         [UnitTest]
         public void StopLessThanStartThrows()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(1, 0, DateTime.UnixEpoch));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DataSourceInfo(1, 0, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(1, 0, DateTime.UnixEpoch));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DataSourceInfo(1, 0, DateTime.UnixEpoch));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Tests/DirectoryDataSourceAttributeTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/DirectoryDataSourceAttributeTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void NullDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new DirectoryDataSourceAttribute(null));
         }
 
@@ -23,7 +23,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void WhitespaceDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => new DirectoryDataSourceAttribute(string.Empty));
         }
 

--- a/src/Microsoft.Performance.SDK.Tests/ExtensionlessFileDataSourceAttributeTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ExtensionlessFileDataSourceAttributeTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void NullDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new ExtensionlessFileDataSourceAttribute(null));
         }
 
@@ -23,7 +23,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void WhitespaceDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => new ExtensionlessFileDataSourceAttribute(string.Empty));
         }
 

--- a/src/Microsoft.Performance.SDK.Tests/FileDataSourceAttributeTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/FileDataSourceAttributeTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void NullExtensionThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new FileDataSourceAttribute(null));
         }
 
@@ -23,7 +23,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void WhitespaceExtensionThrows()
         {
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => new FileDataSourceAttribute(string.Empty));
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void NullDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => new FileDataSourceAttribute("ext", null));
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void WhitespaceDescriptionThrows()
         {
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => new FileDataSourceAttribute("ext", string.Empty));
         }
 

--- a/src/Microsoft.Performance.SDK.Tests/ProcessingSourceTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ProcessingSourceTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Performance.SDK.Tests
             };
             sut.SetApplicationEnvironment(applicationEnvironment);
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => sut.CreateProcessor(dataSource, Any.ProcessorEnvironment(), ProcessorOptions.Default));
         }
 
@@ -132,7 +132,7 @@ namespace Microsoft.Performance.SDK.Tests
 
             sut.SetApplicationEnvironment(applicationEnvironment);
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => sut.CreateProcessor(dataSources, Any.ProcessorEnvironment(), ProcessorOptions.Default));
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.Performance.SDK.Tests
         public void WhenTableDiscoveryProvidedIsNull_DiscoveryThrows()
         {
             var sut = new CreateTableProviderBasedStubDataSource(null);
-            Assert.ThrowsException<InvalidOperationException>(() => sut.SetApplicationEnvironment(applicationEnvironment));
+            Assert.ThrowsExactly<InvalidOperationException>(() => sut.SetApplicationEnvironment(applicationEnvironment));
         }
 
         [TestMethod]
@@ -226,7 +226,7 @@ namespace Microsoft.Performance.SDK.Tests
 
             var sut = new CreateTableProviderBasedStubDataSource(discovery);
 
-            Assert.ThrowsException<InvalidOperationException>(() => sut.SetApplicationEnvironment(applicationEnvironment));
+            Assert.ThrowsExactly<InvalidOperationException>(() => sut.SetApplicationEnvironment(applicationEnvironment));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Tests/ProjectionTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ProjectionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void CacheThrowsWithNullArgument()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.CacheOnFirstUse<object>(1, null));
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void CacheThrowsWithNegativeArgument()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
                 () => Projection.CacheOnFirstUse(-1, Projection.Identity<int>()));
         }
 
@@ -82,15 +82,15 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void ComposeThrowsWithNullArguments()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Compose<int, object, object>(null, i => i));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Compose(
                     Projection.Identity<int>(),
                     (Func<int, object>)null));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Compose(
                     Projection.Identity<int>(),
                     (IProjection<int, object>)null));
@@ -173,10 +173,10 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void CreateThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Create<object>((Func<int, object>)null));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Create<object, object>((Func<object, object>)null));
         }
 
@@ -186,85 +186,85 @@ namespace Microsoft.Performance.SDK.Tests
         {
             // int, T
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyPrivateMethodIntToObject));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyPrivateMethodIntToObjectStatic));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyProtectedMethodIntToObject));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyProtectedMethodIntToObjectStatic));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyInternalMethodIntToObject));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyInternalMethodIntToObjectStatic));
 
             // T1,T2
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericPrivateMethod<int, object>));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericPrivateMethodStatic<int, object>));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericProtectedMethod<int, object>));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericProtectedMethodStatic<int, object>));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericInternalMethod<int, object>));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(MyGenericInternalMethodStatic<int, object>));
 
             // non-public nested
 
             var internalInstance = new InternalNestedType();
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(internalInstance.Method));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(InternalNestedType.MethodStatic));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(internalInstance.MethodGeneric<int, object>));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(InternalNestedType.MethodGenericStatic<int, object>));
 
             var protectedInstance = new ProtectedNestedType();
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(protectedInstance.Method));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(ProtectedNestedType.MethodStatic));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(protectedInstance.MethodGeneric<int, object>));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(ProtectedNestedType.MethodGenericStatic<int, object>));
 
             var privateInstance = new PrivateNestedType();
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(privateInstance.Method));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(PrivateNestedType.MethodStatic));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(privateInstance.MethodGeneric<int, object>));
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create(PrivateNestedType.MethodGenericStatic<int, object>));
 
             // anonymous
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create<int, object>(i => i));
 
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Create<DateTime, string>(x => x.ToString()));
         }
 
@@ -326,7 +326,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void IndexThrowsOnNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Index((IReadOnlyList<object>)null));
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void PrepopulatedCacheThrowsWithNullArgument()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.PrepopulatedCache<object>(1, null));
         }
 
@@ -382,7 +382,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void PrepopulatedCacheThrowsWithNegativeArgument()
         {
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
                 () => Projection.PrepopulatedCache(-1, Projection.Identity<int>()));
         }
 
@@ -448,12 +448,12 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_1_ThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, string>(
                     null,
                     Project_1_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, string>(
                     Projection.Constant(DateTime.UtcNow),
                     null));
@@ -463,7 +463,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_1_ThrowsIfNonStaticFuncGiven()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Project<int, DateTime, string>(
                     Projection.Constant(DateTime.UtcNow),
                     x => x.ToString()));
@@ -495,19 +495,19 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_2_ThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, string>(
                     null,
                     Projection.Constant(Guid.NewGuid()),
                     Project_2_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, string>(
                     Projection.Constant(DateTime.UtcNow),
                     null,
                     Project_2_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -518,7 +518,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_2_ThrowsIfNonStaticFuncGiven()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Project<int, DateTime, Guid, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -554,28 +554,28 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_3_ThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, string>(
                     null,
                     Projection.Constant(Guid.NewGuid()),
                     Projection.Constant(TimeSpan.Zero),
                     Project_3_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, string>(
                     Projection.Constant(DateTime.UtcNow),
                     null,
                     Projection.Constant(TimeSpan.Zero),
                     Project_3_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
                     null,
                     Project_3_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -587,7 +587,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_3_ThrowsIfNonStaticFuncGiven()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -627,7 +627,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_4_ThrowsForNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     null,
                     Projection.Constant(Guid.NewGuid()),
@@ -635,7 +635,7 @@ namespace Microsoft.Performance.SDK.Tests
                     Projection.Constant(DateTimeOffset.MaxValue),
                     Project_4_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     Projection.Constant(DateTime.UtcNow),
                     null,
@@ -643,7 +643,7 @@ namespace Microsoft.Performance.SDK.Tests
                     Projection.Constant(DateTimeOffset.MaxValue),
                     Project_4_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -651,7 +651,7 @@ namespace Microsoft.Performance.SDK.Tests
                     Projection.Constant(DateTimeOffset.MaxValue),
                     Project_4_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -659,7 +659,7 @@ namespace Microsoft.Performance.SDK.Tests
                     null,
                     Project_4_Projector));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),
@@ -672,7 +672,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void Project_4_ThrowsIfNonStaticFuncGiven()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => Projection.Project<int, DateTime, Guid, TimeSpan, DateTimeOffset, string>(
                     Projection.Constant(DateTime.UtcNow),
                     Projection.Constant(Guid.NewGuid()),

--- a/src/Microsoft.Performance.SDK.Tests/TableConfigurationTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TableConfigurationTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void AddingColumnCollectionRightLeftOfLeftThrows()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => this.Sut.Columns = new[]
                 {
                     TableConfiguration.RightFreezeColumn,
@@ -92,7 +92,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void AddingColumnCollectionGraphLeftOfPivotThrows()
         {
-            Assert.ThrowsException<InvalidOperationException>(
+            Assert.ThrowsExactly<InvalidOperationException>(
                 () => this.Sut.Columns = new[]
                 {
                     TableConfiguration.GraphColumn,
@@ -112,7 +112,7 @@ namespace Microsoft.Performance.SDK.Tests
                     c,
                 };
 
-                Assert.ThrowsException<InvalidOperationException>(
+                Assert.ThrowsExactly<InvalidOperationException>(
                    () => this.Sut.Columns = testCase);
             }
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Performance.SDK.Tests
             foreach (var c in TableConfiguration.AllMetadataColumns)
             {
                 var r = ColumnRole.Duration;
-                Assert.ThrowsException<InvalidOperationException>(() => this.Sut.AddColumnRole(r, c.Metadata.Guid));
+                Assert.ThrowsExactly<InvalidOperationException>(() => this.Sut.AddColumnRole(r, c.Metadata.Guid));
             }
         }        
 
@@ -172,7 +172,7 @@ namespace Microsoft.Performance.SDK.Tests
 
             this.Sut.AddColumnRole(r1, c.Metadata.Guid);
 
-            Assert.ThrowsException<InvalidOperationException>(() => this.Sut.AddColumnRole(r2, c.Metadata.Guid));
+            Assert.ThrowsExactly<InvalidOperationException>(() => this.Sut.AddColumnRole(r2, c.Metadata.Guid));
         }
 
         [TestMethod]

--- a/src/Microsoft.Performance.SDK.Tests/TestClasses/TableDescriptorUtils.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TestClasses/TableDescriptorUtils.cs
@@ -39,13 +39,11 @@ namespace Microsoft.Performance.SDK.Tests.TestClasses
                         serializer,
                         out TableDescriptor expected,
                         out Action<ITableBuilder, IDataExtensionRetrieval> buildTableAction),
-                    "Unable to create table descriptor for type `{0}`",
-                    types[i]);
+                    $"Unable to create table descriptor for type `{types[i]}`");
 
                 Assert.IsNotNull(
                     expected,
-                    "TableDescriptorFactory.TryCreate for type `{0}` returned true but yielded null.",
-                    types[i]);
+                    $"TableDescriptorFactory.TryCreate for type `{types[i]}` returned true but yielded null.");
 
                 descriptors.Add(expected);
                 buildActions.Add(buildTableAction);

--- a/src/Microsoft.Performance.SDK.Tests/TypeExtensionTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/TypeExtensionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void IsStaticThrowsOnNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => TypeExtensions.IsStatic(null));
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void IsConcreteThrowsOnNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => TypeExtensions.IsConcrete(null));
         }
 
@@ -79,9 +79,9 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void IsThrowsOnNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => TypeExtensions.Is(null, typeof(ConcreteType)));
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => TypeExtensions.Is(typeof(ConcreteType), null));
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Performance.SDK.Tests
         [UnitTest]
         public void IsGenericThrowsOnNull()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => TypeExtensions.Is<ConcreteType>(null));
         }
 

--- a/src/Microsoft.Performance.Testing/AssertEx.cs
+++ b/src/Microsoft.Performance.Testing/AssertEx.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Performance.Testing
             var areEqual = comparer.Equals(expected, actual);
             Assert.IsTrue(
                 areEqual, 
-                "AssertEx.AreEqual failed. Expected:<{0}>. Actual:<{1}>.",
-                expected,
-                actual);
+                $"AssertEx.AreEqual failed. Expected:<{expected}>. Actual:<{actual}>.");
         }
 
         public static void IsInstanceOfType<T>(object obj)
@@ -37,7 +35,7 @@ namespace Microsoft.Performance.Testing
             string message, 
             params object[] paramters)
         {
-            Assert.IsInstanceOfType(obj, typeof(T), message, paramters);
+            Assert.IsInstanceOfType(obj, typeof(T), string.Format(message, paramters));
         }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/DataSourceSetTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/DataSourceSetTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void AddDataSource_NullFile_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSource(null, typeof(Source123DataSource)));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSource(null, typeof(Source123DataSource)));
         }
 
         [TestMethod]
@@ -46,7 +46,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         public void AddDataSource_NullType_Throws()
         {
             var file = CreateTestFile(".txt");
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSource(file, null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSource(file, null));
         }
 
         [TestMethod]
@@ -60,7 +60,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             Assert.IsTrue(this.Sut.Plugins.ProcessingSourceReferences.Any(x => x.Instance is Source123DataSource));
 
             var file = CreateTestFile(Source123DataSource.Extension);
-            var e = Assert.ThrowsException<UnsupportedProcessingSourceException>(() => this.Sut.AddDataSource(file, typeof(ToolkitEngineTests)));
+            var e = Assert.ThrowsExactly<UnsupportedProcessingSourceException>(() => this.Sut.AddDataSource(file, typeof(ToolkitEngineTests)));
             Assert.AreEqual(typeof(ToolkitEngineTests).FullName, e.RequestedProcessingSource);
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             Assert.IsTrue(this.Sut.Plugins.ProcessingSourceReferences.Any(x => x.Instance is Source123DataSource));
 
             var file = CreateTestFile(".380298502");
-            var e = Assert.ThrowsException<UnsupportedDataSourceException>(() => this.Sut.AddDataSource(file, typeof(Source123DataSource)));
+            var e = Assert.ThrowsExactly<UnsupportedDataSourceException>(() => this.Sut.AddDataSource(file, typeof(Source123DataSource)));
             Assert.AreEqual(file.Uri.ToString(), e.DataSource);
             Assert.AreEqual(typeof(Source123DataSource).FullName, e.RequestedProcessingSource);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void AddDataSourceOnly_Null_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSource(null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSource(null));
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             {
 
                 var file = CreateTestFile(".380298502");
-                var e = Assert.ThrowsException<UnsupportedDataSourceException>(() => this.Sut.AddDataSource(file));
+                var e = Assert.ThrowsExactly<UnsupportedDataSourceException>(() => this.Sut.AddDataSource(file));
                 Assert.AreEqual(file.Uri.ToString(), e.DataSource);
                 Assert.IsNull(e.RequestedProcessingSource);
             }
@@ -287,7 +287,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void AddDataSources_NullFiles_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSources(null, typeof(Source123DataSource)));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSources(null, typeof(Source123DataSource)));
         }
 
 
@@ -295,14 +295,14 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [IntegrationTest]
         public void AddDataSources_EmptyFiles_Throws()
         {
-            Assert.ThrowsException<ArgumentException>(() => this.Sut.AddDataSources(new IDataSource[0], typeof(Source123DataSource)));
+            Assert.ThrowsExactly<ArgumentException>(() => this.Sut.AddDataSources(new IDataSource[0], typeof(Source123DataSource)));
         }
 
         [TestMethod]
         [IntegrationTest]
         public void AddDataSources_ContainsNullFiles_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSources(new[] { (IDataSource)null, }, typeof(Source123DataSource)));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSources(new[] { (IDataSource)null, }, typeof(Source123DataSource)));
         }
 
         [TestMethod]
@@ -310,7 +310,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         public void AddDataSources_NullType_Throws()
         {
             var file = CreateTestFile(".txt");
-            Assert.ThrowsException<ArgumentNullException>(() => this.Sut.AddDataSources(new[] { file, }, null));
+            Assert.ThrowsExactly<ArgumentNullException>(() => this.Sut.AddDataSources(new[] { file, }, null));
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             Assert.IsTrue(this.Sut.Plugins.ProcessingSourceReferences.Any(x => x.Instance is Source123DataSource));
 
             var file = CreateTestFile(Source123DataSource.Extension);
-            var e = Assert.ThrowsException<UnsupportedProcessingSourceException>(() => this.Sut.AddDataSources(new[] { file, }, typeof(ToolkitEngineTests)));
+            var e = Assert.ThrowsExactly<UnsupportedProcessingSourceException>(() => this.Sut.AddDataSources(new[] { file, }, typeof(ToolkitEngineTests)));
             Assert.AreEqual(typeof(ToolkitEngineTests).FullName, e.RequestedProcessingSource);
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             var file1 = CreateTestFile(Source123DataSource.Extension);
             var file2 = CreateTestFile(Source123DataSource.Extension);
-            var e = Assert.ThrowsException<UnsupportedDataSourceException>(() => this.Sut.AddDataSources(new[] { file1, file2, }, typeof(Source4DataSource)));
+            var e = Assert.ThrowsExactly<UnsupportedDataSourceException>(() => this.Sut.AddDataSources(new[] { file1, file2, }, typeof(Source4DataSource)));
 
             Assert.AreEqual(file1.Uri.ToString(), e.DataSource);
             Assert.AreEqual(typeof(Source4DataSource).FullName, e.RequestedProcessingSource);

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/EngineFixture.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/EngineFixture.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             }
             catch (Exception e)
             {
-                Assert.Fail("Initialize: Unable to create scratch directory `{0}`: {1}", this.Scratch.FullName, e);
+                Assert.Fail($"Initialize: Unable to create scratch directory `{this.Scratch.FullName}`: {e}");
             }
 
             this.OnInitialize();
@@ -57,10 +57,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(
-                        "Cleanup: Unable to delete scratch directory `{0}`: {1}",
-                        this.Scratch.FullName,
-                        e);
+                    Assert.Fail($"Cleanup: Unable to delete scratch directory `{this.Scratch.FullName}`: {e}");
                 }
             }
             else

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/PluginSetTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/PluginSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             var file = Path.Combine(this.Scratch.FullName, "test.txt");
             File.WriteAllText(file, "test");
 
-            var e = Assert.ThrowsException<InvalidExtensionDirectoryException>(() => PluginSet.Load(file));
+            var e = Assert.ThrowsExactly<InvalidExtensionDirectoryException>(() => PluginSet.Load(file));
             Assert.AreEqual(file, e.Path);
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         {
             var doesNotExist = Path.Combine(this.Scratch.FullName, "doesNotExist");
 
-            var e = Assert.ThrowsException<InvalidExtensionDirectoryException>(() => PluginSet.Load(doesNotExist));
+            var e = Assert.ThrowsExactly<InvalidExtensionDirectoryException>(() => PluginSet.Load(doesNotExist));
             Assert.AreEqual(doesNotExist, e.Path);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             var dir1 = this.Scratch.CreateSubdirectory("Dir1");
             var dirDoesNotExist = Path.Combine(this.Scratch.FullName, "doesNotExist");
 
-            var e = Assert.ThrowsException<InvalidExtensionDirectoryException>(() => PluginSet.Load(new[] { dir1.FullName, dirDoesNotExist }));
+            var e = Assert.ThrowsExactly<InvalidExtensionDirectoryException>(() => PluginSet.Load(new[] { dir1.FullName, dirDoesNotExist }));
             Assert.AreEqual(dirDoesNotExist, e.Path);
         }
 

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineCreateInfoTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineCreateInfoTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             using var dataSourceSet = DataSourceSet.Create();
             var sut = new EngineCreateInfo(dataSourceSet.AsReadOnly());
             IProcessingOptionsResolver resolver = null;
-            Assert.ThrowsException<ArgumentNullException>(() => sut.WithProcessorOptions(resolver));
+            Assert.ThrowsExactly<ArgumentNullException>(() => sut.WithProcessorOptions(resolver));
         }
     }
 }

--- a/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
+++ b/src/Microsoft.Performance.Toolkit.Engine.Tests/ToolkitEngineTests.cs
@@ -50,20 +50,20 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
         [UnitTest]
         public void Create_NullParameters_Throw()
         {
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create((EngineCreateInfo)null));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create((IDataSource)null));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create((IDataSource)null, typeof(Source123Processor)));
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create(Any.DataSource(), null));
 
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create((IEnumerable<IDataSource>)null, typeof(Source123Processor)));
-            Assert.ThrowsException<ArgumentNullException>(
+            Assert.ThrowsExactly<ArgumentNullException>(
                 () => Engine.Create(new[] { Any.DataSource(), }, null));
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             var info = new EngineCreateInfo(dataSources.AsReadOnly());
             using var sut = Engine.Create(info);
 
-            Assert.AreNotSame(dataSources, sut.DataSourcesToProcess);
+            Assert.AreNotSame<object>(dataSources, sut.DataSourcesToProcess);
             Assert.AreEqual(1, sut.DataSourcesToProcess.FreeDataSourcesToProcess.Count());
             Assert.AreEqual(file, sut.DataSourcesToProcess.FreeDataSourcesToProcess.Single());
         }
@@ -236,7 +236,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             var cooker = DataCookerPath.ForComposite("not-there-id");
 
-            var e = Assert.ThrowsException<CookerNotFoundException>(() => sut.EnableCooker(cooker));
+            var e = Assert.ThrowsExactly<CookerNotFoundException>(() => sut.EnableCooker(cooker));
             Assert.AreEqual(cooker, e.DataCookerPath);
         }
 
@@ -248,7 +248,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             sut.Process();
 
-            Assert.ThrowsException<InstanceAlreadyProcessedException>(() => sut.EnableCooker(this.DefaultSet.Plugins.AllCookers.First()));
+            Assert.ThrowsExactly<InstanceAlreadyProcessedException>(() => sut.EnableCooker(this.DefaultSet.Plugins.AllCookers.First()));
         }
 
         [TestMethod]
@@ -260,7 +260,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             using var sut = Engine.Create(createInfo);
 
-            Assert.ThrowsException<NoDataSourceException>(() => sut.EnableCooker(Source4DataCooker.DataCookerPath));
+            Assert.ThrowsExactly<NoDataSourceException>(() => sut.EnableCooker(Source4DataCooker.DataCookerPath));
         }
 
         #endregion Enable Cooker
@@ -369,7 +369,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             var table = new TableDescriptor(Guid.NewGuid(), "Unknown Table", "Unknown Table");
 
-            var e = Assert.ThrowsException<TableNotFoundException>(() => sut.EnableTable(table));
+            var e = Assert.ThrowsExactly<TableNotFoundException>(() => sut.EnableTable(table));
             Assert.AreEqual(table, e.Descriptor);
         }
 
@@ -381,7 +381,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             sut.Process();
 
-            Assert.ThrowsException<InstanceAlreadyProcessedException>(() => sut.EnableTable(sut.AvailableTables.First()));
+            Assert.ThrowsExactly<InstanceAlreadyProcessedException>(() => sut.EnableTable(sut.AvailableTables.First()));
         }
 
         #endregion EnableTable
@@ -652,7 +652,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             foreach (var throwingTable in testCase.ThrowingTables)
             {
-                Assert.ThrowsException<TableNotEnabledException>(() => result.BuildTable(sut.AvailableTables.Single(x => x.Guid == Guid.Parse(throwingTable))));
+                Assert.ThrowsExactly<TableNotEnabledException>(() => result.BuildTable(sut.AvailableTables.Single(x => x.Guid == Guid.Parse(throwingTable))));
             }
         }
 
@@ -753,7 +753,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             sut.Process();
 
-            Assert.ThrowsException<InstanceAlreadyProcessedException>(() => sut.Process());
+            Assert.ThrowsExactly<InstanceAlreadyProcessedException>(() => sut.Process());
         }
 
         [TestMethod]
@@ -789,13 +789,13 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             foreach (var cooker in testCase.SourceCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
-                Assert.IsTrue(sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(sut.TryEnableCooker(cookerPath), $"Unable to enable cooker '{cookerPath}'");
             }
 
             foreach (var cooker in testCase.CompositeCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
-                Assert.IsTrue(sut.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(sut.TryEnableCooker(cookerPath), $"Unable to enable cooker '{cookerPath}'");
             }
 
             var results = sut.Process();
@@ -808,16 +808,14 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 var enumerableData = data as IEnumerable;
                 Assert.IsNotNull(
                     enumerableData,
-                    "Test output data must implement IEnumerable<> (type wasn't enumerable): '{0}'",
-                    data.GetType());
+                    $"Test output data must implement IEnumerable<> (type wasn't enumerable): '{data.GetType()}'");
                 var enumerableType = enumerableData.GetType();
                 var eInterface = enumerableType.GetInterface(typeof(IEnumerable<>).Name);
                 Assert.IsNotNull(
                     eInterface,
-                    "Test output data must implement IEnumerable<> (interface wasn't found): {0}",
-                    string.Join(", ", data.GetType().GetInterfaces().Select(x => x.FullName)));
+                    $"Test output data must implement IEnumerable<> (interface wasn't found): {string.Join(", ", data.GetType().GetInterfaces().Select(x => x.FullName))}");
                 var collectionType = eInterface.GetGenericArguments()[0];
-                Assert.IsNotNull(collectionType, "Unable to retrieve collection type for {0}", data.GetType());
+                Assert.IsNotNull(collectionType, $"Unable to retrieve collection type for {data.GetType()}");
 
                 var enumeratedData = new List<object>();
                 foreach (var o in enumerableData)
@@ -828,8 +826,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 Assert.AreEqual(
                     expectedDataPoints.Length,
                     enumeratedData.Count,
-                    "The processor did not process the correct amount of data: {0}",
-                    dataOutputPath);
+                    $"The processor did not process the correct amount of data: {dataOutputPath}");
 
                 var properties = collectionType.GetProperties()
                     .ToDictionary(x => x.Name, x => x, StringComparer.InvariantCultureIgnoreCase);
@@ -859,19 +856,16 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
                 Assert.IsTrue(
                     results.TryQueryOutput(dataOutputPath, out object data),
-                    "Output for {0} not found.",
-                    dataOutputPathRaw);
-                Assert.IsNotNull(data, "output for {0} was null ???", dataOutputPathRaw);
+                    $"Output for {dataOutputPathRaw} not found.");
+                Assert.IsNotNull(data, $"output for {dataOutputPathRaw} was null ???");
                 assertOutput(expectedDataPoints, data, dataOutputPath);
 
                 Assert.IsTrue(
                     results.TryGetCookedData(dataOutputPath.CookerPath, out var co),
-                    "Unable to retrieve CookerOutput: {0}",
-                    dataOutputPath.CookerPath);
+                    $"Unable to retrieve CookerOutput: {dataOutputPath.CookerPath}");
                 Assert.IsTrue(
                     co.TryQueryOutput(dataOutputPath.OutputId, out data),
-                    "Output on CookedData {0} not found.",
-                    dataOutputPathRaw);
+                    $"Output on CookedData {dataOutputPathRaw} not found.");
                 assertOutput(expectedDataPoints, data, dataOutputPath);
             }
 
@@ -891,16 +885,13 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
                 Assert.IsFalse(
                     results.TryQueryOutput(dataOutputPath, out var _),
-                    "Output should not have been available: {0}",
-                    dataOutputPathRaw);
+                    $"Output should not have been available: {dataOutputPathRaw}");
                 Assert.IsTrue(
                     results.TryGetCookedData(dataOutputPath.CookerPath, out var co),
-                    "Source Output should have been available: {0}",
-                    dataOutputPathRaw);
+                    $"Source Output should have been available: {dataOutputPathRaw}");
                 Assert.IsFalse(
                     co.TryQueryOutput(dataOutputPath.OutputId, out var _),
-                    "Output should not have been available: {0}",
-                    dataOutputPathRaw);
+                    $"Output should not have been available: {dataOutputPathRaw}");
             }
 
             foreach (var kvp in throwingCompositePaths)
@@ -910,12 +901,10 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
                 Assert.IsFalse(
                     results.TryQueryOutput(dataOutputPath, out var _),
-                    "Output should not have been available: {0}",
-                    dataOutputPathRaw);
+                    $"Output should not have been available: {dataOutputPathRaw}");
                 Assert.IsFalse(
                     results.TryGetCookedData(dataOutputPath.CookerPath, out var _),
-                    "Composite Output should not have been available: {0}",
-                    dataOutputPathRaw);
+                    $"Composite Output should not have been available: {dataOutputPathRaw}");
             }
         }
 
@@ -965,13 +954,13 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
             foreach (var cooker in testCase.SourceCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForSource(cooker.SourceParserId, cooker.DataCookerId);
-                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), $"Unable to enable cooker '{cookerPath}'");
             }
 
             foreach (var cooker in testCase.CompositeCookersToEnable ?? Array.Empty<EngineProcessDataCookerPathDto>())
             {
                 var cookerPath = DataCookerPath.ForComposite(cooker.DataCookerId);
-                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), "Unable to enable cooker '{0}'", cookerPath);
+                Assert.IsTrue(runtime.TryEnableCooker(cookerPath), $"Unable to enable cooker '{cookerPath}'");
             }
 
             var results = runtime.Process();
@@ -983,22 +972,20 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 DataOutputPath dataOutputPath = Parse(dataOutputPathRaw);
 
                 Assert.IsTrue(
-                    results.TryQueryOutput(dataOutputPath, out object data), "Output for {0} not found.", dataOutputPathRaw);
-                Assert.IsNotNull(data, "output for {0} was null ???", dataOutputPathRaw);
+                    results.TryQueryOutput(dataOutputPath, out object data), $"Output for {dataOutputPathRaw} not found.");
+                Assert.IsNotNull(data, $"output for {dataOutputPathRaw} was null ???");
 
                 var enumerableData = data as IEnumerable;
                 Assert.IsNotNull(
                     enumerableData,
-                    "Test output data must implement IEnumerable<> (type wasn't enumerable): '{0}'",
-                    data.GetType());
+                    $"Test output data must implement IEnumerable<> (type wasn't enumerable): '{data.GetType()}'");
                 var enumerableType = enumerableData.GetType();
                 var eInterface = enumerableType.GetInterface(typeof(IEnumerable<>).Name);
                 Assert.IsNotNull(
                     eInterface,
-                    "Test output data must implement IEnumerable<> (interface wasn't found): {0}",
-                    string.Join(", ", data.GetType().GetInterfaces().Select(x => x.FullName)));
+                    $"Test output data must implement IEnumerable<> (interface wasn't found): {string.Join(", ", data.GetType().GetInterfaces().Select(x => x.FullName))}");
                 var collectionType = eInterface.GetGenericArguments()[0];
-                Assert.IsNotNull(collectionType, "Unable to retrieve collection type for {0}", data.GetType());
+                Assert.IsNotNull(collectionType, $"Unable to retrieve collection type for {data.GetType()}");
 
                 var enumeratedData = new List<object>();
                 foreach (var o in enumerableData)
@@ -1009,8 +996,7 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
                 Assert.AreEqual(
                     expectedDataPoints.Length,
                     enumeratedData.Count,
-                    "The processor did not process the correct amount of data: {0}",
-                    dataOutputPath);
+                    $"The processor did not process the correct amount of data: {dataOutputPath}");
 
                 var properties = collectionType.GetProperties()
                     .ToDictionary(x => x.Name, x => x, StringComparer.InvariantCultureIgnoreCase);
@@ -1053,17 +1039,17 @@ namespace Microsoft.Performance.Toolkit.Engine.Tests
 
             sut.Dispose();
 
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.AvailableTables);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.CreateInfo);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.DataSourcesToProcess);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.EnabledCookers);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.EnabledTables);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.IsProcessed);
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.Plugins);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.AvailableTables);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.CreateInfo);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.DataSourcesToProcess);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.EnabledCookers);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.EnabledTables);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.IsProcessed);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Plugins);
 
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.EnableCooker(Any.DataCookerPath()));
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.Process());
-            Assert.ThrowsException<ObjectDisposedException>(() => sut.TryEnableCooker(Any.DataCookerPath()));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.EnableCooker(Any.DataCookerPath()));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.Process());
+            Assert.ThrowsExactly<ObjectDisposedException>(() => sut.TryEnableCooker(Any.DataCookerPath()));
         }
 
         [TestMethod]

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj
@@ -10,11 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/PluginIdentityTest.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/PluginIdentityTest.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Performance.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Core.Tests;
 
 [TestClass]
+[UnitTest]
 public class PluginIdentityTest
 {
     [TestMethod]

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/PluginMetadataSerializationTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Core.Tests/PluginMetadataSerializationTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using Microsoft.Performance.Toolkit.Plugins.Core.Metadata;
+using Microsoft.Performance.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Fixture = AutoFixture.Fixture;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Core.Tests;
 
 [TestClass]
+[UnitTest]
 public sealed class PluginMetadataSerializationTests
 {
     private Fixture? fixture = null;

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemInstalledPluginStorageTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemInstalledPluginStorageTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                 fakeLoggerFactory);
 
             // Act
-            PluginPackageExtractionException e = await Assert.ThrowsExceptionAsync<PluginPackageExtractionException>(
+            PluginPackageExtractionException e = await Assert.ThrowsExactlyAsync<PluginPackageExtractionException>(
                 async () => await sut.AddAsync(fakePluginPackage.Object, CancellationToken.None, null));
 
             // Assert

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemPluginRegistryTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/FileSystemPluginRegistryTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.GetAllAsync(CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<RepositoryCorruptedException>(() => sut.GetAllAsync(CancellationToken.None));
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
                 var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-                await Assert.ThrowsExceptionAsync<RepositoryDataAccessException>(() => sut.GetAllAsync(CancellationToken.None));
+                await Assert.ThrowsExactlyAsync<RepositoryDataAccessException>(() => sut.GetAllAsync(CancellationToken.None));
             }
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
                 fakeSerializer.Object,
                 fakeLoggerFactory);
 
-            RepositoryCorruptedException e = await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.GetAllAsync(CancellationToken.None));
+            RepositoryCorruptedException e = await Assert.ThrowsExactlyAsync<RepositoryCorruptedException>(() => sut.GetAllAsync(CancellationToken.None));
             Assert.AreSame(exception, e.InnerException);
             fakeLogger.Verify(l => l.Error(exception, It.IsAny<string>()));
         }
@@ -199,7 +199,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.TryGetByIdAsync(fakeInstalledPluginInfo.Metadata.Identity.Id, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<RepositoryCorruptedException>(() => sut.TryGetByIdAsync(fakeInstalledPluginInfo.Metadata.Identity.Id, CancellationToken.None));
         }
 
         #endregion
@@ -255,7 +255,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<RepositoryCorruptedException>(() => sut.ExistsAsync(fakeInstalledPluginInfo, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<RepositoryCorruptedException>(() => sut.ExistsAsync(fakeInstalledPluginInfo, CancellationToken.None));
         }
 
         #endregion
@@ -327,7 +327,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.AddAsync(plugin1, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.AddAsync(plugin1, CancellationToken.None));
         }
 
         #endregion
@@ -343,7 +343,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => sut.DeleteAsync(fakeInstalledPluginInfo, CancellationToken.None));
         }
 
@@ -394,7 +394,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
         }
 
 
@@ -417,7 +417,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.DeleteAsync(plugin2, CancellationToken.None));
         }
 
         #endregion
@@ -435,7 +435,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => sut.UpdateAsync(fakeInstalledPluginInfo, fakeUpdatedPluginInfo, CancellationToken.None));
         }
 
@@ -450,7 +450,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => sut.UpdateAsync(fakeInstalledPluginInfo, toUpdate, CancellationToken.None));
         }
 
@@ -469,7 +469,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
         }
 
         [TestMethod]
@@ -490,7 +490,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
 
             var sut = new FileBackedPluginRegistry(this.registryRoot, fakeSerializer.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => sut.UpdateAsync(current, toUpdate, CancellationToken.None));
         }
 
         [TestMethod]

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests.csproj
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests.csproj
@@ -9,12 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/PluginSourcesRepositoryTests.cs
+++ b/src/PluginsSystem/Microsoft.Performance.Toolkit.Plugins.Runtime.Tests/PluginSourcesRepositoryTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var repo = new PluginSourceRepository();
 
             PluginSource? pluginSource = null;
-            Assert.ThrowsException<ArgumentNullException>(() => repo.Add(pluginSource));
+            Assert.ThrowsExactly<ArgumentNullException>(() => repo.Add(pluginSource));
         }
         #endregion
 
@@ -179,7 +179,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var repo = new PluginSourceRepository();
 
             PluginSource[]? pluginSources = null;
-            Assert.ThrowsException<ArgumentNullException>(() => repo.Add(pluginSources));
+            Assert.ThrowsExactly<ArgumentNullException>(() => repo.Add(pluginSources));
         }
 
         #endregion
@@ -270,7 +270,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var repo = new PluginSourceRepository();
 
             PluginSource? pluginSource = null;
-            Assert.ThrowsException<ArgumentNullException>(() => repo.Remove(pluginSource));
+            Assert.ThrowsExactly<ArgumentNullException>(() => repo.Remove(pluginSource));
         }
 
         #endregion
@@ -364,7 +364,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.Runtime.Tests
             var repo = new PluginSourceRepository();
 
             PluginSource[]? pluginSources = null;
-            Assert.ThrowsException<ArgumentNullException>(() => repo.Remove(pluginSources));
+            Assert.ThrowsExactly<ArgumentNullException>(() => repo.Remove(pluginSources));
         }
 
         #endregion

--- a/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/Microsoft.Performance.Toolkit.Plugins.Cli.Tests.csproj
+++ b/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/Microsoft.Performance.Toolkit.Plugins.Cli.Tests.csproj
@@ -8,14 +8,18 @@
 
   <ItemGroup>
 	<PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Performance.SDK\Microsoft.Performance.SDK.csproj" />
+    <ProjectReference Include="..\..\..\Microsoft.Performance.Testing\Microsoft.Performance.Testing.csproj" />
     <ProjectReference Include="..\..\Microsoft.Performance.Toolkit.Plugins.Core.Tests\Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj" />
     <ProjectReference Include="..\..\Microsoft.Performance.Toolkit.Plugins.Core\Microsoft.Performance.Toolkit.Plugins.Core.csproj" />
     <ProjectReference Include="..\Microsoft.Performance.Toolkit.Plugins.Cli\Microsoft.Performance.Toolkit.Plugins.Cli.csproj" />

--- a/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/PluginManifestSerializationTests.cs
+++ b/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli.Tests/PluginManifestSerializationTests.cs
@@ -3,11 +3,13 @@
 
 using Microsoft.Performance.Toolkit.Plugins.Cli.Manifest;
 using Microsoft.Performance.Toolkit.Plugins.Core.Tests;
+using Microsoft.Performance.Testing;
 using Fixture = AutoFixture.Fixture;
 
 namespace Microsoft.Performance.Toolkit.Plugins.Cli.Tests;
 
 [TestClass]
+[UnitTest]
 public sealed class PluginManifestSerializationTest
 {
     private Fixture? fixture = null;


### PR DESCRIPTION
• Bump  MSTest.TestAdapter  /  MSTest.TestFramework  from 2.2.7 → 4.2.2 in  Directory.Build.targets 
• Bump  Microsoft.NET.Test.Sdk  from 16.11.0 → 18.5.1
• Update  Microsoft.Performance.Toolkit.Plugins.Core.Tests.csproj  and  ...Plugins.Runtime.Tests.csproj  to use centrally-managed package versions; bump  Moq  and  coverlet.collector 
• Replace all  Assert.ThrowsException<T>  calls with  Assert.ThrowsExactly<T> 
• Replace all  Assert.ThrowsExceptionAsync<T>  calls with  Assert.ThrowsExactlyAsync<T> 
• Convert composite-format assert messages ( "...{0}...", args ) to C#-interpolated strings across affected test files
• Fix  AssertEx.IsInstanceOfType  to use  string.Format  since the formatted-message overload was removed
• Add explicit generic type argument to the ambiguous  Assert.AreNotSame  call in  ToolkitEngineTests.cs