### PR TITLE
Populate a column's description and short description from each other

### DIFF
--- a/documentation/Using-the-SDK/Building-a-table.md
+++ b/documentation/Using-the-SDK/Building-a-table.md
@@ -60,6 +60,13 @@ public sealed class WordTable
 }
 ```
 
+`ColumnMetadata` carries two user-facing descriptions:
+* `Description` is the full explanation of the column, shown where there is room for it and exposed via programmatic APIs such as MCP.
+* `ShortDescription` is a brief form, shown where there is not — a tooltip, for example.
+
+For best user experience, it is recommended to provide both `Description` and `ShortDescription`.
+However, if only one is provided, the SDK will populate the other based on the one provided.
+
 ### Defining column projections
 
 
@@ -92,7 +99,7 @@ Note that _every_ column a table provides must be added through a call to `ITabl
 Removing a column can break existing saved configurations that reference it: they will silently lose the column, and filters depending on it will become invalid.
 To retire a column gradually, set `IsDeprecated` on its `ColumnMetadata`. Keep adding the column via `AddColumn` with its `Guid` and projection unchanged.
 This will hide it from certain UI surfaces, but saved configurations that reference it continue to load and render as before.
-It is recommended to update the column's `ShortDescription` with the rationale or the alternatives.
+It is recommended to update the column's `Description` and `ShortDescription` with the rationale or the alternatives.
 
 ## Adding TableConfigurations
 

--- a/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
+++ b/src/Microsoft.Performance.SDK.Tests/ColumnMetadataTests.cs
@@ -116,5 +116,78 @@ namespace Microsoft.Performance.SDK.Tests
 
             Assert.IsTrue(copy.IsDeprecated);
         }
+
+        [TestMethod]
+        public void NoDescription_ShortDescriptionIsNull()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name");
+
+            Assert.AreEqual("name", metadata.Description);
+            Assert.IsNull(metadata.ShortDescription);
+        }
+
+        [TestMethod]
+        public void ShortDescriptionIsDerivedFromDescription()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name", "a real description");
+
+            Assert.AreEqual("a real description", metadata.Description);
+            Assert.AreEqual("a real description", metadata.ShortDescription);
+        }
+
+        [TestMethod]
+        public void DescriptionOverThreshold_IsTruncatedWithEllipsis()
+        {
+            var description = new string('a', 51);
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name", description);
+
+            Assert.AreEqual(description, metadata.Description);
+            Assert.AreEqual(40, metadata.ShortDescription.Length);
+            Assert.AreEqual(new string('a', 39) + "\u2026", metadata.ShortDescription);
+        }
+
+        [TestMethod]
+        public void SettingShortDescription_PopulatesAbsentDescription()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name")
+            {
+                ShortDescription = "a tooltip",
+            };
+
+            Assert.AreEqual("a tooltip", metadata.ShortDescription);
+            Assert.AreEqual("a tooltip", metadata.Description);
+        }
+
+        [TestMethod]
+        public void SettingShortDescription_DoesNotOverwriteRealDescription()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name", "a real description")
+            {
+                ShortDescription = "short",
+            };
+
+            Assert.AreEqual("a real description", metadata.Description);
+            Assert.AreEqual("short", metadata.ShortDescription);
+        }
+
+        [TestMethod]
+        public void NullShortDescription_DoesNotClearDescription()
+        {
+            var metadata = new ColumnMetadata(this.ColumnGuid, "name", "long")
+            {
+                ShortDescription = null,
+            };
+
+            Assert.AreEqual("long", metadata.Description);
+            Assert.AreEqual("long", metadata.ShortDescription);
+
+            // Doesn't overwrite default description either
+            var fallback = new ColumnMetadata(this.ColumnGuid, "name")
+            {
+                ShortDescription = null,
+            };
+
+            Assert.AreEqual("name", fallback.Description);
+        }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Performance.SDK.Processing
 
                 this.shortDescription = value;
 
