### PR TITLE
Allow columns to be marked as deprecated

### DIFF
--- a/documentation/Using-the-SDK/Building-a-table.md
+++ b/documentation/Using-the-SDK/Building-a-table.md
@@ -87,6 +87,13 @@ tableBuilderWithRowCount.AddColumn(this.wordCountColumn, wordCountProjection);
 
 Note that _every_ column a table provides must be added through a call to `ITableBuilderWithRowCount.AddColumn`, even if they're not used in a `TableConfiguration` (see below).
 
+### Deprecating a column
+
+Removing a column can break existing saved configurations that reference it: they will silently lose the column, and filters depending on it will become invalid.
+To retire a column gradually, set `IsDeprecated` on its `ColumnMetadata`. Keep adding the column via `AddColumn` with its `Guid` and projection unchanged.
+This will hide it from certain UI surfaces, but saved configurations that reference it continue to load and render as before.
+It is recommended to update the column's `ShortDescription` with the rationale or the alternatives.
+
 ## Adding TableConfigurations
 
 Some tables may have _many_ columns available. In these situations, it is not useful for a user to be shown every single column at once. A `TableConfiguration` describes groupings of columns that should be used together, along with metadata information such as `ColumnRoles`. Every `Table` must provide at least one `TableConfiguration`.

--- a/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
@@ -9,12 +9,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Performance.SDK.Tests
 {
     [TestClass]
+    [UnitTest]
     public class ColumnMetadataTests
     {
         private Guid ColumnGuid { get; set; } = Guid.NewGuid();
 
         [TestMethod]
-        [UnitTest]
         public void ConstantStringName_NameAlwaysReturnsSameValue()
         {
             var metadata = new ColumnMetadata(this.ColumnGuid, "name");
@@ -26,7 +26,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void ConstantStringName_NameIsConstantReturnsTrue()
         {
             var metadata = new ColumnMetadata(this.ColumnGuid, "name");
@@ -35,7 +34,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void ConstantTitleProjection_NameStillRespectsDefault()
         {
             var projection = Projection.Constant("name");
@@ -48,7 +46,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void ConstantTitleProjection_NameIsConstantReturnsTrue()
         {
             var projection = Projection.Constant("name");
@@ -58,7 +55,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void DynamicTitleProjection_NameIsConstantReturnsFalse()
         {
             var projection = Projection.CreateUsingFuncAdaptor<int, string>(i => i.ToString());
@@ -69,7 +65,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void DynamicTitleProjection_ProjectorIsExposed()
         {
             var projection = Projection.CreateUsingFuncAdaptor<int, string>(i => i.ToString());
@@ -80,7 +75,6 @@ namespace Microsoft.Performance.SDK.Tests
         }
 
         [TestMethod]
-        [UnitTest]
         public void DynamicTitleProjection_NameAlwaysReturnsDefaultValue()
         {
             var projection = Projection.CreateUsingFuncAdaptor<int, string>(i => i.ToString());
@@ -95,6 +89,32 @@ namespace Microsoft.Performance.SDK.Tests
             {
                 Assert.AreEqual("default", metadata.Name);
             }
+        }
+
+        [TestMethod]
+        public void CloneT_PreservesProperties()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name")
+            {
+                IsDeprecated = true,
+            };
+
+            ColumnMetadata clone = metadata.CloneT();
+
+            Assert.IsTrue(clone.IsDeprecated);
+        }
+
+        [TestMethod]
+        public void CopyConstructor_CopyProperties()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name")
+            {
+                IsDeprecated = true,
+            };
+
+            var copy = new ColumnMetadata(metadata);
+
+            Assert.IsTrue(copy.IsDeprecated);
         }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Performance.SDK.Processing
             this.IsNameConstant = other.IsNameConstant;
             this.IsPercent = other.IsPercent;
             this.IsDynamic = other.IsDynamic;
+            this.IsDeprecated = other.IsDeprecated;
             this.FormatProvider = other.FormatProvider;
         }
 
@@ -216,6 +217,13 @@ namespace Microsoft.Performance.SDK.Processing
         ///     column if it is available.
         /// </summary>
         public bool IsDynamic { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether this column is deprecated.
+        ///     Deprecated columns can be hidden from certain user interface
+        ///     but remain fully functional when deserialized.
+        /// </summary>
+        public bool IsDeprecated { get; set; }
 
         /// <summary>
         ///     Gets or sets the format provider to use to format the


### PR DESCRIPTION
See the updated markdown file for on overview.

This PR adds a new `IsDeprecated` property. This gives a way for WPA to hide a column in UI to prevent it from being added to a table, while still keeping it functional for any existing profiles.