### PR TITLE
Unify column short description and description

### DIFF
--- a/src/Microsoft.Performance.SDK.Runtime.Tests/TableConfigurationSerializationTests.cs
+++ b/src/Microsoft.Performance.SDK.Runtime.Tests/TableConfigurationSerializationTests.cs
@@ -164,7 +164,10 @@ namespace Microsoft.Performance.SDK.Runtime.Tests
                 Assert.AreEqual(preV1config.Columns.Count(), newConfig.Columns.Count());
                 CompareInnerValues(preV1config.Columns.Select(x => x.Metadata.Guid), newConfig.Columns.Select(x => x.Metadata.Guid));
                 CompareInnerValues(preV1config.Columns.Select(x => x.Metadata.Name), newConfig.Columns.Select(x => x.Metadata.Name));
-                CompareInnerValues(preV1config.Columns.Select(x => x.Metadata.Description), newConfig.Columns.Select(x => x.Metadata.Description));
+
+                // ColumnMetadata.Description and ColumnMetadata.ShortDescription are aliases of a single value,
+                // with ShortDescription overwriting the value, so both round-trip to the short description.
+                CompareInnerValues(preV1config.Columns.Select(x => x.Metadata.ShortDescription), newConfig.Columns.Select(x => x.Metadata.Description));
                 CompareInnerValues(preV1config.Columns.Select(x => x.Metadata.ShortDescription), newConfig.Columns.Select(x => x.Metadata.ShortDescription));
                 CompareInnerValues(preV1config.Columns.Select(x => x.DisplayHints.AggregationMode.ToString()), newConfig.Columns.Select(x => x.DisplayHints.AggregationMode.ToString()));
                 CompareInnerValues(preV1config.Columns.Select(x => x.DisplayHints.CellFormat), newConfig.Columns.Select(x => x.DisplayHints.CellFormat));

--- a/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
@@ -116,5 +116,23 @@ namespace Microsoft.Performance.SDK.Tests
 
             Assert.IsTrue(copy.IsDeprecated);
         }
+
+        [TestMethod]
+        public void NullShortDescription_DoesNotClearDescription()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name", "long")
+            {
+                ShortDescription = null,
+            };
+
+            Assert.AreEqual("long", metadata.Description);
+
+            var fallback = new ColumnMetadata(this.ColumnGuid, "name")
+            {
+                ShortDescription = null,
+            };
+
+            Assert.AreEqual("name", fallback.Description);
+        }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
@@ -142,7 +142,6 @@ namespace Microsoft.Performance.SDK.Processing
             this.NameProjection = other.NameProjection;
 
             this.Guid = other.Guid;
-            this.ShortDescription = other.ShortDescription;
             this.Description = other.Description;
             this.IsNameConstant = other.IsNameConstant;
             this.IsPercent = other.IsPercent;
@@ -196,14 +195,27 @@ namespace Microsoft.Performance.SDK.Processing
         public IProjection<int, string> NameProjection { get; }
 
         /// <summary>
-        /// Gets the user friendly short description of this column.
+        ///     Gets or sets the user friendly description of this column.
+        ///     This is an alias of <see cref="Description"/>.
         /// </summary>
-        public string ShortDescription { get; set; }
+        public string ShortDescription
+        {
+            get { return this.Description; }
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    this.Description = value;
+                }
+            }
+        }
 
         /// <summary>
         ///     Gets the user friendly description of this column.
+        ///     Defaults to <see cref="Name"/>.
+        ///     This is an alias of <see cref="ShortDescription"/>.
         /// </summary>
-        public string Description { get; }
+        public string Description { get; private set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether this column


### PR DESCRIPTION
All existing Xperf columns use either Description or ShortDescription. These 2 properties are basically interchangeable in reality.
Their distinction is not described and unclear to both the plugin authors and consumers.
In many places, we only consume one but not the other.

Instead of making the consumers having to decide which to use (or by checking whether the description equals to the column name), we can just unify them in the SDK