-                // Overwite the description if the current value isn't informative
+                // Overwrite the description if the current value isn't informative
                 if (string.Equals(this.Description, this.Name, StringComparison.Ordinal))
                 {
                     this.Description = value;

--- a/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
@@ -11,7 +11,15 @@ namespace Microsoft.Performance.SDK.Processing
     public class ColumnMetadata
         : ICloneable<ColumnMetadata>
     {
+        // Only truncate the auto-populated short description to the given length if it exceeds the threshold
+        private const int ShortDescriptionLength = 40;
+        private const int ShortDescriptionTruncationThreshold = 50;
+
+        private const string Ellipsis = "\u2026";
+
         private readonly string name;
+
+        private string shortDescription;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ColumnMetadata"/>
@@ -117,11 +125,12 @@ namespace Microsoft.Performance.SDK.Processing
 
             this.Guid = guid;
             this.Description = description;
-            this.IsNameConstant = Projection.IsConstant(nameProjection);
 
             this.NameProjection = nameProjection;
             this.IsNameConstant = Projection.IsConstant(this.NameProjection);
             this.Name = defaultName;
+
+            this.shortDescription = GenerateShortDescription(description, defaultName);
         }
 
         /// <summary>
@@ -142,7 +151,7 @@ namespace Microsoft.Performance.SDK.Processing
             this.NameProjection = other.NameProjection;
 
             this.Guid = other.Guid;
-            this.ShortDescription = other.ShortDescription;
+            this.shortDescription = other.shortDescription;
             this.Description = other.Description;
             this.IsNameConstant = other.IsNameConstant;
             this.IsPercent = other.IsPercent;
@@ -196,14 +205,40 @@ namespace Microsoft.Performance.SDK.Processing
         public IProjection<int, string> NameProjection { get; }
 
         /// <summary>
-        /// Gets the user friendly short description of this column.
+        ///     Gets or sets a brief, user friendly description of this column,
+        ///     suitable for places with little room such as a tooltip.
+        ///     By default, this is initialized from <see cref="Description"/>, truncated if too long.
+        ///     Setting this will also update <see cref="Description"/> if <see cref="Description"/> isn't already set.
         /// </summary>
-        public string ShortDescription { get; set; }
+        public string ShortDescription
+        {
+            get
+            {
+                return this.shortDescription;
+            }
+
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
+
+                this.shortDescription = value;
+
+                // Overwite the description if the current value isn't informative
+                if (string.Equals(this.Description, this.Name, StringComparison.Ordinal))
+                {
+                    this.Description = value;
+                }
+            }
+        }
 
         /// <summary>
-        ///     Gets the user friendly description of this column.
+        ///     Gets the full user friendly description of this column.
+        ///     Defaults to <see cref="Name"/> when none was supplied.
         /// </summary>
-        public string Description { get; }
+        public string Description { get; private set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether this column
@@ -241,6 +276,24 @@ namespace Microsoft.Performance.SDK.Processing
         public ColumnMetadata CloneT()
         {
             return new ColumnMetadata(this);
+        }
+
+        private static string GenerateShortDescription(string description, string name)
+        {
+            if (string.Equals(description, name, StringComparison.Ordinal))
+            {
+                // Nothing useful to show as a short description
+                return null;
+            }
+
+            if (description.Length <= ShortDescriptionTruncationThreshold)
+            {
+                return description;
+            }
+
+            return string.Concat(
+                description.Substring(0, ShortDescriptionLength - Ellipsis.Length).TrimEnd(),
+                Ellipsis);
         }
     }
 }

--- a/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
+++ b/src/Microsoft.Performance.SDK/Processing/ColumnMetadata.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Performance.SDK.Processing
         /// <summary>
         ///     Gets or sets a brief, user friendly description of this column,
         ///     suitable for places with little room such as a tooltip.
-        ///     By default, this is initialized from <see cref="Description"/>, truncated if too long.
+        ///     By default, this is initialized from <see cref="Description"/>, truncated if over 50 characters.
         ///     Setting this will also update <see cref="Description"/> if <see cref="Description"/> isn't already set.
         /// </summary>
         public string ShortDescription


### PR DESCRIPTION
All existing Xperf columns use either Description or ShortDescription. These 2 properties are basically used interchangeably in reality.
As a result, depending on which one is set, column descriptions are often only available either as tooltips or inside the table config dialog in WPA, but never both.

While plugin authors are responsible for providing both of them, one improvement we can do in SDK is to provide default values for them, so that they remain useful even if only one of them is set --- a short description can be the description, and a description can a short description after truncation. Plugin authors can still overwrite the default values if they want, and they are encouraged to do so